### PR TITLE
Expand hybrid search test for weighting behavior

### DIFF
--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -10,7 +10,13 @@ classdef TestHybridSearch < RegTestCase
             S = reg.hybrid_search(Xtfidf, E, vocab);
             res = S.query("liquidity coverage ratio HQLA", 0.5);
             tc.verifyGreaterThan(height(res), 0);
-            tc.verifyTrue(any(res.row == 2));
+            tc.verifyEqual(res.row(1), 2);
+
+            resLex = S.query("liquidity coverage ratio HQLA", 0.8);
+            resSem = S.query("liquidity coverage ratio HQLA", 0.2);
+            tc.verifyEqual(resLex.row(1), 2);
+            tc.verifyEqual(resSem.row(1), 2);
+            tc.verifyGreaterThan(resLex.score(1), resSem.score(1));
         end
     end
 end


### PR DESCRIPTION
## Summary
- Enhance `TestHybridSearch` to assert that the most relevant document is ranked first
- Add additional queries to verify result scores under different lexical vs semantic weightings

## Testing
- `matlab -batch "runtests('tests/TestHybridSearch.m')"` *(fails: command not found)*
- `octave -qf --eval "runtests('tests/TestHybridSearch.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0030d3048330b250d9c27fa8b890