### PR TITLE
Use integer column type for labels in chunk upserts

### DIFF
--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -28,7 +28,7 @@ if isstruct(conn) && isfield(conn,'sqlite')
         if startsWith(colname, "score_")
             coltype = "REAL";
         else
-            coltype = "TEXT";
+            coltype = "INTEGER";
         end
         exec(sconn, "ALTER TABLE reg_chunks ADD COLUMN " + colname + " " + coltype);
     end


### PR DESCRIPTION
## Summary
- Define label columns as INTEGER when adding them to `reg_chunks`

## Testing
- `octave -qf --eval "runtests('tests/TestDB.m')"` *(fails: command not found)*
- Manual sqlite insert/replace to verify existing rows and new rows after adding INTEGER label columns

------
https://chatgpt.com/codex/tasks/task_b_689a439ad890833080ff1c1ab08fd662