### PR TITLE
Handle fastTextWordEmbedding API change

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,18 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+% The fastTextWordEmbedding API changed in recent MATLAB releases to no
+% longer accept a language argument. Attempt to call with the configured
+% language and fall back to the no-argument form if too many inputs are
+% supplied.
+try
+    emb = fastTextWordEmbedding(fasttextCfg.language);
+catch ME
+    if strcmp(ME.identifier, 'MATLAB:TooManyInputs')
+        emb = fastTextWordEmbedding;
+    else
+        rethrow(ME);
+    end
+end
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);


### PR DESCRIPTION
## Summary
- make `doc_embeddings_fasttext` compatible with MATLAB releases where `fastTextWordEmbedding` takes no language argument

## Testing
- `matlab -batch "runtests('TestProjectionAutoloadPipeline/pipeline_uses_projection_if_present')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0ff9f02083309c1f3eb8e203d27e