### PR TITLE
Expand identifier registry and align docs

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -46,14 +46,14 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 | Name | Purpose | Scope | Owner | Related Files | Notes |
 |------|---------|-------|-------|---------------|-------|
-| InvoiceProcessor | Extracts data from invoices | module | @janedoe | pdfIngest.m | example |
-|  |  |  |  |  |  |
+| RegPipeline | Orchestrates end-to-end workflow | global | @todo | reg_pipeline.m | planned |
 
 ## Functions
 
 | Name | Purpose | Scope | Input Contract | Output Contract | Owner | Notes |
 |------|---------|-------|----------------|-----------------|-------|------|
 | parseDocument | Convert raw text into tokens | module | `text` string | token array | @janedoe | example |
+| config | Load project configuration files | module | – | struct `C` | @todo | stub |
 | ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
 | chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
 | weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
@@ -69,6 +69,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | loadGold | Load gold annotation data | module | `pathStr` string | `goldTbl` table | @todo | stub |
 | crrDiffVersions | Compare CRR versions | module | `oldPathStr` string, `newPathStr` string | diff struct | @todo | stub |
 | crrDiffArticles | Compare CRR articles | module | `articleId` string, `versionA` string, `versionB` string | diff struct | @todo | stub |
+| crrSync | Fetch latest regulatory corpus | module | – | downloaded files | @todo | stub |
+| crrDiffReport | Render diff report between versions | module | `diffStruct` struct | report files | @todo | stub |
 
 ## Variables
 
@@ -79,10 +81,13 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 ## Constants / Enums
 
-| Name | Purpose | Scope | Value/Type | Notes |
-|------|---------|-------|-----------|-------|
-| MAX_RETRY_COUNT | Limits retry attempts | global | 3 | example |
-|  |  |  |  |  |
+| Name | Purpose | Scope | Value/Type | Owner | Notes |
+|------|---------|-------|-----------|-------|------|
+| MAX_RETRY_COUNT | Limits retry attempts | global | 3 | @janedoe | example |
+| CHUNK_SIZE_TOKENS | Default tokens per chunk | module | 300 | @todo | from `config.m` |
+| CHUNK_OVERLAP | Overlap between chunks | module | 80 | @todo | from `config.m` |
+| MIN_RULE_CONF | Weak label confidence cutoff | global | 0.0 | @todo | from `config.m` |
+| EMBEDDING_DIM | Dimensionality of BERT embeddings | global | 768 | @todo | BERT base |
 
 ## Files / Modules
 
@@ -117,37 +122,70 @@ Common test scopes or prefixes include:
 - `TestIntegration` for integration scenarios
 - `TestSmoke` for smoke tests
 
-| Name | Purpose | Related Functions | Notes |
-|------|---------|-------------------|-------|
-| TestPDFIngest | Stub test for ingestPdfs | ingestPdfs | stub |
-| TestIngestAndChunk | Stub test for ingestion and chunking | ingestPdfs, chunkText | stub |
-| TestRulesAndModel | Stub test for weak rules and model | weakRules, trainMultilabel | stub |
-| TestFeatures | Stub test for embedding generation | docEmbeddingsBertGpu, precomputeEmbeddings | stub |
-| TestRegressionMetricsSimulated | Stub test for regression metrics | trainMultilabel, evalPerLabel | stub |
-| TestHybridSearch | Stub test for hybrid search | hybridSearch | stub |
-| TestProjectionHeadSimulated | Stub test for projection head training | trainProjectionHead | stub |
-| TestProjectionAutoloadPipeline | Stub test for projection head autoload | trainProjectionHead | stub |
-| TestFineTuneSmoke | Stub test for encoder fine-tuning smoke | ftBuildContrastiveDataset, ftTrainEncoder | stub |
-| TestFineTuneResume | Stub test for fine-tune resume | ftTrainEncoder | stub |
-| TestMetricsExpectedJSON | Stub test for metrics JSON | evalRetrieval | stub |
-| TestGoldMetrics | Stub test for gold metrics | loadGold, evalPerLabel | stub |
-| TestReportArtifact | Stub test for report generation | evalRetrieval | stub |
-| TestFetchers | Stub test for fetch utilities | crrDiffVersions, crrDiffArticles | stub |
+| Name | Purpose | Scope | Owner | Related Functions | Notes |
+|------|---------|-------|-------|-------------------|-------|
+| TestPDFIngest | Test PDF ingestion | unit | @todo | ingestPdfs | stub |
+| TestIngestAndChunk | Test ingestion and chunking together | integration | @todo | ingestPdfs, chunkText | stub |
+| TestRulesAndModel | Test weak rules and model training | unit | @todo | weakRules, trainMultilabel | stub |
+| TestFeatures | Test embedding generation | unit | @todo | docEmbeddingsBertGpu, precomputeEmbeddings | stub |
+| TestRegressionMetricsSimulated | Test regression metrics | unit | @todo | trainMultilabel, evalPerLabel | stub |
+| TestHybridSearch | Test hybrid search | unit | @todo | hybridSearch | stub |
+| TestProjectionHeadSimulated | Test projection head training | unit | @todo | trainProjectionHead | stub |
+| TestProjectionAutoloadPipeline | Test projection head autoload pipeline | integration | @todo | trainProjectionHead | stub |
+| TestFineTuneSmoke | Smoke test for encoder fine-tuning | smoke | @todo | ftBuildContrastiveDataset, ftTrainEncoder | stub |
+| TestFineTuneResume | Test fine-tune resume | unit | @todo | ftTrainEncoder | stub |
+| TestMetricsExpectedJSON | Test metrics JSON output | unit | @todo | evalRetrieval | stub |
+| TestGoldMetrics | Test gold metrics evaluation | unit | @todo | loadGold, evalPerLabel | stub |
+| TestReportArtifact | Test report generation | unit | @todo | evalRetrieval | stub |
+| TestFetchers | Test fetch utilities | unit | @todo | crrDiffVersions, crrDiffArticles | stub |
 
 ---
 
 ## Data Contracts (Between Modules)
 
+### Schemas
+
+#### Document
+| Field | Type | Description |
+|-------|------|-------------|
+| docId | string | Unique document identifier |
+| text | string | Raw document text |
+
+#### Chunk
+| Field | Type | Description |
+|-------|------|-------------|
+| chunkId | string | Unique chunk identifier |
+| docId | string | Parent document reference |
+| text | string | Chunk content |
+
+#### Label
+| Name | Type | Description |
+|------|------|-------------|
+| Yboot | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
+
+#### Embedding
+| Name | Type | Description |
+|------|------|-------------|
+| X | double `[numChunks x embeddingDim]` | Chunk embeddings |
+
+#### Metric
+| Field | Type | Description |
+|-------|------|-------------|
+| metric | string | Metric name |
+| value | double | Metric value |
+
+### Flows
+
 | Producer → Consumer | Payload Schema | Format | Validation | Notes |
 |--------------------|----------------|--------|-----------|-------|
-| ingest → chunking | `docs` table `{ docId: string, text: string }` | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
-| chunking → weak labeling / embeddings | `chunks` table `{ chunkId: string, docId: string, text: string }` | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
-| weak labeling → classifier | `Yboot` sparse logical matrix `[numChunks x numClasses]` | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
-| embedding generation → classifier | `X` double matrix `[numChunks x embeddingDim]` | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
-| classifier → retrieval / eval | `model` struct `{ weights: double[embeddingDim x numClasses], bias: double[1 x numClasses] }` | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
-| projection head training → retrieval | `head` struct `{ weights: double[?], bias: double[?] }` | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
-| fine-tune → evaluation | `ftEncoder` struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
-| evaluation → reports | metrics table `{ metric: string, value: double }` | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
+| ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
+| chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
+| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
+| embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
+| classifier → retrieval / eval | model struct `{ weights: double[embeddingDim x numClasses], bias: double[1 x numClasses] }` | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| projection head training → retrieval | head struct `{ weights: double[?], bias: double[?] }` | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
+| fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
+| evaluation → reports | Metric | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
 
 ---
 

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -6,10 +6,10 @@
 
 ## Instructions
 1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`). Fetcher utilities save downloaded PDFs to `data/raw`.
-2. Before running `reg.ingest_pdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
+2. Before running `reg.ingestPdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
 3. In MATLAB, call the ingestion routine:
    ```matlab
-   docs = reg.ingest_pdfs('data/pdfs');
+   docs = reg.ingestPdfs('data/pdfs');
    ```
 4. The function extracts text from each PDF. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
 5. Save the resulting table for later steps:
@@ -18,9 +18,9 @@
    ```
 
 ## Function Interface
-- `reg.ingest_pdfs(inputDir)`  
-  - `inputDir` (string): folder containing source PDFs.  
-  - returns `docs` (`table`): columns `docId` (string), `text` (string).  
+- `reg.ingestPdfs(inputDir)`
+  - `inputDir` (string): folder containing source PDFs.
+  - returns `docs` (`table`): follows the **Document** schema (`docId`, `text`).
   - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
 
 ## Verification

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -9,9 +9,9 @@
    ```matlab
    load('data/docs.mat','docs')
    ```
-2. Chunk each document with the helper function (default `chunk_size_tokens=300`, `chunk_overlap=80`):
+2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab
-   chunks = reg.chunk_text(docs, 'chunk_size_tokens', 300, 'chunk_overlap', 80);
+   chunks = reg.chunkText(docs, 'chunkSizeTokens', 300, 'chunkOverlap', 80);
    ```
 3. Save the chunks for later modules:
    ```matlab
@@ -19,11 +19,11 @@
    ```
 
 ## Function Interface
-- `reg.chunk_text(docs, 'chunk_size_tokens', n, 'chunk_overlap', m)`  
-  - `docs` (table): from Step 3 with `docId` and `text` fields.  
-  - `n` (double): tokens per chunk.  
-  - `m` (double): overlap between chunks.  
-  - returns `chunks` (`table`): columns `chunkId` (string), `docId` (string), `text` (string).  
+- `reg.chunkText(docs, 'chunkSizeTokens', n, 'chunkOverlap', m)`
+  - `docs` (table): Step 3 output following the **Document** schema.
+  - `n` (double): tokens per chunk.
+  - `m` (double): overlap between chunks.
+  - returns `chunks` (`table`): follows the **Chunk** schema (`chunkId`, `docId`, `text`).
   - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
 
 ## Verification

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -11,7 +11,7 @@
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
-   Yweak = reg.weak_rules(chunks.text, C.labels);
+   Yweak = reg.weakRules(chunks.text, C.labels);
    Yboot = Yweak >= C.min_rule_conf; % optional threshold
    ```
 3. Store the sparse label matrix for future training:
@@ -20,12 +20,12 @@
    ```
 
 ## Function Interface
-- `reg.weak_rules(text, labels)`  
+- `reg.weakRules(text, labels)`
   - `text` (string array): chunk content.  
   - `labels` (string array): list of topic names.  
   - returns `Yweak` (double sparse matrix) with confidence scores.
-- `Yboot = Yweak >= threshold` yields a sparse logical matrix used in later steps.  
-- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `Yboot`.
+- `Yboot = Yweak >= threshold` yields a sparse logical matrix used in later steps.
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for the **Label** schema of `Yboot`.
 
 > **Note:** `reg.weak_rules` requires `chunks.text` and the label list `C.labels`
 > from [`config.m`](../config.m). The confidence cutoff `C.min_rule_conf` is

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -11,20 +11,20 @@
    ```
 2. Generate embeddings with the GPU-enabled BERT encoder:
    ```matlab
-   X = reg.doc_embeddings_bert_gpu(chunks);
+   X = reg.docEmbeddingsBertGpu(chunks);
    ```
    If a GPU is unavailable, the function automatically falls back to a CPU-friendly model.
 3. Cache embeddings for reuse:
    ```matlab
-   reg.precompute_embeddings(X,'data/embeddings.mat');
+   reg.precomputeEmbeddings(X,'data/embeddings.mat');
    ```
 
 ## Function Interface
-- `reg.doc_embeddings_bert_gpu(chunks)`  
+- `reg.docEmbeddingsBertGpu(chunks)`
   - `chunks` (table): as defined in Step 4.  
   - returns `X` (double matrix): size `[numChunks x 768]` by default.  
-- `reg.precompute_embeddings(X, outPath)` caches the matrix to disk.  
-- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `X`.
+- `reg.precomputeEmbeddings(X, outPath)` caches the matrix to disk.
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for the **Embedding** schema of `X`.
 
 ## Verification
 - `X` has one row per chunk and 768 columns (BERT base dimension).

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -12,20 +12,20 @@
    ```
 2. Train the baseline classifier:
    ```matlab
-   model = reg.train_multilabel(X, Yboot);
+   model = reg.trainMultilabel(X, Yboot);
    save('models/baseline_model.mat','model')
    ```
 3. Enable hybrid retrieval combining cosine similarity and BM25:
    ```matlab
-   results = reg.hybrid_search(model, X, 'query', 'sample text');
+   results = reg.hybridSearch(model, X, 'query', 'sample text');
    ```
 
 ## Function Interface
-- `reg.train_multilabel(X, Yboot)`  
-  - `X` (double matrix): embeddings from Step 6.  
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.  
+- `reg.trainMultilabel(X, Yboot)`
+  - `X` (double matrix): embeddings from Step 6 following the **Embedding** schema.
+  - `Yboot` (sparse logical matrix): weak labels from Step 5 following the **Label** schema.
   - returns `model` (struct): fields `weights`, `bias`.  
-- `reg.hybrid_search(model, X, 'query', text)`  
+- `reg.hybridSearch(model, X, 'query', text)`
   - `model` (struct) and `X` (double matrix).  
   - `'query'` (string): search text.  
   - returns `results` (table) with `docId` and score fields.  

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -8,16 +8,16 @@
 1. Load embeddings and weak labels as in Step 7.
 2. Train the projection head:
    ```matlab
-   head = reg.train_projection_head(X, Yboot);
+   head = reg.trainProjectionHead(X, Yboot);
    save('models/projection_head.mat','head')
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
 
 ## Function Interface
-- `reg.train_projection_head(X, Yboot)`  
-  - `X` (double matrix): embeddings from Step 6.  
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.  
-  - returns `head` (struct): fields `weights`, `bias` used for retrieval enhancement.  
+- `reg.trainProjectionHead(X, Yboot)`
+  - `X` (double matrix): embeddings from Step 6 following the **Embedding** schema.
+  - `Yboot` (sparse logical matrix): weak labels from Step 5 following the **Label** schema.
+  - returns `head` (struct): fields `weights`, `bias` used for retrieval enhancement.
 - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references.
 
 ## Verification

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -7,24 +7,24 @@
 ## Instructions
 1. Build the contrastive training dataset:
    ```matlab
-   ds = reg.ft_build_contrastive_dataset(chunks, Yboot);
+   ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab
-   ftEncoder = reg.ft_train_encoder(ds, 'unfreeze_top', 4);
+   ftEncoder = reg.ftTrainEncoder(ds, 'unfreeze_top', 4);
    save('models/fine_tuned_bert.mat','ftEncoder')
    ```
 3. Update pipeline settings to point to the fine-tuned encoder if needed.
 
 ## Function Interface
-- `reg.ft_build_contrastive_dataset(chunks, Yboot)`  
-  - `chunks` (table): see Step 4.  
-  - `Yboot` (sparse logical matrix): weak labels.  
-  - returns `ds` (dataset) for contrastive pairs.  
-- `reg.ft_train_encoder(ds, 'unfreeze_top', n)`  
-  - `ds` (dataset): training data.  
-  - `'unfreeze_top'` (double): number of BERT layers to unfreeze.  
-  - returns `ftEncoder` (struct) with updated weights.  
+- `reg.ftBuildContrastiveDataset(chunks, Yboot)`
+  - `chunks` (table): follows the **Chunk** schema.
+  - `Yboot` (sparse logical matrix): follows the **Label** schema.
+  - returns `ds` (dataset) for contrastive pairs.
+- `reg.ftTrainEncoder(ds, 'unfreeze_top', n)`
+  - `ds` (dataset): training data.
+  - `'unfreeze_top'` (double): number of BERT layers to unfreeze.
+  - returns `ftEncoder` (struct) with updated weights.
 - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact schema.
 
 ## Verification

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -5,22 +5,25 @@
 **Depends on:** Model artifacts from [Step 7](step07_baseline_classifier.md), [Step 8](step08_projection_head.md), or [Step 9](step09_encoder_finetuning.md).
 
 ## Instructions
-1. Run the evaluation script to compute retrieval metrics and generate a PDF report:
+1. Run the evaluation routine to compute retrieval metrics and generate a PDF report:
    ```matlab
-   reg_eval_and_report
+   reg.evalRetrieval(resultsTbl, goldTbl);
    ```
 2. Optional: evaluate against a gold mini-pack if available:
    ```matlab
-   reg_eval_gold
+   goldTbl = reg.loadGold('path/to/gold');
+   reg.evalPerLabel(predYMat, goldTbl.y);
    ```
 3. Inspect generated artifacts in the `reports` or `output` folder.
 
 ## Function Interface
-- `reg_eval_and_report()`  
-  - consumes model artifacts and test queries.  
-  - outputs metrics tables and `reg_eval_report.pdf`.  
-- `reg_eval_gold()`  
-  - optionally evaluates against curated gold annotations.  
+- `reg.evalRetrieval(resultsTbl, goldTbl)`
+  - consumes retrieval results and optional gold labels.
+  - outputs metrics table and `reg_eval_report.pdf` following the **Metric** schema.
+- `reg.loadGold(pathStr)`
+  - reads curated gold annotations into `goldTbl`.
+- `reg.evalPerLabel(predYMat, trueYMat)`
+  - optionally evaluates per-label metrics.
 - See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
 
 ## Verification

--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -7,22 +7,22 @@
 ## Instructions
 1. Synchronize the Common Rulebook (CRR) or similar sources:
    ```matlab
-   reg_crr_sync
+   reg.crrSync();
    ```
 2. Generate diff reports between document versions:
    ```matlab
-   reg.crr_diff_versions('versionA','versionB')
-   reg_crr_diff_report
+   reg.crrDiffVersions('versionA','versionB');
+   reg.crrDiffReport;
    ```
 3. Review HTML or PDF diff outputs for changes.
 
 ## Function Interface
-- `reg_crr_sync()` downloads the latest corpus to `data/raw`.  
-- `reg.crr_diff_versions(vA, vB)`  
+- `reg.crrSync()` downloads the latest corpus to `data/raw`.
+- `reg.crrDiffVersions(vA, vB)`
   - `vA`, `vB` (string): version identifiers.  
   - returns a structure describing added, removed, and changed documents.  
-- `reg_crr_diff_report` renders HTML/PDF summaries.  
-- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for corpus schema references.
+- `reg.crrDiffReport` renders HTML/PDF summaries.
+- See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for corpus (**Document**) schema references.
 
 ## Verification
 - Date-stamped corpora appear in the `data` directory.


### PR DESCRIPTION
## Summary
- enumerate functions, classes, constants, and tests with owners in identifier registry
- add document, chunk, label, embedding, and metric schemas to data contracts
- reference canonical identifiers and schemas throughout step guides

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b53dd237883309067b0947b8e4b42