### PR TITLE
Refactor knob loading in config

### DIFF
--- a/config.m
+++ b/config.m
@@ -1,25 +1,32 @@
 function C = config()
 %CONFIG Project configuration for regulatory topic classifier
 
-% Load knobs from knobs.json if present
-C.knobs = reg.load_knobs();
-if isfield(C.knobs,'Chunk')
-    if isfield(C.knobs.Chunk,'SizeTokens'), C.chunk_size_tokens = C.knobs.Chunk.SizeTokens; end
-    if isfield(C.knobs.Chunk,'Overlap'),    C.chunk_overlap = C.knobs.Chunk.Overlap; end
+% Default Chunking
+C.chunk_size_tokens = 350;
+C.chunk_overlap     = 60;
+
+% Load knobs and apply overrides
+try
+    C.knobs = reg.load_knobs();
+catch ME
+    warning("Knobs load/apply failed: %s", ME.message);
+    C.knobs = struct();
 end
 
 % Display active knobs summary
 disp('=== Active knobs configuration ===');
 disp(jsonencode(C.knobs));
 
+% Apply Chunk overrides
+if isfield(C.knobs,'Chunk')
+    if isfield(C.knobs.Chunk,'SizeTokens'), C.chunk_size_tokens = C.knobs.Chunk.SizeTokens; end
+    if isfield(C.knobs.Chunk,'Overlap'),    C.chunk_overlap = C.knobs.Chunk.Overlap; end
+end
+
 C.input_dir   = "data/pdfs";     % drop regs here (PDFs)
 C.labels = ["IRB","CreditRisk","Securitisation","SRT","MarketRisk_FRTB", ...
             "Liquidity_LCR","Liquidity_NSFR","LeverageRatio","OperationalRisk", ...
             "AML_KYC","Governance","Reporting_COREP_FINREP","StressTesting","Outsourcing_ICT_DORA"];
-
-% Chunking
-C.chunk_size_tokens = 350;
-C.chunk_overlap     = 60;
 
 % FastText embedding (Text Analytics Toolbox)
 C.embeddings_backend = 'bert'; % 'bert' or 'fasttext'
@@ -38,16 +45,4 @@ C.db = struct('enable', false, 'vendor','postgres', 'dbname','reg_topics', ...
 % Reports
 C.report_title = "Banking Regulation Topic Classifier — Snapshot";
 
-    % === Load knobs.json and apply Chunk overrides ===
-    try
-        K = reg.load_knobs();
-        C.knobs = K;
-        if isfield(K,'Chunk')
-            if isfield(K.Chunk,'SizeTokens'), C.chunk_size_tokens = K.Chunk.SizeTokens; end
-            if isfield(K.Chunk,'Overlap'),    C.chunk_overlap     = K.Chunk.Overlap;    end
-        end
-    catch ME
-        warning("Knobs load/apply failed: %s", ME.message);
-    end
-    
 end


### PR DESCRIPTION
## Summary
- streamline knob handling by loading once with error handling
- show active knobs and apply chunk overrides after loading

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689a2f94eac08330a6db2cdac709c275