### PR TITLE
feat: limit EBA fetches and parallelize full runs

### DIFF
--- a/+reg/fetch_crr_eba.m
+++ b/+reg/fetch_crr_eba.m
@@ -1,5 +1,14 @@
-function T = fetch_crr_eba()
+function T = fetch_crr_eba(varargin)
 %FETCH_CRR_EBA Download CRR articles from EBA Interactive Single Rulebook (HTML + plaintext).
+% T = fetch_crr_eba('maxArticles',N) limits the download to the first N articles.
+% When the full corpus is fetched (default), pages are downloaded in parallel
+% using PARFEVAL while enforcing a 0.2s politeness delay between requests.
+
+p = inputParser;
+addParameter(p,'maxArticles',inf);
+parse(p,varargin{:});
+maxArticles = p.Results.maxArticles;
+
 base = "https://eba.europa.eu";
 root = base + "/regulation-and-policy/single-rulebook/interactive-single-rulebook/12674";
 html = webread(root);
@@ -15,26 +24,54 @@ titles= txt(mask);
 hrefs = hrefs(ia); titles = titles(ia);
 
 outDir = fullfile("data","eba_isrb","crr"); if ~isfolder(outDir), mkdir(outDir); end
-n = numel(hrefs); ids = strings(n,1); files = strings(n,1); titlesS = strings(n,1); urls = strings(n,1);
-for i = 1:n
-    url = base + string(hrefs{i});
-    try
-        page = webread(url);
-        ids(i) = "CRR_" + string(i);
-        htmlPath = fullfile(outDir, ids(i) + ".html");
-        txtPath  = fullfile(outDir, ids(i) + ".txt");
-        fid=fopen(htmlPath,'w'); fwrite(fid, page); fclose(fid);
-        t = htmlTree(page); bodyTxt = extractHTMLText(t);
-        writelines(string(bodyTxt), txtPath);
-        files(i) = htmlPath;
-        titlesS(i) = string(titles{i});
-        urls(i) = url;
+nAll = numel(hrefs);
+n = min(nAll, maxArticles);
+ids = strings(n,1); files = strings(n,1); titlesS = strings(n,1); urls = strings(n,1);
+
+if n < nAll
+    % Sequential fetch when limiting number of articles
+    for i = 1:n
+        url = base + string(hrefs{i});
+        [ids(i), titlesS(i), urls(i), files(i)] = fetchOne(base, hrefs{i}, titles{i}, i, outDir);
         pause(0.2); % politeness
-    catch ME
-        warning("Failed fetching %s: %s", url, ME.message);
+    end
+else
+    % Full fetch: download in parallel with politeness delay
+    pool = gcp('nocreate'); if isempty(pool), pool = parpool; end
+    futures(n) = parallel.FevalFuture;
+    for i = 1:n
+        if i > 1, pause(0.2); end
+        futures(i) = parfeval(pool,@fetchOne,4,base,hrefs{i},titles{i},i,outDir);
+    end
+    for j = 1:n
+        try
+            [idx, id, titleS, url, file] = fetchNext(futures);
+            ids(idx) = id; titlesS(idx) = titleS; urls(idx) = url; files(idx) = file;
+        catch ME
+            warning("Failed fetching article %d: %s", j, ME.message);
+        end
     end
 end
+
 T = table(ids, titlesS, urls, files, 'VariableNames', {'article_id','title','url','html_file'});
 writetable(T, fullfile(outDir,"index.csv"));
 fprintf("Saved %d CRR article pages to %s\n", height(T), outDir);
+end
+
+function [id, titleS, url, htmlPath] = fetchOne(base, href, title, idx, outDir)
+%FETCHONE Fetch a single article and save HTML + plaintext
+url = base + string(href);
+id = "CRR_" + string(idx);
+htmlPath = fullfile(outDir, id + ".html");
+txtPath  = fullfile(outDir, id + ".txt");
+try
+    page = webread(url);
+    fid=fopen(htmlPath,'w'); fwrite(fid, page); fclose(fid);
+    t = htmlTree(page); bodyTxt = extractHTMLText(t);
+    writelines(string(bodyTxt), txtPath);
+    titleS = string(title);
+catch ME
+    warning("Failed fetching %s: %s", url, ME.message);
+    titleS = ""; url = ""; htmlPath = "";
+end
 end

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -213,7 +213,7 @@ Main report now includes a **Gold Mini-Pack** section (if `gold/*` exists), show
 **Data acquisition + diffs added:**
 - Fetchers:
   - `+reg/fetch_crr_eurlex.m` — downloads consolidated CRR PDF by consolidation date.
-  - `+reg/fetch_crr_eba.m` — scrapes EBA ISRB per-article pages (HTML + plaintext) with index CSV.
+  - `+reg/fetch_crr_eba.m` — scrapes EBA ISRB per-article pages (HTML + plaintext) with index CSV; supports `maxArticles` and parallel full fetches.
 - Diffs:
   - `+reg/crr_diff_versions.m` — compare two CRR corpora (e.g., older vs newer EBA text dumps), write CSV + patch.
   - `+reg/diff_methods.m` — compare Top-10 retrievals across baseline/projection/fine-tuned for a query set.

--- a/tests/TestFetchers.m
+++ b/tests/TestFetchers.m
@@ -9,12 +9,15 @@ classdef TestFetchers < RegTestCase
             end
         end
         function eba_fetch_signature(tc)
-            % Only check that the function returns a table or errors gracefully (no net in CI)
-            try
-                T = reg.fetch_crr_eba();
-                tc.verifyTrue(istable(T));
-            catch ME
-                tc.assertTrue(~isempty(ME.message));
+            % Verify limited and full fetch modes handle lack of network gracefully
+            limits = [1, inf];
+            for k = 1:numel(limits)
+                try
+                    T = reg.fetch_crr_eba('maxArticles', limits(k)); %#ok<NASGU>
+                    tc.verifyTrue(istable(T));
+                catch ME
+                    tc.assertTrue(~isempty(ME.message));
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary
- allow restricting CRR article downloads via `maxArticles`
- fetch full CRR corpus in parallel with politeness delays
- document and test new fetch options

## Testing
- `sudo apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` (fails: repository not signed)
- `octave --eval "runtests('tests')"` (fails: command not found)
- `matlab -batch "runtests('tests')"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_689a37a625248330b14c8208e32cfb16