### PR TITLE
docs: broaden naming registry scope

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -1,7 +1,9 @@
 # Naming Conventions & Registry (Quick Start)
 
-This repository enforces consistent naming through:
-1. A **single source of truth**: `naming_registry.md`
+This repository enforces consistent naming across classes, functions,
+variables, constants, files/modules, tests, and other identifiers
+through:
+1. A **single source of truth** for all names: `naming_registry.md`
 2. Editor aids and grep-able breadcrumbs
 3. Naming convention is detailed in the MATLAB style guide
 ## TL;DR

--- a/docs/naming_registry.md
+++ b/docs/naming_registry.md
@@ -1,6 +1,8 @@
 # Naming Registry
 
-This is the **single source of truth** for object, method, variable, and file names. Update it via PR and keep it in sync with code.
+This is the **single source of truth** for class, function, variable,
+constant, file/module, test, and other identifier names. Update it via
+PR and keep it in sync with code.
 
 > Tip: In code, add grep-able breadcrumbs like `%% NAME-REGISTRY:CLASS InvoiceProcessor` (MATLAB) or `# NAME-REGISTRY:METHOD parseDocument` so you can jump from code → registry.
 


### PR DESCRIPTION
## Summary
- document that naming conventions cover classes, functions, variables, constants, files/modules, tests, and other identifiers
- update naming registry intro to match expanded scope

## Testing
- `matlab -batch "runtests"` (fails: command not found)
- `octave --eval "runtests"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_689b112e5ae4833080b8d73e4a780704