### PR TITLE
docs: clarify automated PDF download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ test using SQLite (no external server required).
 ## Running
 1. Optionally tweak `pipeline.json` (pipeline settings) and `knobs.json` (training knobs).
 2. Put PDFs under `data/pdfs` (or use the provided dummy).
+
+   Automated download modules (e.g., `reg.fetch_crr_eurlex`) save PDFs to `data/raw`. Move the downloaded files into
+   `data/pdfs` or set `"input_dir": "data/raw"` in `pipeline.json` before running the pipeline.
+
 3. Open MATLAB in this folder and run:
    ```matlab
    results = runtests("tests","IncludeSubfolders",true,"UseParallel",false);


### PR DESCRIPTION
## Summary
- note that automated download helpers (like `reg.fetch_crr_eurlex`) save PDFs to `data/raw`
- explain how to either move downloaded PDFs to `data/pdfs` or adjust `pipeline.json` to point at `data/raw`

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b0c65a4e08330b8b16259083c5c3c