### PR TITLE
docs: expand identifier registry scope

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -2,7 +2,9 @@
 
 This README is a process guide for maintaining naming consistency. The
 [Matlab Style Guide](Matlab_Style_Guide.md) is the normative reference for
-all naming rules.
+all naming rules. All approved classes, functions, variables, constants,
+files/modules, tests, and other identifiers are tracked in the
+`identifier_registry.md`.
 
 
 ## TL;DR
@@ -14,11 +16,15 @@ For specific perscribed rules, see the
 
 1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest
    naming guidance.
-2. Before coding check the `identifier_registry.md` for any variables that may be influenced by your tas.
+2. Before coding, check the `identifier_registry.md` for existing classes,
+   functions, variables, constants, files/modules, tests, and other
+   identifiers that may be affected by your task.
 4. Note identifiers currently in use, use these consistently in your code, if required.
 5. Update the codebase accordingly.
-6. when introducing new identifiers in your code, **always** crosscheck this name isnt in use and **always** update 
-   the `identifier_registry.md` with new identifiers through a PR with your new code.
+6. when introducing new identifiers in your code, **always** crosscheck this
+   name isnt in use and **always** update the `identifier_registry.md` with
+   new classes, functions, variables, constants, files/modules, tests, and
+   other identifiers through a PR with your new code.
 4. Run CI to ensure naming checks pass.
 
 ## CI
@@ -28,7 +34,6 @@ violations are found.
 
 ## Updating Names
 
-1. Propose new identifiers in `identifier_registry.md` with a PR. **always** ensure you are **not** causing drift by introducing 
-   new identifiers and not recording them, or by not using existing identifiers consistently
+1. Propose new classes, functions, variables, constants, files/modules, tests, or other identifiers in `identifier_registry.md` with a PR. **always** ensure you are **not** causing drift by introducing new identifiers and not recording them, or by not using existing identifiers consistently
 2. Update code and commit, with any new identifiers and the updated `identifier_registry.md`  
 3. CI validates.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,6 +1,8 @@
 # Identifier Registry
 
-This is the **single source of truth** for object, method, variable, and file names. Update it via PR and keep it in sync with code.
+This is the **single source of truth** for class, function, variable,
+constant, file/module, test, and other identifier names. Update it via PR
+and keep it in sync with code.
 
 > Tip: In code, add grep-able breadcrumbs like `%% NAME-REGISTRY:CLASS InvoiceProcessor` (MATLAB) or `# NAME-REGISTRY:METHOD parseDocument` so you can jump from code → registry.
 


### PR DESCRIPTION
## Summary
- describe the identifier registry as tracking approved classes, functions, variables, constants, files/modules, tests, and other identifiers
- ensure README_NAMING points to this broader registry and uses inclusive wording throughout

## Testing
- `octave --version` *(command not found)*
- `apt-get update` *(403 Forbidden: repository not signed)*
- `octave -qf run_smoke_test.m` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b1988f2bc83308f74c828d2cbc570