### PR TITLE
doc: clarify PDF ingestion sources

### DIFF
--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -5,13 +5,14 @@
 **Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
 
 ## Instructions
-1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`).
-2. In MATLAB, call the ingestion routine:
+1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`). Fetcher utilities save downloaded PDFs to `data/raw`.
+2. Before running `reg.ingest_pdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
+3. In MATLAB, call the ingestion routine:
    ```matlab
    docs = reg.ingest_pdfs('data/pdfs');
    ```
-3. The function extracts text from each PDF. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
-4. Save the resulting table for later steps:
+4. The function extracts text from each PDF. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
+5. Save the resulting table for later steps:
    ```matlab
    save('data/docs.mat','docs')
    ```


### PR DESCRIPTION
## Summary
- Document that fetcher utilities store downloaded PDFs under `data/raw`.
- Advise copying PDFs or updating `pipeline.json` before calling `reg.ingest_pdfs`.

## Testing
- `matlab -batch "runtests('tests/TestPDFIngest.m')"` *(command not found)*
- `octave --eval "runtests('tests/TestPDFIngest.m')"` *(command not found)*
- `apt-get update` *(failed: repository unsigned/403)*

------
https://chatgpt.com/codex/tasks/task_b_689b0c68e29483309f91c511ceb870bd