### PR TITLE
Use column-name pragma query for upsert_chunks

### DIFF
--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -9,8 +9,8 @@ if isstruct(conn) && isfield(conn,'sqlite')
     sconn = conn.sqlite;
     % Create label columns if needed
     cols = fieldnames(T)';
-    cur = fetch(sconn, "PRAGMA table_info(reg_chunks);");
-    existing = string(cur(:,2));
+    cur = fetch(sconn, "SELECT name FROM pragma_table_info('reg_chunks');");
+    existing = string(cur(:,1));
     toAdd = setdiff(string(cols), existing);
     for k = 1:numel(toAdd)
         exec(sconn, "ALTER TABLE reg_chunks ADD COLUMN " + toAdd(k) + " TEXT");


### PR DESCRIPTION
## Summary
- Simplify SQLite schema introspection in upsert_chunks by querying only column names
- Handle pragma results as a single-column cell array when determining missing columns

## Testing
- `matlab -batch "disp('MATLAB running');"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_b_689a78408ca08330a9d959041045f0a7