### PR TITLE
Handle optional fastText language

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,15 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+%   E = DOC_EMBEDDINGS_FASTTEXT(TEXTSTR) returns mean-pooled and normalized
+%   fastText embeddings using the default language model.
+%   E = DOC_EMBEDDINGS_FASTTEXT(TEXTSTR, FASTTEXTCFG) allows specifying a
+%   language via FASTTEXTCFG.language.
+
+if nargin < 2 || ~isfield(fasttextCfg, 'language') || isempty(fasttextCfg.language)
+    emb = fastTextWordEmbedding();
+else
+    emb = fastTextWordEmbedding('Language', fasttextCfg.language);
+end
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);


### PR DESCRIPTION
## Summary
- Allow `doc_embeddings_fasttext` to load default fastText model when no language is provided.
- Accept optional `fasttextCfg.language` and invoke `fastTextWordEmbedding` with `'Language'` parameter when specified.

## Testing
- `matlab -batch "runtests('TestRulesAndModel/test_rules_and_train_predict')"` *(command failed: `bash: command not found: matlab`)*

------
https://chatgpt.com/codex/tasks/task_b_689a7e03fd2c8330b4dbcad40b8c3ee8