### PR TITLE
docs: fix naming guide capitalization and spelling

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -3,7 +3,7 @@
 This repository enforces consistent naming through:
 1. A **single source of truth**: `naming_registry.md`
 2. Editor aids and grep-able breadcrumbs
-3. naming converntion is detailed in the matlab style guide
+3. Naming convention is detailed in the MATLAB style guide
 ## TL;DR
 
 | Category | Rule |


### PR DESCRIPTION
## Summary
- fix spelling and capitalization for MATLAB style guide reference in naming README

## Testing
- `matlab -batch "runtests"` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_b_689b092ca608833098a084a50d46ae3d