### PR TITLE
Ensure gold chunk text column named consistently

### DIFF
--- a/+reg/load_gold.m
+++ b/+reg/load_gold.m
@@ -7,6 +7,16 @@ function G = load_gold(dirPath)
 %   expected_metrics.json        (overall + per_label thresholds)
 if nargin<1, dirPath = "gold"; end
 chunks = readtable(fullfile(dirPath,"sample_gold_chunks.csv"), "TextType","string");
+% Some MATLAB/Octave versions rename the text column (e.g. to Var3 or
+% text_).  Ensure the column containing the chunk text is consistently named
+% "text" so downstream code can rely on it.
+if ~ismember("text", chunks.Properties.VariableNames)
+    idx = find(strcmpi(chunks.Properties.VariableNames, "text"), 1);
+    if isempty(idx)
+        idx = width(chunks); % assume last column holds text
+    end
+    chunks.Properties.VariableNames{idx} = "text";
+end
 labJ = jsondecode(fileread(fullfile(dirPath,"sample_gold_labels.json")));
 Y = readmatrix(fullfile(dirPath,"sample_gold_Ytrue.csv"));
 expJ = jsondecode(fileread(fullfile(dirPath,"expected_metrics.json")));


### PR DESCRIPTION
## Summary
- Normalize variable names when loading gold chunks so the text column is always named `text`

## Testing
- `octave --eval "runtests('tests/TestGoldMetrics.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0fb684ec833093506211a8553e9d