### PR TITLE
fix: update fastText embedding instantiation

### DIFF
--- a/+reg/doc_embeddings_fasttext.m
+++ b/+reg/doc_embeddings_fasttext.m
@@ -1,6 +1,6 @@
 function E = doc_embeddings_fasttext(textStr, fasttextCfg)
 %DOC_EMBEDDINGS_FASTTEXT Mean-pooled fastText vectors (normalized)
-emb = fastTextWordEmbedding(fasttextCfg.language);
+emb = fastTextWordEmbedding("Language", fasttextCfg.language);
 tok = tokenizedDocument(string(textStr));
 W = doc2sequence(emb, tok);
 d = size(emb.WordVectors,2);

--- a/tests/TestFeatures.m
+++ b/tests/TestFeatures.m
@@ -7,6 +7,8 @@ classdef TestFeatures < TestBase
             E = reg.doc_embeddings_fasttext(str, struct('language','en'));
             tc.verifySize(E, [numel(str), size(E,2)]);
             tc.verifyGreaterThan(norm(E(1,:)), 0);
+            n = vecnorm(E,2,2);
+            tc.verifyEqual(n, ones(size(n)), 'AbsTol',1e-6);
         end
     end
 end

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -4,6 +4,7 @@ classdef TestHybridSearch < TestBase
             docs = ["IRB approach for PD LGD.", "LCR requires HQLA", "KYC procedures for AML"];
             [docsTok, vocab, Xtfidf] = reg.ta_features(docs); %#ok<ASGLU>
             E = reg.doc_embeddings_fasttext(docs, struct('language','en'));
+            tc.verifyEqual(vecnorm(E,2,2), ones(size(E,1),1), 'AbsTol',1e-6);
             S = reg.hybrid_search(Xtfidf, E, vocab);
             res = S.query("liquidity coverage ratio HQLA", 0.5);
             tc.verifyGreaterThan(height(res), 0);

--- a/tests/TestRulesAndModel.m
+++ b/tests/TestRulesAndModel.m
@@ -13,6 +13,7 @@ classdef TestRulesAndModel < TestBase
             mdlLDA = fitlda(bag, numTopics, 'Verbose',0);
             topicDist = transform(mdlLDA, bag);
             E = reg.doc_embeddings_fasttext(text, struct('language','en'));
+            tc.verifyEqual(vecnorm(E,2,2), ones(size(E,1),1), 'AbsTol',1e-6);
             X = [Xtfidf, sparse(topicDist), E];
 
             Yweak = reg.weak_rules(text, labels);


### PR DESCRIPTION
## Summary
- use name-value pair to create fastText embeddings
- verify embeddings are normalized in tests

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a7dbf9fec8330bfa7627814f0eba0