### PR TITLE
docs: broaden identifier language

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -1,7 +1,7 @@
-# Naming Conventions & Registry (Quick Start)
+# Naming Conventions & Identifier Registry (Quick Start)
 
 This repository enforces consistent naming through:
-1. A **single source of truth**: `naming_registry.md`
+1. A **single source of truth** for classes, functions, variables, constants, files/modules, and other identifiers: `identifier_registry.md`
 2. Editor aids and grep-able breadcrumbs
 3. Naming convention is detailed in the MATLAB style guide
 ## TL;DR
@@ -25,6 +25,6 @@ violations are found.
 
 ## Updating Names
 
-1. Propose changes in `naming_registry.md` with a PR.
+1. Propose changes in `identifier_registry.md` with a PR.
 2. Update code and commit.
 3. CI validates.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,6 +1,6 @@
-# Naming Registry
+# Identifier Registry
 
-This is the **single source of truth** for object, method, variable, and file names. Update it via PR and keep it in sync with code.
+This is the **single source of truth** for classes, functions, variables, constants, files/modules, and other identifiers. Update it via PR and keep it in sync with code.
 
 > Tip: In code, add grep-able breadcrumbs like `%% NAME-REGISTRY:CLASS InvoiceProcessor` (MATLAB) or `# NAME-REGISTRY:METHOD parseDocument` so you can jump from code → registry.
 


### PR DESCRIPTION
## Summary
- rename naming registry to identifier registry and expand introduction to cover classes, functions, variables, constants, files/modules, and other identifiers
- reference the new identifier registry in quick-start naming guide

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_b_689b113d3a648330a25ff7cb107f14df