### PR TITLE
Limit LDA topics based on document count

### DIFF
--- a/reg_pipeline.m
+++ b/reg_pipeline.m
@@ -9,7 +9,8 @@ chunksT = reg.chunk_text(docsT, C.chunk_size_tokens, C.chunk_overlap); % chunk_i
 % C) Features: TF-IDF bag + LDA topics + embeddings
 [docsTok, vocab, Xtfidf] = reg.ta_features(chunksT.text);
 bag = bagOfWords(docsTok);
-mdlLDA = fitlda(bag, C.lda_topics, 'Verbose',0);
+numTopics = min(C.lda_topics, bag.NumDocuments);
+mdlLDA = fitlda(bag, numTopics, 'Verbose',0);
 topicDist = transform(mdlLDA, bag);
 E = reg.doc_embeddings_fasttext(chunksT.text, C.fasttext);
 

--- a/tests/TestRulesAndModel.m
+++ b/tests/TestRulesAndModel.m
@@ -9,7 +9,8 @@ classdef TestRulesAndModel < TestBase
             labels = ["IRB","Liquidity_LCR","AML_KYC"];
             [docsTok, vocab, Xtfidf] = reg.ta_features(text); %#ok<ASGLU>
             bag = bagOfWords(docsTok);
-            mdlLDA = fitlda(bag, 6, 'Verbose',0);
+            numTopics = min(6, bag.NumDocuments);
+            mdlLDA = fitlda(bag, numTopics, 'Verbose',0);
             topicDist = transform(mdlLDA, bag);
             E = reg.doc_embeddings_fasttext(text, struct('language','en'));
             X = [Xtfidf, sparse(topicDist), E];


### PR DESCRIPTION
## Summary
- Clamp requested LDA topics to the available document count before fitting
- Apply the same limit in unit tests that fit an LDA model

## Testing
- `octave -qf tests/TestRulesAndModel.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a784242788330a7e75da1b7e50419