### PR TITLE
Handle existing SQLite file and pragma fetch

### DIFF
--- a/+reg/ensure_db.m
+++ b/+reg/ensure_db.m
@@ -3,7 +3,11 @@ function conn = ensure_db(DB)
 % For SQLite, it creates a file (DB.sqlite_path) and returns struct with .sqlite handle.
 if isfield(DB,'vendor') && strcmpi(DB.vendor,'sqlite')
     if ~isfolder(fileparts(DB.sqlite_path)), mkdir(fileparts(DB.sqlite_path)); end
-    sconn = sqlite(DB.sqlite_path, 'create'); %#ok<SQLITE>
+    if isfile(DB.sqlite_path)
+        sconn = sqlite(DB.sqlite_path);          % open existing file
+    else
+        sconn = sqlite(DB.sqlite_path, 'create'); %#ok<SQLITE> % create new file
+    end
     % ensure table
     createSQL = [
         'CREATE TABLE IF NOT EXISTS reg_chunks (' ...

--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -15,8 +15,13 @@ if isstruct(conn) && isfield(conn,'sqlite')
     sconn = conn.sqlite;
     % Create label/score columns if needed
     cols = fieldnames(T)';
-    cur = fetch(sconn, "PRAGMA table_info(reg_chunks);");
-    existing = string(cur(:,2));
+    % Only retrieve column names to avoid NULL default values triggering errors
+    cur = fetch(sconn, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+    if istable(cur)
+        existing = string(cur{:,:});
+    else
+        existing = string(cur(:,1));
+    end
     toAdd = setdiff(string(cols), existing);
     for k = 1:numel(toAdd)
         colname = toAdd(k);


### PR DESCRIPTION
## Summary
- Open existing SQLite database or create it in `ensure_db` to avoid errors when the file already exists
- Retrieve only column names in `upsert_chunks` so PRAGMA queries with NULL default values no longer error

## Testing
- `matlab -batch "results=runtests('tests','IncludeSubfolders',true); disp(results); exit(~all([results.Passed]));"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899fc5f3b24833085ff635d7661ed96