### PR TITLE
Store per-label score columns

### DIFF
--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -1,19 +1,31 @@
 function upsert_chunks(conn, chunksT, labels, pred, scores)
-%UPSERT_CHUNKS Insert/Upsert chunk rows and label columns
-% Build a table with label columns (0/1) and simple score cols (optional)
+%UPSERT_CHUNKS Insert/Upsert chunk rows, label columns and score columns
+% Build a table with label columns (0/1) and numeric score columns
 L = cellstr("lbl_" + labels);
 P = array2table(pred, 'VariableNames', L);
-T = [chunksT(:, {'chunk_id','doc_id','text'}) P];
+if exist('scores','var') && ~isempty(scores)
+    SL = cellstr("score_" + labels);
+    S = array2table(scores, 'VariableNames', SL);
+    T = [chunksT(:, {'chunk_id','doc_id','text'}) P S];
+else
+    T = [chunksT(:, {'chunk_id','doc_id','text'}) P];
+end
 
 if isstruct(conn) && isfield(conn,'sqlite')
     sconn = conn.sqlite;
-    % Create label columns if needed
+    % Create label/score columns if needed
     cols = fieldnames(T)';
     cur = fetch(sconn, "PRAGMA table_info(reg_chunks);");
     existing = string(cur(:,2));
     toAdd = setdiff(string(cols), existing);
     for k = 1:numel(toAdd)
-        exec(sconn, "ALTER TABLE reg_chunks ADD COLUMN " + toAdd(k) + " TEXT");
+        colname = toAdd(k);
+        if startsWith(colname, "score_")
+            coltype = "REAL";
+        else
+            coltype = "TEXT";
+        end
+        exec(sconn, "ALTER TABLE reg_chunks ADD COLUMN " + colname + " " + coltype);
     end
     % Upsert rows (INSERT OR REPLACE)
     for i = 1:height(T)

--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -34,6 +34,8 @@ classdef TestDB < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT count(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, 2);
+                cols = fetch(conn.sqlite, "PRAGMA table_info(reg_chunks);");
+                tc.verifyTrue(any(strcmp('score_IRB', cols(:,2))));
                 close(conn.sqlite);
             end
         end

--- a/tests/TestDBIntegrationSimulated.m
+++ b/tests/TestDBIntegrationSimulated.m
@@ -10,6 +10,9 @@ classdef TestDBIntegrationSimulated < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT COUNT(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, height(chunksT));
+                cols = fetch(conn.sqlite, "PRAGMA table_info(reg_chunks);");
+                scoreCol = char("score_" + labels(1));
+                tc.verifyTrue(any(strcmp(scoreCol, cols(:,2))));
                 close(conn.sqlite);
             end
             if isfile(C.db.sqlite_path), delete(C.db.sqlite_path); end


### PR DESCRIPTION
## Summary
- extend `reg.upsert_chunks` to persist numeric score columns alongside labels
- add SQLite schema creation logic for score columns
- update DB tests to verify score column storage

## Testing
- `matlab -batch "runtests('tests/TestDB.m','tests/TestDBIntegrationSimulated.m')"` *(fails: command not found)*
- `octave --eval "runtests('tests/TestDB.m','tests/TestDBIntegrationSimulated.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a002f22808330b5e095f705dc9e29