### PR TITLE
fix: ensure test path and metrics field access

### DIFF
--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -1,4 +1,4 @@
-classdef TestDB < matlab.unittest.TestCase
+classdef TestDB < RegTestCase
     properties
         TempDB
     end

--- a/tests/TestDBIntegrationSimulated.m
+++ b/tests/TestDBIntegrationSimulated.m
@@ -1,4 +1,4 @@
-classdef TestDBIntegrationSimulated < matlab.unittest.TestCase
+classdef TestDBIntegrationSimulated < RegTestCase
     methods (Test)
         function sqlite_roundtrip(tc)
             [chunksT, labels, Ytrue] = testutil.generate_simulated_crr();

--- a/tests/TestFeatures.m
+++ b/tests/TestFeatures.m
@@ -1,4 +1,4 @@
-classdef TestFeatures < matlab.unittest.TestCase
+classdef TestFeatures < RegTestCase
     methods (Test)
         function setBackend(~)
             C = config(); %#ok<NASGU>

--- a/tests/TestFetchers.m
+++ b/tests/TestFetchers.m
@@ -1,4 +1,4 @@
-classdef TestFetchers < matlab.unittest.TestCase
+classdef TestFetchers < RegTestCase
     methods (Test)
         function eurlex_url_build(tc)
             try

--- a/tests/TestFineTuneResume.m
+++ b/tests/TestFineTuneResume.m
@@ -1,4 +1,4 @@
-classdef TestFineTuneResume < matlab.unittest.TestCase
+classdef TestFineTuneResume < RegTestCase
     methods (Test)
         function resume_from_checkpoint(tc)
             if gpuDeviceCount==0

--- a/tests/TestFineTuneSmoke.m
+++ b/tests/TestFineTuneSmoke.m
@@ -1,4 +1,4 @@
-classdef TestFineTuneSmoke < matlab.unittest.TestCase
+classdef TestFineTuneSmoke < RegTestCase
     methods (Test)
         function smoke_ft(tc)
             if gpuDeviceCount==0

--- a/tests/TestGoldMetrics.m
+++ b/tests/TestGoldMetrics.m
@@ -1,4 +1,4 @@
-classdef TestGoldMetrics < matlab.unittest.TestCase
+classdef TestGoldMetrics < RegTestCase
     methods (Test)
         function gold_meets_thresholds(tc)
             G = reg.load_gold("gold");
@@ -16,7 +16,7 @@ classdef TestGoldMetrics < matlab.unittest.TestCase
             tol = G.expect.overall.tolerance;
             tc.verifyGreaterThan(recall10 + tol, G.expect.overall.RecallAt10_min);
             tc.verifyGreaterThan(mAP + tol, G.expect.overall.mAP_min);
-            tc.verifyGreaterThan(ndcg10 + tol, G.expect.overall["nDCG@10_min"]);
+            tc.verifyGreaterThan(ndcg10 + tol, G.expect.overall.("nDCG@10_min"));
             % per-label
             per = reg.eval_per_label(E, G.Y, 10);
             labs = G.labels;

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -1,4 +1,4 @@
-classdef TestHybridSearch < matlab.unittest.TestCase
+classdef TestHybridSearch < RegTestCase
     methods (Test)
         function setBackend(~)
             C = config(); %#ok<NASGU>

--- a/tests/TestIngestAndChunk.m
+++ b/tests/TestIngestAndChunk.m
@@ -1,4 +1,4 @@
-classdef TestIngestAndChunk < matlab.unittest.TestCase
+classdef TestIngestAndChunk < RegTestCase
     methods (Test)
         function test_ingest_and_chunk(tc)
             C = config();

--- a/tests/TestIntegrationSimulated.m
+++ b/tests/TestIntegrationSimulated.m
@@ -1,4 +1,4 @@
-classdef TestIntegrationSimulated < matlab.unittest.TestCase
+classdef TestIntegrationSimulated < RegTestCase
     methods (Test)
         function e2e_simulated(tc)
             [chunksT, labels, Ytrue] = testutil.generate_simulated_crr();

--- a/tests/TestKnobs.m
+++ b/tests/TestKnobs.m
@@ -1,4 +1,4 @@
-classdef TestKnobs < matlab.unittest.TestCase
+classdef TestKnobs < RegTestCase
     methods (Test)
         function chunk_overrides(tc)
             % Write a temporary knobs.json overriding chunk sizes

--- a/tests/TestMetricsExpectedJSON.m
+++ b/tests/TestMetricsExpectedJSON.m
@@ -1,4 +1,4 @@
-classdef TestMetricsExpectedJSON < matlab.unittest.TestCase
+classdef TestMetricsExpectedJSON < RegTestCase
     methods (Test)
         function metrics_meet_expected(tc)
             addpath("tests/fixtures");
@@ -16,7 +16,7 @@ classdef TestMetricsExpectedJSON < matlab.unittest.TestCase
             ndcg10 = reg.metrics_ndcg(E*E.', posSets, 10);
             tc.verifyGreaterThan(recall10 + K.tolerance, K.RecallAt10_min);
             tc.verifyGreaterThan(mAP + K.tolerance, K.mAP_min);
-            tc.verifyGreaterThan(ndcg10 + K.tolerance, K["nDCG@10_min"]);
+            tc.verifyGreaterThan(ndcg10 + K.tolerance, K.("nDCG@10_min"));
         end
     end
 end

--- a/tests/TestPDFIngest.m
+++ b/tests/TestPDFIngest.m
@@ -1,4 +1,4 @@
-classdef TestPDFIngest < matlab.unittest.TestCase
+classdef TestPDFIngest < RegTestCase
     methods (Test)
         function ingest_text_pdf(tc)
             C = config();

--- a/tests/TestProjectionAutoloadPipeline.m
+++ b/tests/TestProjectionAutoloadPipeline.m
@@ -1,4 +1,4 @@
-classdef TestProjectionAutoloadPipeline < matlab.unittest.TestCase
+classdef TestProjectionAutoloadPipeline < RegTestCase
     methods (Test)
         function pipeline_uses_projection_if_present(tc)
             % Create a small head from synthetic data and save to projection_head.mat

--- a/tests/TestProjectionHeadSimulated.m
+++ b/tests/TestProjectionHeadSimulated.m
@@ -1,4 +1,4 @@
-classdef TestProjectionHeadSimulated < matlab.unittest.TestCase
+classdef TestProjectionHeadSimulated < RegTestCase
     methods (Test)
         function projection_improves_or_equal(tc)
             [chunksT, labels, Ytrue] = testutil.generate_simulated_crr();

--- a/tests/TestRegressionMetricsSimulated.m
+++ b/tests/TestRegressionMetricsSimulated.m
@@ -1,4 +1,4 @@
-classdef TestRegressionMetricsSimulated < matlab.unittest.TestCase
+classdef TestRegressionMetricsSimulated < RegTestCase
     methods (Test)
         function regression_metrics(tc)
             [chunksT, labels, Ytrue] = testutil.generate_simulated_crr();

--- a/tests/TestReportArtifact.m
+++ b/tests/TestReportArtifact.m
@@ -1,4 +1,4 @@
-classdef TestReportArtifact < matlab.unittest.TestCase
+classdef TestReportArtifact < RegTestCase
     methods (Test)
         function report_exists_and_nontrivial(tc)
             C = config();

--- a/tests/TestRulesAndModel.m
+++ b/tests/TestRulesAndModel.m
@@ -1,4 +1,4 @@
-classdef TestRulesAndModel < matlab.unittest.TestCase
+classdef TestRulesAndModel < RegTestCase
     methods (Test)
         function setBackend(~)
             C = config(); %#ok<NASGU>

--- a/tests/fixtures/RegTestCase.m
+++ b/tests/fixtures/RegTestCase.m
@@ -1,0 +1,8 @@
+classdef (Abstract) RegTestCase < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function addProjectPath(tc)
+            % Ensure parent directory is on MATLAB path for access to project code
+            tc.applyFixture(matlab.unittest.fixtures.PathFixture('..'));
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add RegTestCase base class that adds project root to MATLAB path for tests
- update tests to inherit from RegTestCase
- fix metric tests' dynamic field access for names like `nDCG@10_min`

## Testing
- `matlab -batch "addpath(pwd); results=runtests('tests','IncludeSubfolders',true,'UseParallel',false); disp(results)"` *(fails: command not found)*
- `octave --eval "addpath(pwd); results=runtests('tests'); disp(results)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899f4f090d0833098af20b5c47804e8