### PR TITLE
Fix report artifact test fixture path

### DIFF
--- a/tests/TestReportArtifact.m
+++ b/tests/TestReportArtifact.m
@@ -3,14 +3,16 @@ classdef TestReportArtifact < RegTestCase
         function report_exists_and_nontrivial(tc)
             C = config();
             % Minimal data: use fixtures PDF to run pipeline then eval report
-            if ~isfolder("data/pdfs"), mkdir("data/pdfs"); end
-            copyfile(fullfile("tests","fixtures","sim_text.pdf"), fullfile("data","pdfs","sim_text.pdf"));
+            testDir = fileparts(mfilename("fullpath"));
+            pdfDir = fullfile(testDir, "data", "pdfs");
+            if ~isfolder(pdfDir), mkdir(pdfDir); end
+            copyfile(fullfile(testDir, "fixtures", "sim_text.pdf"), fullfile(pdfDir, "sim_text.pdf"));
             run reg_pipeline
             run reg_eval_and_report
             f = dir("reg_eval_report.pdf");
             tc.verifyFalse(isempty(f), "Report not generated");
             tc.verifyGreaterThan(f.bytes, 10*1024, "Report seems too small to be valid");
-            delete(fullfile("data","pdfs","sim_text.pdf"));
+            delete(fullfile(pdfDir, "sim_text.pdf"));
         end
     end
 end


### PR DESCRIPTION
## Summary
- Fix TestReportArtifact fixture path resolution to avoid missing file error.

## Testing
- `matlab -batch "runtests('tests/TestReportArtifact.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a100ed45083309fa16cf2cdc5ffce