### PR TITLE
docs: document module interfaces and data contracts

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -96,7 +96,14 @@ Common test scopes or prefixes include:
 
 | Producer → Consumer | Payload Schema | Format | Validation | Notes |
 |--------------------|----------------|--------|-----------|-------|
-| ingest → preprocess | `{ docId: string, pages: string[], meta: {...} }` | JSON | schema v1 | draft |
+| ingest → chunking | `docs` table `{ docId: string, text: string }` | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
+| chunking → weak labeling / embeddings | `chunks` table `{ chunkId: string, docId: string, text: string }` | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
+| weak labeling → classifier | `Yboot` sparse logical matrix `[numChunks x numClasses]` | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
+| embedding generation → classifier | `X` double matrix `[numChunks x embeddingDim]` | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
+| classifier → retrieval / eval | `model` struct `{ weights: double[embeddingDim x numClasses], bias: double[1 x numClasses] }` | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| projection head training → retrieval | `head` struct `{ weights: double[?], bias: double[?] }` | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
+| fine-tune → evaluation | `ftEncoder` struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
+| evaluation → reports | metrics table `{ metric: string, value: double }` | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
 
 ---
 

--- a/docs/step01_environment_tooling.md
+++ b/docs/step01_environment_tooling.md
@@ -24,6 +24,11 @@
    ver
    ```
 
+## Function Interface
+- `gpuDevice()` reports the active GPU and its properties.  
+- `ver` returns a table of installed MATLAB products.  
+- Subsequent modules rely on this environment. See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for data artifacts produced later in the pipeline.
+
 ## Verification
 - `gpuDevice` reports a supported GPU and its memory.
 - `ver` lists all required toolboxes and the BERT add-on.

--- a/docs/step02_repository_setup.md
+++ b/docs/step02_repository_setup.md
@@ -20,6 +20,11 @@
    config
    ```
 
+## Function Interface
+- `addpath(genpath(pwd)); savepath` adds all subfolders to the MATLAB path.  
+- `config()` reads `pipeline.json`, `knobs.json`, and optional overrides, returning a struct printed to the console.  
+- Data structures referenced in later modules are detailed in [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts).
+
 ## Verification
 - `config` prints the contents of the JSON files without errors.
 - MATLAB can locate project functions such as `reg_pipeline`.

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -17,8 +17,14 @@
    save('data/docs.mat','docs')
    ```
 
+## Function Interface
+- `reg.ingest_pdfs(inputDir)`  
+  - `inputDir` (string): folder containing source PDFs.  
+  - returns `docs` (`table`): columns `docId` (string), `text` (string).  
+  - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
+
 ## Verification
-- `docs` is a table with columns such as `doc_id` and `text`.
+- `docs` is a table with columns such as `docId` and `text`.
 - Run the unit test for ingestion:
   ```matlab
   runtests('tests/TestPDFIngest.m')

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -18,8 +18,16 @@
    save('data/chunks.mat','chunks')
    ```
 
+## Function Interface
+- `reg.chunk_text(docs, 'chunk_size_tokens', n, 'chunk_overlap', m)`  
+  - `docs` (table): from Step 3 with `docId` and `text` fields.  
+  - `n` (double): tokens per chunk.  
+  - `m` (double): overlap between chunks.  
+  - returns `chunks` (`table`): columns `chunkId` (string), `docId` (string), `text` (string).  
+  - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
+
 ## Verification
-- `chunks` contains `chunk_id`, `doc_id`, and `text` for each segment.
+- `chunks` contains `chunkId`, `docId`, and `text` for each segment.
 - Run the chunking test:
   ```matlab
   runtests('tests/TestIngestAndChunk.m')

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -19,6 +19,14 @@
    save('data/Yboot.mat','Yboot')
    ```
 
+## Function Interface
+- `reg.weak_rules(text, labels)`  
+  - `text` (string array): chunk content.  
+  - `labels` (string array): list of topic names.  
+  - returns `Yweak` (double sparse matrix) with confidence scores.
+- `Yboot = Yweak >= threshold` yields a sparse logical matrix used in later steps.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `Yboot`.
+
 > **Note:** `reg.weak_rules` requires `chunks.text` and the label list `C.labels`
 > from [`config.m`](../config.m). The confidence cutoff `C.min_rule_conf` is
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -19,6 +19,13 @@
    reg.precompute_embeddings(X,'data/embeddings.mat');
    ```
 
+## Function Interface
+- `reg.doc_embeddings_bert_gpu(chunks)`  
+  - `chunks` (table): as defined in Step 4.  
+  - returns `X` (double matrix): size `[numChunks x 768]` by default.  
+- `reg.precompute_embeddings(X, outPath)` caches the matrix to disk.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `X`.
+
 ## Verification
 - `X` has one row per chunk and 768 columns (BERT base dimension).
 - Run the features test:

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -20,6 +20,17 @@
    results = reg.hybrid_search(model, X, 'query', 'sample text');
    ```
 
+## Function Interface
+- `reg.train_multilabel(X, Yboot)`  
+  - `X` (double matrix): embeddings from Step 6.  
+  - `Yboot` (sparse logical matrix): weak labels from Step 5.  
+  - returns `model` (struct): fields `weights`, `bias`.  
+- `reg.hybrid_search(model, X, 'query', text)`  
+  - `model` (struct) and `X` (double matrix).  
+  - `'query'` (string): search text.  
+  - returns `results` (table) with `docId` and score fields.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, and model outputs.
+
 ## Verification
 - Classifier training completes and saves `baseline_model.mat`.
 - Run baseline tests:

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -13,6 +13,13 @@
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
 
+## Function Interface
+- `reg.train_projection_head(X, Yboot)`  
+  - `X` (double matrix): embeddings from Step 6.  
+  - `Yboot` (sparse logical matrix): weak labels from Step 5.  
+  - returns `head` (struct): fields `weights`, `bias` used for retrieval enhancement.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references.
+
 ## Verification
 - `projection_head.mat` exists in the `models` folder.
 - Run projection head tests:

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -16,6 +16,17 @@
    ```
 3. Update pipeline settings to point to the fine-tuned encoder if needed.
 
+## Function Interface
+- `reg.ft_build_contrastive_dataset(chunks, Yboot)`  
+  - `chunks` (table): see Step 4.  
+  - `Yboot` (sparse logical matrix): weak labels.  
+  - returns `ds` (dataset) for contrastive pairs.  
+- `reg.ft_train_encoder(ds, 'unfreeze_top', n)`  
+  - `ds` (dataset): training data.  
+  - `'unfreeze_top'` (double): number of BERT layers to unfreeze.  
+  - returns `ftEncoder` (struct) with updated weights.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact schema.
+
 ## Verification
 - `fine_tuned_bert.mat` is saved and contains updated weights.
 - Run fine-tuning tests:

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -15,6 +15,14 @@
    ```
 3. Inspect generated artifacts in the `reports` or `output` folder.
 
+## Function Interface
+- `reg_eval_and_report()`  
+  - consumes model artifacts and test queries.  
+  - outputs metrics tables and `reg_eval_report.pdf`.  
+- `reg_eval_gold()`  
+  - optionally evaluates against curated gold annotations.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
+
 ## Verification
 - Report files such as `reg_eval_report.pdf` and metric CSVs are created.
 - Run evaluation tests:

--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -16,6 +16,14 @@
    ```
 3. Review HTML or PDF diff outputs for changes.
 
+## Function Interface
+- `reg_crr_sync()` downloads the latest corpus to `data/raw`.  
+- `reg.crr_diff_versions(vA, vB)`  
+  - `vA`, `vB` (string): version identifiers.  
+  - returns a structure describing added, removed, and changed documents.  
+- `reg_crr_diff_report` renders HTML/PDF summaries.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for corpus schema references.
+
 ## Verification
 - Date-stamped corpora appear in the `data` directory.
 - Run fetcher tests:

--- a/docs/step12_continuous_testing.md
+++ b/docs/step12_continuous_testing.md
@@ -13,6 +13,12 @@
 2. Investigate any failures before committing changes.
 3. Optional: configure continuous integration (e.g., GitHub Actions) to run the same command on each push.
 
+## Function Interface
+- `runtests('tests','IncludeSubfolders',true,'UseParallel',false)`  
+  - Executes all MATLAB tests in the project.  
+  - returns `results` (table) with fields `Name`, `Passed`, `Failed`, `Incomplete`, `Duration`.  
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for any test-related artifacts.
+
 ## Verification
 - All tests pass locally, producing a table with `Passed` outcomes.
 - CI reports clean builds.


### PR DESCRIPTION
## Summary
- add interface summaries to each build-step guide so readers know function inputs and outputs
- expand identifier registry with schemas for docs, chunks, labels, embeddings, models, and reports
- cross-link step guides to the identifier registry for synchronized definitions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b4e6d77ac8330b5b58398859abdcf