### PR TITLE
docs: link naming workflow in style guide

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -2,6 +2,11 @@
 
 A beginner-friendly reference for writing clear, consistent MATLAB code.
 
+See the [naming process guide](README_NAMING.md) for how to propose
+and register identifiers. The canonical source of truth is the
+[identifier registry](identifier_registry.md). Naming rules defined
+here must be registered in the registry via that process.
+
 ---
 
 ## 1. Variable Naming Conventions


### PR DESCRIPTION
## Summary
- reference naming process guide and identifier registry in MATLAB style guide
- note that naming rules in the style guide must be registered through the process

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b20e338d483308a5a8f6c9d77e6d3