### PR TITLE
Fix diff report logging

### DIFF
--- a/reg_crr_diff_report.m
+++ b/reg_crr_diff_report.m
@@ -43,6 +43,5 @@ if N > 0
 end
 
 close(r);
-fprintf('Wrote diff report: %s
-', fullfile(O,'crr_diff_report.pdf'));
+fprintf('Wrote diff report: %s', fullfile(O,'crr_diff_report.pdf'));
 end


### PR DESCRIPTION
## Summary
- fix fprintf format in reg_crr_diff_report to print report path

## Testing
- `octave -q run_smoke_test.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a002d38248330a9455bf33fad4b71