### PR TITLE
docs: streamline build plan intro

### DIFF
--- a/SYSTEM_BUILD_PLAN.md
+++ b/SYSTEM_BUILD_PLAN.md
@@ -1,12 +1,6 @@
 # Regulatory Topic Classifier – Build & Test Roadmap
 
-
-
-# Detailed step-by-step guides for each task are available in the `docs/` folder.
-
 Detailed step-by-step guides for each task are available in the `docs/` folder.
-
-
 
 This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic classifier. Each task is scoped to minimize coupling and lists prerequisites so the system can be assembled and tested incrementally.
 


### PR DESCRIPTION
## Summary
- simplify the build plan introduction to a single sentence referencing the `docs/` folder
- keep overview paragraph and reorder whitespace for clearer formatting

## Testing
- `matlab -batch "results=runtests('tests','IncludeSubfolders',true,'UseParallel',false); disp(results); exit" >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b08fb488c83308026a45ed2dea5a5