### PR TITLE
Initialize FastText embeddings with language option

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,6 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+emb = fastTextWordEmbedding('Language', fasttextCfg.language);
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);
@@ -8,7 +8,7 @@ E = zeros(numel(W), d, 'single');
 for i = 1:numel(W)
     if isempty(W{i}), continue; end
     V = single(W{i});
-    E(i,:) = mean(V, 2, 'omitnan');
+    E(i,:) = mean(V, 2, 'omitnan')';
 end
 n = vecnorm(E,2,2); n(n==0)=1; E = E ./ n;
 end


### PR DESCRIPTION
## Summary
- Initialize fastText word embeddings via explicit `Language` parameter.
- Store mean-pooled vectors as row vectors for proper shape.
- Maintain empty-sequence handling for robustness.

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a783f423c833093f1c8d383d85313