### PR TITLE
Fix SQLite connection creation in ensure_db

### DIFF
--- a/+reg/ensure_db.m
+++ b/+reg/ensure_db.m
@@ -10,21 +10,20 @@ if isfield(DB,'vendor') && strcmpi(DB.vendor,'sqlite')
     if ~exist(dbdir, 'dir')
         mkdir(dbdir);
     end
-    if exist(DB.sqlite_path, 'file')
+    % Open or create the SQLite database file
+    sconn = sqlite(DB.sqlite_path);
 
-        sconn = sqlite(DB.sqlite_path);          % open existing file
-    else
+    % Ensure the reg_chunks table exists
+    createSQL = [
+        'CREATE TABLE IF NOT EXISTS reg_chunks (' ...
+        '  chunk_id TEXT PRIMARY KEY,' ...
+        '  doc_id TEXT,' ...
+        '  text TEXT' ...
+        ');'];
+    exec(sconn, createSQL);
 
-        % ensure table
-        createSQL = [
-            'CREATE TABLE IF NOT EXISTS reg_chunks (' ...
-            '  chunk_id TEXT PRIMARY KEY,' ...
-            '  doc_id TEXT,' ...
-            '  text TEXT' ...
-            ');'];
-        exec(sconn, createSQL);
-        conn = struct('sqlite', sconn, 'vendor','sqlite');
-    end
+    % Return a connection struct consistent with Postgres branch
+    conn = struct('sqlite', sconn, 'vendor','sqlite');
 else
     % Default to Database Toolbox server connection (e.g., Postgres)
     conn = database(DB.dbname, DB.user, DB.pass, 'Vendor', DB.vendor, ...


### PR DESCRIPTION
## Summary
- Ensure `ensure_db` initializes a SQLite connection before creating the `reg_chunks` table
- Always return a connection struct for SQLite similar to other database vendors

## Testing
- `octave -qf --eval "runtests('tests','IncludeSubfolders',true)"` *(fails: command not found)*
- `matlab -batch "runtests('tests','IncludeSubfolders',true)"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_689a2d717c4483308535ea14f6f93fca