### PR TITLE
refactor knob validation in print_active_knobs

### DIFF
--- a/+reg/print_active_knobs.m
+++ b/+reg/print_active_knobs.m
@@ -1,7 +1,12 @@
 function print_active_knobs(C)
 %PRINT_ACTIVE_KNOBS Pretty-print active knobs at the start of a run
 fprintf("\n=== Active Knobs ===\n");
-    if isfield(C,'knobs') && ~isempty(C.knobs), try, reg.validate_knobs(C.knobs); end, end
+if isfield(C,'knobs') && ~isempty(C.knobs)
+    try
+        reg.validate_knobs(C.knobs);
+    catch
+    end
+end
 if isfield(C,'knobs') && ~isempty(C.knobs)
     K = C.knobs;
     if isfield(K,'BERT')


### PR DESCRIPTION
## Summary
- expand knob validation one-liner into a proper try/catch block

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a29c08ca48330a1a8fc3f614dd7c7