### PR TITLE
Clarify raw data ingestion instructions

### DIFF
--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -61,6 +61,6 @@ run reg_eval_and_report
 - If `gold/` exists, report includes **Gold Mini-Pack Evaluation**.
 
 ## 8. Move to Real CRR PDFs
-- Drop into `data/raw/`.
+ - Drop into `data/pdfs/`. Download scripts deposit PDFs in `data/raw` by default. The pipeline's default `input_dir` is `data/pdfs`.
 - Adjust `config.m` paths.
 - Rerun `reg_pipeline` + `reg_eval_and_report`.


### PR DESCRIPTION
## Summary
- clarify that download scripts store PDFs in `data/raw` by default
- note the pipeline expects `data/pdfs` as its `input_dir`

## Testing
- `matlab -batch "results = runtests('tests', 'IncludeSubfolders', true, 'UseParallel', false); disp(results)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b0c664a9483308b3a9ffa192fa5f2