### PR TITLE
Fix MATLAB indexing and optional negative mining

### DIFF
--- a/+reg/crr_diff_versions.m
+++ b/+reg/crr_diff_versions.m
@@ -9,8 +9,14 @@ O = p.Results.OutDir; if ~isfolder(O), mkdir(O); end
 
 A = dir(fullfile(dirA, '*.txt'));
 B = dir(fullfile(dirB, '*.txt'));
-mapA = containers.Map(); for i=1:numel(A), mapA(A[i].name) = fullfile(A[i].folder,A[i].name); end
-mapB = containers.Map(); for i=1:numel(B), mapB(B[i].name) = fullfile(B[i].folder,B[i].name); end
+mapA = containers.Map(); for i = 1:numel(A)
+    % Use MATLAB parenthesis indexing when iterating over struct arrays
+    % rather than the Python-style A[i] which causes a syntax error.
+    mapA(A(i).name) = fullfile(A(i).folder, A(i).name);
+end
+mapB = containers.Map(); for i = 1:numel(B)
+    mapB(B(i).name) = fullfile(B(i).folder, B(i).name);
+end
 keys = unique([string({A.name})'; string({B.name})'], 'stable');
 
 added=0; removed=0; changed=0; same=0;

--- a/+reg/metrics_ndcg.m
+++ b/+reg/metrics_ndcg.m
@@ -25,9 +25,13 @@ for i = 1:N
         idcg = idcg + (idealRel(j) / log2(j+1));
     end
     if idcg > 0
-        ndcg_i[i] = dcg / idcg;
+        % MATLAB uses 1-based indexing with parentheses. The previous
+        % implementation accidentally used square brackets (`ndcg_i[i]`)
+        % which is Python-style indexing and results in a syntax error.
+        % Use the correct parenthesis-based indexing.
+        ndcg_i(i) = dcg / idcg;
     else
-        ndcg_i[i] = 0;
+        ndcg_i(i) = 0;
     end
 end
 ndcg = mean(ndcg_i);


### PR DESCRIPTION
## Summary
- fix Python-style indexing in metrics_ndcg and crr_diff_versions
- correct layer indexing in ft_train_encoder and allow optional hard-negative mining with Yboot labels

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0020b8f8833098f1187f415027cf