### PR TITLE
doc: expand identifier registry scope

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,19 +1,21 @@
 # Identifier Registry
 
-This is the **single source of truth** for object, method, variable, and file names. Update it via PR and keep it in sync with code.
+This is the **single source of truth** for classes, functions, variables, constants, files/modules, tests, and other identifiers.
+Update it via PR and keep it in sync with code.
 
-> Tip: In code, add grep-able breadcrumbs like `%% NAME-REGISTRY:CLASS InvoiceProcessor` (MATLAB) or `# NAME-REGISTRY:METHOD parseDocument` so you can jump from code → registry.
+> Tip: In code, add grep-able breadcrumbs like `%% NAME-REGISTRY:CLASS InvoiceProcessor` (MATLAB), `# NAME-REGISTRY:FUNCTION parseDocument`, or `# NAME-REGISTRY:TEST testParseDocument` so you can jump from code → registry.
 
 ---
 
 ## Conventions (Authoritative)
 
-- **Classes/Objects:** `PascalCase` (e.g., `InvoiceProcessor`)
-- **Methods/Functions:** `camelCase` (e.g., `parseDocument`)
+- **Classes:** `PascalCase` (e.g., `InvoiceProcessor`)
+- **Functions:** `camelCase` (e.g., `parseDocument`)
 - **Class properties:** `lowerCamelCase` (e.g., `learningRate`)
 - **Variables:** `snake_case` (e.g., `doc_index`)
 - **Constants/Enums:** `UPPER_SNAKE_CASE` (e.g., `MAX_RETRY_COUNT`)
 - **Files/Modules:** `lower_snake_case.ext` (e.g., `pdf_ingest.m`, `text_chunker.m`)
+- **Tests:** `testFunctionName.m` (e.g., `test_parse_document.m`)
 - **Temporary Variables** Short names such as `tmp` or `idx` are permitted only for a few lines and must not escape the local scope.
 
 Scopes:
@@ -21,13 +23,13 @@ Scopes:
 
 ---
 
-## Objects / Classes
+## Classes
 
 | Name | Purpose | Scope | Owner | Related Files | Notes |
 |------|---------|-------|-------|---------------|-------|
 |  |  |  |  |  |  |
 
-## Methods / Functions
+## Functions
 
 | Name | Purpose | Scope | Input Contract | Output Contract | Owner | Notes |
 |------|---------|-------|----------------|-----------------|-------|------|


### PR DESCRIPTION
## Summary
- broaden identifier registry intro to cover classes, functions, constants, files/modules, tests, and more
- add test breadcrumbs and naming conventions
- rename class/function sections for clarity

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b198c30f8833095b67669bb6cf20c