### PR TITLE
Simplify negative sampling in build_pairs

### DIFF
--- a/+reg/build_pairs.m
+++ b/+reg/build_pairs.m
@@ -23,18 +23,15 @@ for i = 1:N
     posSets{i}(posSets{i}==i) = []; % remove self
 end
 
-% Negatives: disjoint labels
-negMask = ~labelsLogical;
+% Negatives: choose rows that share no label with the anchor
 trip = zeros(3,0,'uint32');
 for i = 1:N
     Pset = posSets{i};
     if numel(Pset) < R.MinPosPerAnchor, continue; end
     % pick one positive at random
     pidx = Pset(randi(numel(Pset)));
-    % negatives: rows that share no label with the anchor
-    negCandidates = find(all(negMask(i,:) | ~negMask, 2)); % rows with all ~labels(i,:)
-    % more robust: true negatives are rows where (labelsLogical(i,:) & labelsLogical(j,:))==0
-    overlap = labelsLogical * labelsLogical(i,:)';
+    % negatives: compute label overlap and keep rows with zero intersection
+    overlap = labelsLogical * labelsLogical(i,:)'; % count shared labels
     negCandidates = find(overlap==0);
     negCandidates(negCandidates==i) = [];
     if isempty(negCandidates), continue; end


### PR DESCRIPTION
## Summary
- simplify negative pair generation by computing label overlap directly and selecting rows with zero intersection
- clarify comments around negative sampling logic

## Testing
- `matlab -batch "results = runtests('tests','IncludeSubfolders',true,'UseParallel',false); disp(results);"` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689a2f98f06c83308f4383dc05df9c9e