### PR TITLE
Handle user interruptions in fetch_crr_eba

### DIFF
--- a/+reg/fetch_crr_eba.m
+++ b/+reg/fetch_crr_eba.m
@@ -39,6 +39,13 @@ for i = 1:n
         urls(i) = url;
         pause(0.2); % politeness
     catch ME
+        isInterrupt = isa(ME, 'matlab.exception.InterruptException') || ...
+            strcmp(ME.identifier, 'MATLAB:OperationTerminatedByUser') || ...
+            any(cellfun(@(e) isa(e, 'matlab.exception.InterruptException') || ...
+            strcmp(e.identifier, 'MATLAB:OperationTerminatedByUser'), ME.cause));
+        if isInterrupt
+            rethrow(ME);
+        end
         warning("Failed fetching %s: %s", url, ME.message);
     end
 end


### PR DESCRIPTION
## Summary
- Recognize user-generated interrupts in `fetch_crr_eba` during article fetching
- Rethrow the interrupt exception so the loop and function terminate immediately

## Testing
- `matlab -batch "runtests('tests/TestFetchers.m')"` *(fails: command not found)*
- `octave --eval "runtests('tests/TestFetchers.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a43e5dd0883309c4ae1addfb906ee