### PR TITLE
Fix adamupdate call to use full itersPerEpoch identifier

### DIFF
--- a/+reg/train_projection_head.m
+++ b/+reg/train_projection_head.m
@@ -49,7 +49,8 @@ for epoch = 1:R.Epochs
             Xa = single(Xa); Xp = single(Xp); Xn = single(Xn);
         end
         [L, gradients] = dlfeval(@modelGradients, head, Xa, Xp, Xn, R.Margin);
-        [head, trailingAvg, trailingAvgSq] = adamupdate(head, gradients, trailingAvg, trailingAvgSq, it + (epoch-1)*itersPerEpoch, R.LR, 0.9, 0.999);
+        [head, trailingAvg, trailingAvgSq] = adamupdate(head, gradients, ...
+            trailingAvg, trailingAvgSq, it + (epoch-1)*itersPerEpoch, R.LR, 0.9, 0.999);
         lossEpoch = lossEpoch + double(gather(extractdata(L)));
     end
     fprintf('Epoch %d/%d - loss: %.4f\n', epoch, R.Epochs, lossEpoch / itersPerEpoch);


### PR DESCRIPTION
## Summary
- avoid splitting `itersPerEpoch` when updating the projection head optimizer

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a29bc6020833093bc348e1e7ce864