### PR TITLE
Fix pragma_table_info query quoting in tests

### DIFF
--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -34,7 +34,7 @@ classdef TestDB < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT count(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, 2);
-                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info('reg_chunks');");
                 if istable(colNames)
                     names = string(colNames{:,:});
                 else

--- a/tests/TestDBIntegrationSimulated.m
+++ b/tests/TestDBIntegrationSimulated.m
@@ -10,7 +10,7 @@ classdef TestDBIntegrationSimulated < RegTestCase
             if isstruct(conn) && isfield(conn,'sqlite')
                 cur = fetch(conn.sqlite, "SELECT COUNT(*) FROM reg_chunks");
                 tc.verifyGreaterThanOrEqual(cur{1}, height(chunksT));
-                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info(''reg_chunks'');");
+                colNames = fetch(conn.sqlite, "SELECT name FROM pragma_table_info('reg_chunks');");
                 if istable(colNames)
                     names = string(colNames{:,:});
                 else


### PR DESCRIPTION
## Summary
- correct SQL pragma_table_info calls in TestDB and TestDBIntegrationSimulated

## Testing
- `matlab -batch "runtests('tests/TestDB.m')"` *(fails: command not found)*
- `matlab -batch "runtests('tests/TestDBIntegrationSimulated.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a439c094c8330a07ac62e8d872abb