### PR TITLE
Document temporary variable naming limits

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,0 +1,9 @@
+# Identifier Registry
+
+Central source of truth for identifier naming guidelines used in this project.
+
+## Conventions
+
+### Temporary Variables
+Short names such as `tmp` or `idx` are permitted only for a few lines and must not escape the local scope.
+


### PR DESCRIPTION
## Summary
- add identifier registry doc
- note that short names like `tmp` or `idx` may only be used briefly and must remain local

## Testing
- `matlab -batch "results=runtests('tests','IncludeSubfolders',true,'UseParallel',false);"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_689b11385bd483308580e9b681ecb466