### PR TITLE
docs: align indentation and line width guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,29 @@
 # Contribution Guidelines
 
-This project welcomes contributions that improve the regulatory topic classifier. Follow the practices below to keep the code base consistent and reliable.
+This project welcomes contributions that improve the regulatory topic
+classifier. Follow the practices below to keep the code base consistent
+and reliable.
 
 ## Coding Style
 - **MATLAB language**
   - One function per `.m` file; file name matches the function name.
-  - Use `lowerCamelCase` for functions and variables, `UpperCamelCase` for classes, and `ALL_CAPS` for constants.
-  - Indent with **four spaces** and keep line length under ~100 characters.
-  - Begin every function with a help comment block describing inputs, outputs, and side effects.
-  - Prefer vectorized operations and built‑in functions over explicit loops when practical.
-  - Place reusable utilities under the `+reg/` package; keep test fixtures in `tests/`.
+  - Use `lowerCamelCase` for functions and variables, `UpperCamelCase` for
+    classes, and `ALL_CAPS` for constants.
+  - Indent with **two spaces** (no tabs) and limit lines to 80 characters.
+  - Begin every function with a help comment block describing inputs,
+    outputs, and side effects.
+  - Prefer vectorized operations and built-in functions over explicit
+    loops when practical.
+  - Place reusable utilities under the `+reg/` package; keep test fixtures
+    in `tests/`.
 - **Documentation and comments**
-  - Use `%` for single‑line comments and `%{ ... %}` for multi‑line blocks.
-  - Update or create accompanying documentation in `docs/` when behavior changes.
+  - Use `%` for single-line comments and `%{ ... %}` for multi-line blocks.
+  - Update or create accompanying documentation in `docs/` when behavior
+    changes.
 
 ## Branching Model
-- The `main` branch represents the latest stable state; do **not** commit directly to it.
+- The `main` branch represents the latest stable state; do **not**
+  commit directly to it.
 - Create topic branches from `main`:
   - `feature/<short-topic>` for new features
   - `fix/<short-topic>` for bug fixes
@@ -27,24 +35,31 @@ This project welcomes contributions that improve the regulatory topic classifier
 - Follow the format: `<type>: <short imperative summary>`
   - Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
   - Example: `feat: add projection-head training script`
-- Limit the summary line to ~72 characters; wrap additional details in the body if needed.
+- Limit the summary line to ~72 characters; wrap additional details in
+  the body if needed.
 - Reference related issues or documentation in the body.
 - Each commit should compile and pass tests on its own.
 
 ## Test Expectations
 - Every change must run the MATLAB test suite before submission:
   ```bash
-  matlab -batch "results=runtests('tests','IncludeSubfolders',true,'UseParallel',false); table(results)"
+  matlab -batch "results=runtests('tests','IncludeSubfolders',true,...
+    'UseParallel',false); table(results)"
   ```
-- Add or update unit tests in `tests/` for new features, edge cases, and bug fixes.
-- Write tests that are deterministic and do not require network access or proprietary data.
-- Include test results in the pull request description. If a failure is unrelated, explain why.
-- Use `run_smoke_test.m` for a quick pipeline sanity check before committing complex changes.
+- Add or update unit tests in `tests/` for new features, edge cases, and
+  bug fixes.
+- Write tests that are deterministic and do not require network access or
+  proprietary data.
+- Include test results in the pull request description. If a failure is
+  unrelated, explain why.
+- Use `run_smoke_test.m` for a quick pipeline sanity check before
+  committing complex changes.
 
 ## Pull Requests
-- Keep pull requests small and self‑contained; one logical change per PR.
+- Keep pull requests small and self-contained; one logical change per PR.
 - Provide a clear summary and list of tests run in the PR body.
 - Ensure documentation and examples are updated alongside code changes.
 
-Following these guidelines keeps the project maintainable and accessible for contributors of all experience levels.
+Following these guidelines keeps the project maintainable and accessible
+for contributors of all experience levels.
 

--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -50,7 +50,7 @@ A beginner-friendly reference for writing clear, consistent MATLAB code.
 | Rule | Example |
 |------|---------|
 | Indent with **two spaces** (no tabs) | `if condition` → `  statement` |
-| Limit lines to 80 characters where practical | Use `...` for continuation |
+| Limit lines to 80 characters | Use `...` for continuation |
 | Always include `end` for `if`, `for`, `while`, `function`, `classdef` | — |
 | Spaces around operators, commas, and after `;` | `a = b + c;` |
 | Insert blank lines between logical sections | Improves readability |
@@ -93,7 +93,7 @@ A beginner-friendly reference for writing clear, consistent MATLAB code.
 | Functions | lowerCamelCase; filename matches function |
 | Classes | UpperCamelCase |
 | Indentation | Two spaces, no tabs |
-| Line width | ≤ 80 characters |
+| Line width | Limit lines to 80 characters |
 | Comments | `%` for line, `%%` for section |
 | Tests | Located in `tests/`; run with `runtests` |
 

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -3,7 +3,7 @@
 This repository enforces consistent naming through:
 1. A **single source of truth**: `naming_registry.md`
 2. Editor aids and grep-able breadcrumbs
-3. naming converntion is detailed in the matlab style guide
+3. Naming convention is detailed in the MATLAB style guide
 ## TL;DR
 
 | Category | Rule |
@@ -13,14 +13,15 @@ This repository enforces consistent naming through:
 | Functions | lowerCamelCase; filename matches function |
 | Classes | UpperCamelCase |
 | Indentation | Two spaces, no tabs |
-| Line width | ≤ 80 characters |
+| Line width | Limit lines to 80 characters |
 | Comments | `%` for line, `%%` for section |
 | Tests | Located in `tests/`; run with `runtests` |
 
 
 ## CI
 
-A GitHub Action runs on every PR/push and fails the build if naming violations are found.
+A GitHub Action runs on every PR/push and fails the build if naming
+violations are found.
 
 ## Updating Names
 


### PR DESCRIPTION
## Summary
- enforce two-space indentation and 80-character line limit in CONTRIBUTING guidelines
- sync MATLAB style guide and naming README wording for indentation and line width

## Testing
- `matlab -batch "results=runtests('tests','IncludeSubfolders',true,'UseParallel',false); table(results)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b0908ded48330b4ab2cc60df497a7