### PR TITLE
Handle fastTextWordEmbedding API differences

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,13 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+% Some MATLAB versions expect a language argument while others do not. Be
+% robust to both by trying the configured language first and falling back to
+% the zero-argument form if the call errors (e.g. "Too many input arguments").
+try
+    emb = fastTextWordEmbedding(fasttextCfg.language);
+catch
+    emb = fastTextWordEmbedding;
+end
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -14,7 +14,13 @@ bagQ = bagOfWords(qTok, S.vocab);
 qv = bagQ.Counts; idf = log( size(S.Xtfidf,1) ./ max(1,sum(S.Xtfidf>0,1)) );
 qtfidf = qv .* idf;
 
-emb = fastTextWordEmbedding("en");
+% fastTextWordEmbedding API differs across MATLAB versions. Try with the
+% language argument first and fall back to the no-argument form if needed.
+try
+    emb = fastTextWordEmbedding("en");
+catch
+    emb = fastTextWordEmbedding;
+end
 seq = doc2sequence(emb, qTok);
 if ~isempty(seq) && ~isempty(seq{1}), qe = mean(single(seq{1}),2)'; else, qe = zeros(1,size(S.E,2),'single'); end
 qe = qe ./ max(1e-9, norm(qe));


### PR DESCRIPTION
## Summary
- Make FastText embedding loading resilient to MATLAB API differences by falling back to zero-argument call when language parameter is unsupported
- Apply the same robust FastText loading in hybrid search queries

## Testing
- `matlab -batch "runtests('tests/TestIntegrationSimulated.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0fd12f448330a955935b74ab738d