### PR TITLE
Fix fixture path for metrics test

### DIFF
--- a/tests/TestMetricsExpectedJSON.m
+++ b/tests/TestMetricsExpectedJSON.m
@@ -1,8 +1,10 @@
 classdef TestMetricsExpectedJSON < RegTestCase
     methods (Test)
         function metrics_meet_expected(tc)
-            addpath("tests/fixtures");
-            K = jsondecode(fileread(fullfile("tests","fixtures","expected_metrics.json")));
+            testDir = fileparts(mfilename("fullpath"));
+            fixturesDir = fullfile(testDir, "fixtures");
+            tc.applyFixture(matlab.unittest.fixtures.PathFixture(fixturesDir));
+            K = jsondecode(fileread(fullfile(fixturesDir, "expected_metrics.json")));
             [chunksT, labels, Ytrue] = testutil.generate_simulated_crr();
             C = config(); C.labels = labels;
             E = reg.precompute_embeddings(chunksT.text, C);


### PR DESCRIPTION
## Summary
- derive fixtures directory relative to test file and add via PathFixture
- load expected metrics from computed fixtures path

## Testing
- `matlab -batch "disp('hello')"` *(fails: command not found)*
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0fe3daa88330b99047d9b57ff9c6