### PR TITLE
Fix SQLite pragma query quoting

### DIFF
--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -16,7 +16,7 @@ if isstruct(conn) && isfield(conn,'sqlite')
     % Create label/score columns if needed
     cols = T.Properties.VariableNames;
     % Only retrieve column names to avoid NULL default values triggering errors
-    cur = fetch(sconn, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+    cur = fetch(sconn, "SELECT name FROM pragma_table_info('reg_chunks');");
     if istable(cur)
         existing = string(cur{:,:});
     else

--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -34,7 +34,7 @@ classdef TestDB < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT count(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, 2);
-                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info('reg_chunks');");
                 if istable(colNames)
                     names = string(colNames{:,:});
                 else

--- a/tests/TestDBIntegrationSimulated.m
+++ b/tests/TestDBIntegrationSimulated.m
@@ -10,7 +10,7 @@ classdef TestDBIntegrationSimulated < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT COUNT(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, height(chunksT));
-                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info('reg_chunks');");
                 if istable(colNames)
                     names = string(colNames{:,:});
                 else


### PR DESCRIPTION
## Summary
- use single quotes in SQLite pragma_table_info query
- update tests to use correct pragma SQL

## Testing
- `octave -qf --eval "runtests('tests/TestDB.m')"` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689a43782ff88330b8f1e1c7677af94f