### PR TITLE
Clarify naming workflow and identifier proposal

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -1,34 +1,31 @@
 # Naming Conventions & Registry Workflow
 
-This README is a process guide for maintaining naming consistency. The
-[Matlab Style Guide](Matlab_Style_Guide.md) is the normative reference for
-all naming rules.
-
-
-## TL;DR
-
-For specific perscribed rules, see the
-[Matlab Style Guide](Matlab_Style_Guide.md).
+This README documents the workflow for keeping names consistent across the
+project. All naming conventions live exclusively in the
+[Matlab Style Guide](Matlab_Style_Guide.md), which is the authoritative source
+for every rule.
 
 ## Workflow
 
-1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest
-   naming guidance.
-2. Before coding check the `identifier_registry.md` for any variables that may be influenced by your tas.
-4. Note identifiers currently in use, use these consistently in your code, if required.
-5. Update the codebase accordingly.
-6. when introducing new identifiers in your code, **always** crosscheck this name isnt in use and **always** update 
-   the `identifier_registry.md` with new identifiers through a PR with your new code.
-4. Run CI to ensure naming checks pass.
+1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest naming
+   guidance.
+2. Check `identifier_registry.md` for existing identifiers that may affect your
+   task.
+3. Use existing identifiers consistently in your code and update the codebase as
+   needed.
+4. When introducing new identifiers, update `identifier_registry.md` in the same
+   PR.
+5. Run CI to ensure naming checks pass.
 
 ## CI
 
 A GitHub Action runs on every PR or push and fails the build if naming
 violations are found.
 
-## Updating Names
+## How to propose a new identifier
 
-1. Propose new identifiers in `identifier_registry.md` with a PR. **always** ensure you are **not** causing drift by introducing 
-   new identifiers and not recording them, or by not using existing identifiers consistently
-2. Update code and commit, with any new identifiers and the updated `identifier_registry.md`  
-3. CI validates.
+- Review the [Matlab Style Guide](Matlab_Style_Guide.md) to confirm the name
+  follows project conventions.
+- Add the identifier to [`identifier_registry.md`](identifier_registry.md) in
+  the same PR as your code changes.
+- Run CI and ensure all naming checks pass.


### PR DESCRIPTION
## Summary
- Streamline naming workflow README to point exclusively to Matlab_Style_Guide.md for conventions
- Add concise instructions on proposing new identifiers via identifier_registry.md and CI

## Testing
- `matlab -batch "run('run_smoke_test.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b198aeab48330b2367a7a9e1a8575