### PR TITLE
Align chunking defaults across docs and config

### DIFF
--- a/EXPERIMENT_CHEATSHEET.md
+++ b/EXPERIMENT_CHEATSHEET.md
@@ -2,11 +2,11 @@
 
 ## 0) One-time setup
 1) MATLAB Add-Ons → install **“Text Analytics Toolbox Model for BERT English.”**
-2) In `config.m` set:
+2) In `config.m` ensure:
    ```matlab
    C.embeddings_backend = 'bert';
-   C.chunk_size_tokens  = 300;
-   C.chunk_overlap      = 80;
+   C.chunk_size_tokens  = 300; % default
+   C.chunk_overlap      = 80;  % default
    C.lda_topics         = 0;
    C.db.enable          = false;
    ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ test using SQLite (no external server required).
 - `tests/` — MATLAB unit tests (no network required), plus sample fixture PDF text.
 
 ## Running
-1. Optionally tweak `pipeline.json` (pipeline settings) and `knobs.json` (training knobs).
+1. Optionally tweak `pipeline.json` (pipeline settings) and `knobs.json` (training knobs, including chunking; defaults are 300-token chunks with 80-token overlap).
 2. Put PDFs under `data/pdfs` (or use the provided dummy).
 3. Open MATLAB in this folder and run:
    ```matlab

--- a/config.m
+++ b/config.m
@@ -25,8 +25,8 @@ C.labels = ["IRB","CreditRisk","Securitisation","SRT","MarketRisk_FRTB", ...
             "AML_KYC","Governance","Reporting_COREP_FINREP","StressTesting","Outsourcing_ICT_DORA"];
 
 % Chunking defaults
-C.chunk_size_tokens = 350;
-C.chunk_overlap     = 60;
+C.chunk_size_tokens = 300;
+C.chunk_overlap     = 80;
 
 % FastText embedding (Text Analytics Toolbox)
 C.embeddings_backend = 'bert'; % 'bert' or 'fasttext'

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -9,9 +9,9 @@
    ```matlab
    load('data/docs.mat','docs')
    ```
-2. Chunk each document with the helper function:
+2. Chunk each document with the helper function (default `chunk_size_tokens=300`, `chunk_overlap=80`):
    ```matlab
-   chunks = reg.chunk_text(docs, 'chunk_size_tokens', 512, 'chunk_overlap', 64);
+   chunks = reg.chunk_text(docs, 'chunk_size_tokens', 300, 'chunk_overlap', 80);
    ```
 3. Save the chunks for later modules:
    ```matlab


### PR DESCRIPTION
## Summary
- Set canonical chunking defaults to 300 tokens and 80-token overlap in `config.m`.
- Updated text chunking guide and experiment cheat sheet to reference the new defaults.
- Mentioned the default chunking parameters in the README; `knobs.json` already reflects them.

## Testing
- `matlab -batch "runtests('tests','IncludeSubfolders',true)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b09339450833080a30c2169962a98