### PR TITLE
Add scaffolding for regulatory classifier modules and tests

### DIFF
--- a/+reg/chunkText.m
+++ b/+reg/chunkText.m
@@ -1,0 +1,18 @@
+function chunkTbl = chunkText(docTbl, chunkSizeTokens, chunkOverlap)
+%CHUNKTEXT Split documents into overlapping token chunks.
+%
+% Inputs
+%   docTbl - table of documents
+%   chunkSizeTokens - maximum tokens per chunk
+%   chunkOverlap - number of overlapping tokens between chunks
+%
+% Outputs
+%   chunkTbl - table of chunks
+%
+%% NAME-REGISTRY:FUNCTION chunkText
+
+% Placeholder implementation
+% TODO: implement text chunking
+
+chunkTbl = table();
+end

--- a/+reg/crrDiffArticles.m
+++ b/+reg/crrDiffArticles.m
@@ -1,0 +1,18 @@
+function diffStruct = crrDiffArticles(articleId, versionA, versionB)
+%CRRDIFFARTICLES Compute article-level differences across versions.
+%
+% Inputs
+%   articleId - identifier of the article
+%   versionA - first version identifier
+%   versionB - second version identifier
+%
+% Outputs
+%   diffStruct - structure summarizing article differences
+%
+%% NAME-REGISTRY:FUNCTION crrDiffArticles
+
+% Placeholder implementation
+% TODO: implement article diffing
+
+diffStruct = struct();
+end

--- a/+reg/crrDiffVersions.m
+++ b/+reg/crrDiffVersions.m
@@ -1,0 +1,17 @@
+function diffStruct = crrDiffVersions(oldPathStr, newPathStr)
+%CRRDIFFVERSIONS Compute differences between CRR versions.
+%
+% Inputs
+%   oldPathStr - path to old CRR version
+%   newPathStr - path to new CRR version
+%
+% Outputs
+%   diffStruct - structure summarizing differences
+%
+%% NAME-REGISTRY:FUNCTION crrDiffVersions
+
+% Placeholder implementation
+% TODO: implement CRR version diffing
+
+diffStruct = struct();
+end

--- a/+reg/docEmbeddingsBertGpu.m
+++ b/+reg/docEmbeddingsBertGpu.m
@@ -1,0 +1,16 @@
+function xMat = docEmbeddingsBertGpu(chunkTbl)
+%DOCEMBEDDINGSBERTGPU Embed chunks using BERT on GPU.
+%
+% Inputs
+%   chunkTbl - table of chunks
+%
+% Outputs
+%   xMat - matrix of embeddings
+%
+%% NAME-REGISTRY:FUNCTION docEmbeddingsBertGpu
+
+% Placeholder implementation
+% TODO: implement BERT GPU embeddings
+
+xMat = [];
+end

--- a/+reg/evalPerLabel.m
+++ b/+reg/evalPerLabel.m
@@ -1,0 +1,17 @@
+function perLabelTbl = evalPerLabel(predYMat, trueYMat)
+%EVALPERLABEL Compute per-label evaluation metrics.
+%
+% Inputs
+%   predYMat - predicted label matrix
+%   trueYMat - ground truth label matrix
+%
+% Outputs
+%   perLabelTbl - table with metrics for each label
+%
+%% NAME-REGISTRY:FUNCTION evalPerLabel
+
+% Placeholder implementation
+% TODO: implement per-label evaluation
+
+perLabelTbl = table();
+end

--- a/+reg/evalRetrieval.m
+++ b/+reg/evalRetrieval.m
@@ -1,0 +1,17 @@
+function metricsStruct = evalRetrieval(resultsTbl, goldTbl)
+%EVALRETRIEVAL Evaluate retrieval metrics against gold data.
+%
+% Inputs
+%   resultsTbl - table of search results
+%   goldTbl - table of gold annotations
+%
+% Outputs
+%   metricsStruct - structure with retrieval metrics
+%
+%% NAME-REGISTRY:FUNCTION evalRetrieval
+
+% Placeholder implementation
+% TODO: implement retrieval evaluation
+
+metricsStruct = struct();
+end

--- a/+reg/ftBuildContrastiveDataset.m
+++ b/+reg/ftBuildContrastiveDataset.m
@@ -1,0 +1,17 @@
+function dsStruct = ftBuildContrastiveDataset(chunkTbl, yMat)
+%FTBUILDCONTRASTIVEDATASET Build dataset for encoder fine-tuning.
+%
+% Inputs
+%   chunkTbl - table of chunks
+%   yMat - label matrix
+%
+% Outputs
+%   dsStruct - structure with contrastive pairs
+%
+%% NAME-REGISTRY:FUNCTION ftBuildContrastiveDataset
+
+% Placeholder implementation
+% TODO: implement contrastive dataset construction
+
+dsStruct = struct();
+end

--- a/+reg/ftTrainEncoder.m
+++ b/+reg/ftTrainEncoder.m
@@ -1,0 +1,16 @@
+function encoderStruct = ftTrainEncoder(dsStruct)
+%FTTRAINENCODER Fine-tune encoder using contrastive dataset.
+%
+% Inputs
+%   dsStruct - structure with contrastive pairs
+%
+% Outputs
+%   encoderStruct - fine-tuned encoder parameters
+%
+%% NAME-REGISTRY:FUNCTION ftTrainEncoder
+
+% Placeholder implementation
+% TODO: implement encoder fine-tuning
+
+encoderStruct = struct();
+end

--- a/+reg/hybridSearch.m
+++ b/+reg/hybridSearch.m
@@ -1,0 +1,18 @@
+function resultsTbl = hybridSearch(queryStr, xMat, docTbl)
+%HYBRIDSEARCH Retrieve documents using hybrid search.
+%
+% Inputs
+%   queryStr - search query string
+%   xMat - embedding matrix
+%   docTbl - table of documents
+%
+% Outputs
+%   resultsTbl - table of search results
+%
+%% NAME-REGISTRY:FUNCTION hybridSearch
+
+% Placeholder implementation
+% TODO: implement hybrid search
+
+resultsTbl = table();
+end

--- a/+reg/ingestPdfs.m
+++ b/+reg/ingestPdfs.m
@@ -1,0 +1,16 @@
+function docTbl = ingestPdfs(pdfPathsCell)
+%INGESTPDFS Convert PDF files to text documents.
+%
+% Inputs
+%   pdfPathsCell - cell array of PDF file paths
+%
+% Outputs
+%   docTbl - table with document IDs and text
+%
+%% NAME-REGISTRY:FUNCTION ingestPdfs
+
+% Placeholder implementation
+% TODO: implement PDF ingestion
+
+docTbl = table();
+end

--- a/+reg/loadGold.m
+++ b/+reg/loadGold.m
@@ -1,0 +1,16 @@
+function goldTbl = loadGold(pathStr)
+%LOADGOLD Load gold annotation data from disk.
+%
+% Inputs
+%   pathStr - file path to gold data
+%
+% Outputs
+%   goldTbl - table of gold annotations
+%
+%% NAME-REGISTRY:FUNCTION loadGold
+
+% Placeholder implementation
+% TODO: implement gold data loading
+
+goldTbl = table();
+end

--- a/+reg/precomputeEmbeddings.m
+++ b/+reg/precomputeEmbeddings.m
@@ -1,0 +1,16 @@
+function xMat = precomputeEmbeddings(chunkTbl)
+%PRECOMPUTEEMBEDDINGS Precompute embeddings for text chunks.
+%
+% Inputs
+%   chunkTbl - table of chunks
+%
+% Outputs
+%   xMat - matrix of embeddings
+%
+%% NAME-REGISTRY:FUNCTION precomputeEmbeddings
+
+% Placeholder implementation
+% TODO: implement embedding precomputation
+
+xMat = [];
+end

--- a/+reg/trainMultilabel.m
+++ b/+reg/trainMultilabel.m
@@ -1,0 +1,17 @@
+function modelStruct = trainMultilabel(xMat, yMat)
+%TRAINMULTILABEL Train a multi-label classifier.
+%
+% Inputs
+%   xMat - feature matrix
+%   yMat - label matrix
+%
+% Outputs
+%   modelStruct - trained model structure
+%
+%% NAME-REGISTRY:FUNCTION trainMultilabel
+
+% Placeholder implementation
+% TODO: implement multi-label training
+
+modelStruct = struct();
+end

--- a/+reg/trainProjectionHead.m
+++ b/+reg/trainProjectionHead.m
@@ -1,0 +1,17 @@
+function headStruct = trainProjectionHead(xMat, yMat)
+%TRAINPROJECTIONHEAD Train a projection head on embeddings.
+%
+% Inputs
+%   xMat - feature matrix
+%   yMat - label matrix
+%
+% Outputs
+%   headStruct - trained projection head parameters
+%
+%% NAME-REGISTRY:FUNCTION trainProjectionHead
+
+% Placeholder implementation
+% TODO: implement projection head training
+
+headStruct = struct();
+end

--- a/+reg/weakRules.m
+++ b/+reg/weakRules.m
@@ -1,0 +1,16 @@
+function yBootMat = weakRules(chunkTbl)
+%WEAKRULES Generate weak labels for text chunks.
+%
+% Inputs
+%   chunkTbl - table of chunks
+%
+% Outputs
+%   yBootMat - sparse label matrix
+%
+%% NAME-REGISTRY:FUNCTION weakRules
+
+% Placeholder implementation
+% TODO: implement weak labeling rules
+
+yBootMat = sparse([]);
+end

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -54,8 +54,22 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Name | Purpose | Scope | Input Contract | Output Contract | Owner | Notes |
 |------|---------|-------|----------------|-----------------|-------|------|
 | parseDocument | Convert raw text into tokens | module | `text` string | token array | @janedoe | example |
-|  |  |  |  |  |  |
-
+| ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
+| chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
+| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
+| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
+| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
+| trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
+| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
+| trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
+| ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
+| evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
+| evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
+| loadGold | Load gold annotation data | module | `pathStr` string | `goldTbl` table | @todo | stub |
+| crrDiffVersions | Compare CRR versions | module | `oldPathStr` string, `newPathStr` string | diff struct | @todo | stub |
+| crrDiffArticles | Compare CRR articles | module | `articleId` string, `versionA` string, `versionB` string | diff struct | @todo | stub |
+
 ## Variables
 
 | Name | Purpose | Scope | Type | Default | Constraints | Notes |
@@ -75,7 +89,21 @@ Keep the illustrative examples below in sync with the current naming conventions
 | File | Purpose | Public API | Owner | Notes |
 |------|---------|-----------|-------|------|
 | pdfIngest.m | Read PDFs into text | pdfIngest | @janedoe | example |
-
+| ingestPdfs.m | Convert PDFs into text documents | ingestPdfs | @todo | stub |
+| chunkText.m | Split documents into token chunks | chunkText | @todo | stub |
+| weakRules.m | Generate weak labels for chunks | weakRules | @todo | stub |
+| docEmbeddingsBertGpu.m | Embed chunks using BERT on GPU | docEmbeddingsBertGpu | @todo | stub |
+| precomputeEmbeddings.m | Precompute embeddings for chunks | precomputeEmbeddings | @todo | stub |
+| trainMultilabel.m | Train multi-label classifier | trainMultilabel | @todo | stub |
+| hybridSearch.m | Retrieve documents with hybrid search | hybridSearch | @todo | stub |
+| trainProjectionHead.m | Train projection head on embeddings | trainProjectionHead | @todo | stub |
+| ftBuildContrastiveDataset.m | Build dataset for encoder fine-tuning | ftBuildContrastiveDataset | @todo | stub |
+| ftTrainEncoder.m | Fine-tune encoder on contrastive dataset | ftTrainEncoder | @todo | stub |
+| evalRetrieval.m | Evaluate retrieval metrics | evalRetrieval | @todo | stub |
+| evalPerLabel.m | Compute per-label metrics | evalPerLabel | @todo | stub |
+| loadGold.m | Load gold annotation data | loadGold | @todo | stub |
+| crrDiffVersions.m | Compare CRR versions | crrDiffVersions | @todo | stub |
+| crrDiffArticles.m | Compare CRR articles | crrDiffArticles | @todo | stub |
 
 
 
@@ -89,6 +117,22 @@ Common test scopes or prefixes include:
 - `TestIntegration` for integration scenarios
 - `TestSmoke` for smoke tests
 
+| Name | Purpose | Related Functions | Notes |
+|------|---------|-------------------|-------|
+| TestPDFIngest | Stub test for ingestPdfs | ingestPdfs | stub |
+| TestIngestAndChunk | Stub test for ingestion and chunking | ingestPdfs, chunkText | stub |
+| TestRulesAndModel | Stub test for weak rules and model | weakRules, trainMultilabel | stub |
+| TestFeatures | Stub test for embedding generation | docEmbeddingsBertGpu, precomputeEmbeddings | stub |
+| TestRegressionMetricsSimulated | Stub test for regression metrics | trainMultilabel, evalPerLabel | stub |
+| TestHybridSearch | Stub test for hybrid search | hybridSearch | stub |
+| TestProjectionHeadSimulated | Stub test for projection head training | trainProjectionHead | stub |
+| TestProjectionAutoloadPipeline | Stub test for projection head autoload | trainProjectionHead | stub |
+| TestFineTuneSmoke | Stub test for encoder fine-tuning smoke | ftBuildContrastiveDataset, ftTrainEncoder | stub |
+| TestFineTuneResume | Stub test for fine-tune resume | ftTrainEncoder | stub |
+| TestMetricsExpectedJSON | Stub test for metrics JSON | evalRetrieval | stub |
+| TestGoldMetrics | Stub test for gold metrics | loadGold, evalPerLabel | stub |
+| TestReportArtifact | Stub test for report generation | evalRetrieval | stub |
+| TestFetchers | Stub test for fetch utilities | crrDiffVersions, crrDiffArticles | stub |
 
 ---
 
@@ -103,4 +147,5 @@ Common test scopes or prefixes include:
 ## Changelog
 
 - YYYY-MM-DD: Initial registry created.
+- 2025-08-12: Stub modules and tests added.
 

--- a/tests/TestFeatures.m
+++ b/tests/TestFeatures.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestFeatures
+function tests = TestFeatures
+%TESTFEATURES Placeholder tests for embedding generation.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.docEmbeddingsBertGpu(table());
+    reg.precomputeEmbeddings(table());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestFetchers.m
+++ b/tests/TestFetchers.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestFetchers
+function tests = TestFetchers
+%TESTFETCHERS Placeholder tests for data fetch utilities.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.crrDiffVersions('', '');
+    reg.crrDiffArticles('', '', '');
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestFineTuneResume.m
+++ b/tests/TestFineTuneResume.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestFineTuneResume
+function tests = TestFineTuneResume
+%TESTFINETUNERESUME Placeholder tests for encoder fine-tuning resume.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.ftTrainEncoder(struct());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestFineTuneSmoke.m
+++ b/tests/TestFineTuneSmoke.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestFineTuneSmoke
+function tests = TestFineTuneSmoke
+%TESTFINETUNESMOKE Placeholder tests for encoder fine-tuning smoke test.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.ftBuildContrastiveDataset(table(), []);
+    reg.ftTrainEncoder(struct());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestGoldMetrics.m
+++ b/tests/TestGoldMetrics.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestGoldMetrics
+function tests = TestGoldMetrics
+%TESTGOLDMETRICS Placeholder tests for gold data metrics.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.loadGold('');
+    reg.evalPerLabel([], []);
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestHybridSearch
+function tests = TestHybridSearch
+%TESTHYBRIDSEARCH Placeholder tests for hybrid search module.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.hybridSearch('', [], table());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestIngestAndChunk.m
+++ b/tests/TestIngestAndChunk.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestIngestAndChunk
+function tests = TestIngestAndChunk
+%TESTINGESTANDCHUNK Placeholder tests for ingest and chunk modules.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.ingestPdfs({});
+    reg.chunkText(table(), 0, 0);
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestMetricsExpectedJSON.m
+++ b/tests/TestMetricsExpectedJSON.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestMetricsExpectedJSON
+function tests = TestMetricsExpectedJSON
+%TESTMETRICSEXPECTEDJSON Placeholder tests for metrics JSON comparison.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.evalRetrieval(table(), table());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestPDFIngest.m
+++ b/tests/TestPDFIngest.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestPDFIngest
+function tests = TestPDFIngest
+%TESTPDFINGEST Placeholder tests for PDF ingestion module.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.ingestPdfs({});
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestProjectionAutoloadPipeline.m
+++ b/tests/TestProjectionAutoloadPipeline.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestProjectionAutoloadPipeline
+function tests = TestProjectionAutoloadPipeline
+%TESTPROJECTIONAUTOLOADPIPELINE Placeholder tests for projection head autoloading.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.trainProjectionHead([], []);
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestProjectionHeadSimulated.m
+++ b/tests/TestProjectionHeadSimulated.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestProjectionHeadSimulated
+function tests = TestProjectionHeadSimulated
+%TESTPROJECTIONHEADSIMULATED Placeholder tests for projection head training.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.trainProjectionHead([], []);
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestRegressionMetricsSimulated.m
+++ b/tests/TestRegressionMetricsSimulated.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestRegressionMetricsSimulated
+function tests = TestRegressionMetricsSimulated
+%TESTREGRESSIONMETRICSSIMULATED Placeholder tests for regression metrics.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.trainMultilabel([], []);
+    reg.evalPerLabel([], []);
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestReportArtifact.m
+++ b/tests/TestReportArtifact.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST TestReportArtifact
+function tests = TestReportArtifact
+%TESTREPORTARTIFACT Placeholder tests for report generation.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.evalRetrieval(table(), table());
+    assert(false, 'Not implemented yet');
+end

--- a/tests/TestRulesAndModel.m
+++ b/tests/TestRulesAndModel.m
@@ -1,0 +1,15 @@
+%% NAME-REGISTRY:TEST TestRulesAndModel
+function tests = TestRulesAndModel
+%TESTRULESANDMODEL Placeholder tests for weak rules and model training.
+%
+% Outputs
+%   tests - handle to local tests
+
+tests = functiontests(localfunctions);
+end
+
+function testPlaceholder(~)
+    reg.weakRules(table());
+    reg.trainMultilabel([], []);
+    assert(false, 'Not implemented yet');
+end


### PR DESCRIPTION
## Summary
- scaffold +reg package with placeholder functions for ingestion, chunking, labeling, embeddings, classification, retrieval, projection head, fine-tuning, evaluation, and diff utilities
- add failing stub tests covering each planned module
- register all new function and test identifiers

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b4e6da2748330979a3e6af590540e