### PR TITLE
Make fastText config optional for doc embeddings

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,12 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+%   E = doc_embeddings_fasttext(textStr) returns mean-pooled fastText
+%   embeddings using the default model. An optional fasttextCfg argument is
+%   accepted for backward compatibility but is ignored.
+if nargin < 2
+    fasttextCfg = struct(); %#ok<NASGU>
+end
+emb = fastTextWordEmbedding();
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -14,7 +14,7 @@ bagQ = bagOfWords(qTok, S.vocab);
 qv = bagQ.Counts; idf = log( size(S.Xtfidf,1) ./ max(1,sum(S.Xtfidf>0,1)) );
 qtfidf = qv .* idf;
 
-qe = reg.doc_embeddings_fasttext(q, struct('language','en'));
+qe = reg.doc_embeddings_fasttext(q);
 qe = qe(1,:);
 
 bm = (S.Xtfidf * qtfidf') ./ max(1e-9, norm(qtfidf));

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -3,7 +3,7 @@ classdef TestHybridSearch < TestBase
         function test_query(tc)
             docs = ["IRB approach for PD LGD.", "LCR requires HQLA", "KYC procedures for AML"];
             [docsTok, vocab, Xtfidf] = reg.ta_features(docs); %#ok<ASGLU>
-            E = reg.doc_embeddings_fasttext(docs, struct('language','en'));
+            E = reg.doc_embeddings_fasttext(docs);
             S = reg.hybrid_search(Xtfidf, E, vocab);
             res = S.query("liquidity coverage ratio HQLA", 0.5);
             tc.verifyGreaterThan(height(res), 0);


### PR DESCRIPTION
## Summary
- Load fastText embeddings with default model and ignore optional configuration
- Update hybrid search to call new embedding helper without config
- Adapt hybrid search test for new doc_embeddings_fasttext signature

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --eval "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a7dfe0dd4833087c1b8f4e8ba26a1