### PR TITLE
Fix fastText embedding and DB upsert issues

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,6 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding('Language', fasttextCfg.language);
+emb = fastTextWordEmbedding(fasttextCfg.language);
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/ta_features.m
+++ b/+reg/ta_features.m
@@ -9,7 +9,7 @@ docsTok = normalizeWords(docsTok,'Style','lemma');
 docsTok = removeShortWords(docsTok,3);
 
 bag = bagOfWords(docsTok);
-bag = removeInfrequentWords(bag, 2);
+bag = removeInfrequentWords(bag, 1);
 bag = removeEmptyDocuments(bag);
 X = bag.Counts;                  % docs×terms
 idf = log( size(X,1) ./ max(1,sum(X>0,1)) );

--- a/+reg/upsert_chunks.m
+++ b/+reg/upsert_chunks.m
@@ -10,7 +10,7 @@ if isstruct(conn) && isfield(conn,'sqlite')
     % Create label columns if needed
     cols = fieldnames(T)';
     cur = fetch(sconn, "SELECT name FROM pragma_table_info('reg_chunks');");
-    existing = string(cur(:,1));
+    existing = string(cur.name);
     toAdd = setdiff(string(cols), existing);
     for k = 1:numel(toAdd)
         exec(sconn, "ALTER TABLE reg_chunks ADD COLUMN " + toAdd(k) + " TEXT");


### PR DESCRIPTION
## Summary
- keep rare tokens when building TF-IDF vocabulary
- call fastTextWordEmbedding with direct language argument
- handle SQLite column name extraction without invalid table conversions

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a7ad604a083308ff9a45d5b0b5db4