### PR TITLE
Handle fastTextWordEmbedding API changes

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,20 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+% The fastTextWordEmbedding API changed across MATLAB releases.  In some
+% versions the language is specified as an input argument, while in others
+% the function does not accept any inputs and defaults to English.  Handle
+% both cases by attempting to pass the language and falling back to the
+% zero-argument form when the former results in a "TooManyInputs" error.
+
+try
+    emb = fastTextWordEmbedding(fasttextCfg.language);
+catch ME
+    if strcmp(ME.identifier, "MATLAB:TooManyInputs")
+        emb = fastTextWordEmbedding();
+    else
+        rethrow(ME);
+    end
+end
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -14,7 +14,18 @@ bagQ = bagOfWords(qTok, S.vocab);
 qv = bagQ.Counts; idf = log( size(S.Xtfidf,1) ./ max(1,sum(S.Xtfidf>0,1)) );
 qtfidf = qv .* idf;
 
-emb = fastTextWordEmbedding("en");
+% fastTextWordEmbedding has differing input requirements across MATLAB
+% versions. Attempt to specify the language and fall back to the default
+% (English) if the function does not accept any input arguments.
+try
+    emb = fastTextWordEmbedding("en");
+catch ME
+    if strcmp(ME.identifier, "MATLAB:TooManyInputs")
+        emb = fastTextWordEmbedding();
+    else
+        rethrow(ME);
+    end
+end
 seq = doc2sequence(emb, qTok);
 if ~isempty(seq) && ~isempty(seq{1}), qe = mean(single(seq{1}),2)'; else, qe = zeros(1,size(S.E,2),'single'); end
 qe = qe ./ max(1e-9, norm(qe));


### PR DESCRIPTION
## Summary
- add compatibility layer for fastTextWordEmbedding to support MATLAB versions that do not accept a language argument
- use same defensive logic in hybrid_search

## Testing
- `matlab -batch "addpath(pwd); results = runtests('tests'); disp(table(results)); exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a0fed12a88330b0883eab61d77057