### PR TITLE
Fix tests by adding project path setup

### DIFF
--- a/tests/TestBase.m
+++ b/tests/TestBase.m
@@ -1,0 +1,8 @@
+classdef (Abstract) TestBase < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function addProjectToPath(tc)
+            root = fileparts(fileparts(mfilename('fullpath')));
+            tc.applyFixture(matlab.unittest.fixtures.PathFixture(root));
+        end
+    end
+end

--- a/tests/TestDB.m
+++ b/tests/TestDB.m
@@ -1,4 +1,4 @@
-classdef TestDB < matlab.unittest.TestCase
+classdef TestDB < TestBase
     properties
         TempDB
     end

--- a/tests/TestFeatures.m
+++ b/tests/TestFeatures.m
@@ -1,4 +1,4 @@
-classdef TestFeatures < matlab.unittest.TestCase
+classdef TestFeatures < TestBase
     methods (Test)
         function test_tfidf_and_embeddings(tc)
             str = ["IRB PD LGD EAD framework."; "LCR requires HQLA"; "AML and KYC obligations"];

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -1,4 +1,4 @@
-classdef TestHybridSearch < matlab.unittest.TestCase
+classdef TestHybridSearch < TestBase
     methods (Test)
         function test_query(tc)
             docs = ["IRB approach for PD LGD.", "LCR requires HQLA", "KYC procedures for AML"];

--- a/tests/TestIngestAndChunk.m
+++ b/tests/TestIngestAndChunk.m
@@ -1,4 +1,4 @@
-classdef TestIngestAndChunk < matlab.unittest.TestCase
+classdef TestIngestAndChunk < TestBase
     methods (Test)
         function test_ingest_and_chunk(tc)
             C = config();

--- a/tests/TestRulesAndModel.m
+++ b/tests/TestRulesAndModel.m
@@ -1,4 +1,4 @@
-classdef TestRulesAndModel < matlab.unittest.TestCase
+classdef TestRulesAndModel < TestBase
     methods (Test)
         function test_rules_and_train_predict(tc)
             text = [


### PR DESCRIPTION
## Summary
- add `TestBase` with a `PathFixture` to include repo root on MATLAB path for tests
- make all test classes inherit from `TestBase`

## Testing
- `matlab -batch "runtests('tests','IncludeSubfolders',true,'UseParallel',false)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a752d679c8330a01988029c272994