### PR TITLE
Use fastText language option and reuse embedding helper

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,6 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+emb = fastTextWordEmbedding('Language', fasttextCfg.language);
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -14,10 +14,8 @@ bagQ = bagOfWords(qTok, S.vocab);
 qv = bagQ.Counts; idf = log( size(S.Xtfidf,1) ./ max(1,sum(S.Xtfidf>0,1)) );
 qtfidf = qv .* idf;
 
-emb = fastTextWordEmbedding("en");
-seq = doc2sequence(emb, qTok);
-if ~isempty(seq) && ~isempty(seq{1}), qe = mean(single(seq{1}),2)'; else, qe = zeros(1,size(S.E,2),'single'); end
-qe = qe ./ max(1e-9, norm(qe));
+qe = reg.doc_embeddings_fasttext(q, struct('language','en'));
+qe = qe(1,:);
 
 bm = (S.Xtfidf * qtfidf') ./ max(1e-9, norm(qtfidf));
 em = single(S.E * qe');


### PR DESCRIPTION
## Summary
- Update doc embeddings to request fastText model using the `Language` option
- Reuse `doc_embeddings_fasttext` in hybrid search queries to avoid duplication

## Testing
- `matlab -batch "results=runtests('tests'); disp(results); exit(any([results.Failed]));"` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_689a7842a2748330a18688aca78e620a