### PR TITLE
Use pragma_table_info name column in sqlite tests

### DIFF
--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -34,8 +34,13 @@ classdef TestDB < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT count(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, 2);
-                cols = fetch(conn.sqlite, "PRAGMA table_info(reg_chunks);");
-                tc.verifyTrue(any(strcmp('score_IRB', cols(:,2))));
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                if istable(colNames)
+                    names = string(colNames{:,:});
+                else
+                    names = string(colNames(:,1));
+                end
+                tc.verifyTrue(any(names == "score_IRB"));
                 close(conn.sqlite);
             end
         end

--- a/tests/TestDBIntegrationSimulated.m
+++ b/tests/TestDBIntegrationSimulated.m
@@ -10,9 +10,14 @@ classdef TestDBIntegrationSimulated < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT COUNT(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, height(chunksT));
-                cols = fetch(conn.sqlite, "PRAGMA table_info(reg_chunks);");
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                if istable(colNames)
+                    names = string(colNames{:,:});
+                else
+                    names = string(colNames(:,1));
+                end
                 scoreCol = char("score_" + labels(1));
-                tc.verifyTrue(any(strcmp(scoreCol, cols(:,2))));
+                tc.verifyTrue(any(names == scoreCol));
                 close(conn.sqlite);
             end
             if isfile(C.db.sqlite_path), delete(C.db.sqlite_path); end


### PR DESCRIPTION
## Summary
- query sqlite column names via `SELECT name FROM pragma_table_info('reg_chunks')`
- handle table or cell results when verifying test columns

## Testing
- `matlab -batch "runtests('tests/TestDBIntegrationSimulated');"` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689a0f79ec7483309017713de8136e05