### PR TITLE
docs: document function handle naming convention

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,0 +1,16 @@
+# Identifier Registry
+
+The central reference for identifier naming across the project.
+
+---
+
+## Conventions
+
+- **Classes/Objects:** `PascalCase` (e.g., `InvoiceProcessor`)
+- **Methods/Functions:** `camelCase` (e.g., `parseDocument`)
+- **Variables:** `snake_case` (e.g., `doc_index`)
+- **Constants/Enums:** `UPPER_SNAKE_CASE` (e.g., `MAX_RETRY_COUNT`)
+- **Files/Modules:** `lower_snake_case.ext` (e.g., `pdf_ingest.m`, `text_chunker.m`)
+- **Function Handles:** end with `Fn` or `Handle` (e.g., `costFn`, `updateHandle`)
+
+


### PR DESCRIPTION
## Summary
- add identifier registry with conventions, clarifying that function handles end with `Fn` or `Handle` and providing examples

## Testing
- `octave -qf run_smoke_test.m` *(command not found)*
- `matlab -batch run_smoke_test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b1139aea883308c248abcc29062b9