### PR TITLE
refactor: simplify triplet batch encoding

### DIFF
--- a/+reg/ft_train_encoder.m
+++ b/+reg/ft_train_encoder.m
@@ -179,8 +179,6 @@ end
 % === Helpers ===
 function [loss, gE, gH] = gradTripletBatch(base, head, tok, aIdx, pIdx, nIdx, maxLen, useFP16, margin)
 B = numel(aIdx);
-texts = [aIdx(:); pIdx(:); nIdx(:)];
-ids = encode(tok, string(assignin('caller','chunksT',[])), 'Padding','longest'); %#ok<NASGU>
 % Re-encode directly from caller chunksT:
 persistent cachedChunks;
 if isempty(cachedChunks), cachedChunks = evalin('caller','chunksT'); end


### PR DESCRIPTION
## Summary
- remove unnecessary encoding and side effects in `gradTripletBatch`
- build batch texts directly from cached `chunksT`

## Testing
- `octave -qf --eval "run('run_smoke_test.m')"` *(fails: command not found)*
- `matlab -batch "run('run_smoke_test.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a2f9757dc8330909d17abf044c189