### PR TITLE
Fix sqlite upsert and isolate test DB path

### DIFF
--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -5,9 +5,10 @@ classdef TestDB < RegTestCase
     methods (TestMethodSetup)
         function setupDB(tc)
             C = config();
-            % Force sqlite for tests
+            % Force sqlite for tests and isolate test database from runtime config
             C.db.vendor = 'sqlite';
-            if isfield(C.db,'sqlite_path'); deleteIfExists(C.db.sqlite_path); end
+            C.db.sqlite_path = fullfile(tempdir(), 'reg_test.sqlite');
+            deleteIfExists(C.db.sqlite_path);
             tc.TempDB = C.db;
             assignin('base','Cdb',tc.TempDB); %#ok<NASGU>
         end


### PR DESCRIPTION
## Summary
- ensure TestDB uses a temporary sqlite path instead of the runtime config
- rewrite sqlite upsert to build full INSERT OR REPLACE statements without unsupported parameter binding

## Testing
- `octave --eval "runtests('tests/TestDB.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a48fbd0088330ae9a87477d797f27