### PR TITLE
Mock webread in signature test

### DIFF
--- a/tests/TestFetchers.m
+++ b/tests/TestFetchers.m
@@ -10,6 +10,10 @@ classdef TestFetchers < RegTestCase
         end
         function eba_fetch_signature(tc)
             % Function should always return a table, even if network unavailable
+            testDir = fileparts(mfilename('fullpath'));
+            timeoutDir = fullfile(testDir, 'fixtures', 'webread_timeout');
+            addpath(timeoutDir);
+            tc.addTeardown(@() rmpath(timeoutDir));
             T = reg.fetch_crr_eba();
             tc.verifyTrue(istable(T));
         end


### PR DESCRIPTION
## Summary
- avoid real HTTP in eba_fetch_signature test by adding webread_timeout mock and teardown

## Testing
- `matlab -batch "runtests('tests/TestFetchers')"` *(command not found)*
- `octave --eval "runtests('tests/TestFetchers')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a44b220f883309512f64c575000bd