### PR TITLE
Clarify naming workflow and simplify TLDR

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -1,30 +1,29 @@
-# Naming Conventions & Registry (Quick Start)
+# Naming Conventions & Registry Workflow
 
-This repository enforces consistent naming through:
-1. A **single source of truth**: `naming_registry.md`
-2. Editor aids and grep-able breadcrumbs
-3. Naming convention is detailed in the MATLAB style guide
+This README is a process guide for maintaining naming consistency. The
+[Matlab Style Guide](Matlab_Style_Guide.md) is the normative reference for
+all naming rules.
+
 ## TL;DR
 
-| Category | Rule |
-|----------|------|
-| Variable names | lowerCamelCase, descriptive |
-| Constants | UPPER_CASE_WITH_UNDERSCORES |
-| Functions | lowerCamelCase; filename matches function |
-| Classes | UpperCamelCase |
-| Indentation | Two spaces, no tabs |
-| Line width | Limit lines to 80 characters |
-| Comments | `%` for line, `%%` for section |
-| Tests | Located in `tests/`; run with `runtests` |
+For specific naming rules, see the
+[Matlab Style Guide](Matlab_Style_Guide.md).
 
+## Workflow
+
+1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest
+   naming guidance.
+2. Record additions or changes in `identifier_registry.md`.
+3. Update the codebase accordingly.
+4. Run CI to ensure naming checks pass.
 
 ## CI
 
-A GitHub Action runs on every PR/push and fails the build if naming
+A GitHub Action runs on every PR or push and fails the build if naming
 violations are found.
 
 ## Updating Names
 
-1. Propose changes in `naming_registry.md` with a PR.
+1. Propose changes in `identifier_registry.md` with a PR.
 2. Update code and commit.
 3. CI validates.


### PR DESCRIPTION
## Summary
- clarify that README_NAMING is a process guide and point to Matlab Style Guide as the naming authority
- describe workflow for reviewing style guide, updating identifier_registry.md, and running CI
- replace TL;DR table with a link to the style guide

## Testing
- `octave -qf --eval "cd tests; runtests"` *(command not found)*
- `matlab -batch "cd('tests'); runtests"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b113e4ee08330abb81d906fb763a8