### PR TITLE
Handle fastText API changes

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,13 +1,26 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-% The fastTextWordEmbedding API changed across MATLAB releases.  In some
+% The fastTextWordEmbedding API changed across MATLAB releases. In some
 % versions the language is specified as an input argument, while in others
-% the function does not accept any inputs and defaults to English.  Handle
+% the function does not accept any inputs and defaults to English. Handle
 % both cases by attempting to pass the language and falling back to the
 % zero-argument form when the former results in a "TooManyInputs" error.
 
+if nargin < 2
+    fasttextCfg = struct();
+end
+
+lang = '';
+if isstruct(fasttextCfg) && isfield(fasttextCfg, 'language')
+    lang = fasttextCfg.language;
+end
+
 try
-    emb = fastTextWordEmbedding(fasttextCfg.language);
+    if ~isempty(lang)
+        emb = fastTextWordEmbedding(lang);
+    else
+        emb = fastTextWordEmbedding();
+    end
 catch ME
     if strcmp(ME.identifier, "MATLAB:TooManyInputs")
         emb = fastTextWordEmbedding();


### PR DESCRIPTION
## Summary
- Support MATLAB versions where `fastTextWordEmbedding` requires no arguments
- Fall back to a zero-argument call when language input triggers `TooManyInputs`

## Testing
- `matlab -batch "results = runtests('tests/TestFeatures.m'); disp(results)"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689a214a7800833084e27971f6b0811a