### PR TITLE
docs: expand naming conventions references

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -10,6 +10,30 @@ all naming rules.
 For specific perscribed rules, see the
 [Matlab Style Guide](Matlab_Style_Guide.md).
 
+## Data-Type Suffixes
+
+Use suffixes to denote common data structures. Refer to the [Data-Type Suffixes](Matlab_Style_Guide.md#11-data-type-suffixes) section of the style guide for full details.
+
+| Data Type | Suffix | Example |
+|-----------|--------|---------|
+| Vector | `Vec` | `positionVec` |
+| Matrix | `Mat` | `rotationMat` |
+| Cell array | `Cell` | `filePathsCell` |
+| Structure | `Struct` | `configStruct` |
+| Table | `Tbl` | `resultsTbl` |
+
+## Function Handles
+
+Suffix function handle variables with `Fn` or `Handle` to make their role explicit. See [Function Handles](Matlab_Style_Guide.md#14-function-handles) for more examples.
+
+## Temporary Variables
+
+Short-lived helpers such as `tmp` or `idx` should remain within a few lines of use. More guidance is available under [Temporary Variables](Matlab_Style_Guide.md#13-temporary-variables).
+
+## Tests
+
+Place tests in the `tests/` folder and name each file `testFunctionName.m`. Refer to [Testing](Matlab_Style_Guide.md#27-testing) for the complete testing conventions.
+
 ## Workflow
 
 1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest


### PR DESCRIPTION
## Summary
- add data-type suffix table
- document Fn/Handle naming for function handles
- clarify temporary variables and test file naming, linking to MATLAB style guide

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b198fcc2c8330bbf37c7d11efb4bf