### PR TITLE
Handle fastTextWordEmbedding API differences

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,16 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+% Handle different fastTextWordEmbedding signatures across MATLAB
+% versions. Some releases expect a language argument while others do not.
+if isstruct(fasttextCfg) && isfield(fasttextCfg, "language")
+    try
+        emb = fastTextWordEmbedding(fasttextCfg.language);
+    catch
+        emb = fastTextWordEmbedding();
+    end
+else
+    emb = fastTextWordEmbedding();
+end
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -14,7 +14,14 @@ bagQ = bagOfWords(qTok, S.vocab);
 qv = bagQ.Counts; idf = log( size(S.Xtfidf,1) ./ max(1,sum(S.Xtfidf>0,1)) );
 qtfidf = qv .* idf;
 
-emb = fastTextWordEmbedding("en");
+% Some MATLAB releases do not accept a language argument for
+% fastTextWordEmbedding. Attempt to request English embeddings, but fall
+% back to the default if the call fails.
+try
+    emb = fastTextWordEmbedding("en");
+catch
+    emb = fastTextWordEmbedding();
+end
 seq = doc2sequence(emb, qTok);
 if ~isempty(seq) && ~isempty(seq{1}), qe = mean(single(seq{1}),2)'; else, qe = zeros(1,size(S.E,2),'single'); end
 qe = qe ./ max(1e-9, norm(qe));


### PR DESCRIPTION
## Summary
- make `doc_embeddings_fasttext` robust to MATLAB versions that lack language argument support
- guard `hybrid_search` against `fastTextWordEmbedding` API differences by falling back to default embeddings

## Testing
- `matlab -batch "results = runtests('tests','IncludeSubfolders',true,'UseParallel',false); assert(~any([results.Failed]));"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689a0fbe49348330a8542d693ae0dcc6