### PR TITLE
Add master scaffold documentation and link from build plan

### DIFF
--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -2,6 +2,8 @@
 
 Detailed step-by-step guides for each task are available in the `docs/` folder.
 
+See [Master Scaffold](master_scaffold.md) for module stubs and test skeletons.
+
 This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic classifier. Each task is scoped to minimize coupling and lists prerequisites so the system can be assembled and tested incrementally.
 
 ## 1. Environment & Tooling

--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -1,0 +1,42 @@
+# Master Scaffold
+
+This document summarizes the MATLAB `+reg` package, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
+
+## Package Structure
+
+Each module is implemented as a stub `.m` file under `+reg/`. Every stub includes a `%% NAME-REGISTRY:FUNCTION` breadcrumb and a `TODO` placeholder. The table below lists the modules in build order and their paired tests.
+
+| Step | Module | Stub `.m` file | Test skeleton(s) |
+|------|--------|----------------|------------------|
+| 3 | Data ingestion | `+reg/ingestPdfs.m` | `tests/TestPDFIngest.m`, `tests/TestIngestAndChunk.m` |
+| 4 | Text chunking | `+reg/chunkText.m` | `tests/TestIngestAndChunk.m` |
+| 5 | Weak labeling | `+reg/weakRules.m` | `tests/TestRulesAndModel.m` |
+| 6 | Embedding generation | `+reg/docEmbeddingsBertGpu.m`, `+reg/precomputeEmbeddings.m` | `tests/TestFeatures.m` |
+| 7 | Baseline classifier & retrieval | `+reg/trainMultilabel.m`, `+reg/hybridSearch.m` | `tests/TestRegressionMetricsSimulated.m`, `tests/TestHybridSearch.m` |
+| 8 | Projection head | `+reg/trainProjectionHead.m` | `tests/TestProjectionHeadSimulated.m`, `tests/TestProjectionAutoloadPipeline.m` |
+| 9 | Encoder fine-tuning | `+reg/ftBuildContrastiveDataset.m`, `+reg/ftTrainEncoder.m` | `tests/TestFineTuneSmoke.m`, `tests/TestFineTuneResume.m` |
+| 10 | Evaluation & reporting | `+reg/evalRetrieval.m`, `+reg/evalPerLabel.m`, `+reg/loadGold.m` | `tests/TestMetricsExpectedJSON.m`, `tests/TestGoldMetrics.m`, `tests/TestReportArtifact.m` |
+| 11 | Data acquisition & diff utilities | `+reg/crrDiffVersions.m`, `+reg/crrDiffArticles.m` | `tests/TestFetchers.m` |
+
+## TDD Workflow
+
+1. **Write a failing test**
+   - Create a skeleton in `tests/` named `TestMyFeature.m`.
+   - Include `%% NAME-REGISTRY:TEST TestMyFeature` and call the target stub.
+   - Force the failure with `assert(false, 'Not implemented yet');`.
+
+2. **Add a stub module**
+   - Under `+reg/`, create `myFeature.m` with the function signature, a `%% NAME-REGISTRY:FUNCTION myFeature` breadcrumb, and a `TODO` placeholder.
+
+3. **Update the identifier registry**
+   - Add entries for the new function, file, and test in `docs/identifier_registry.md`.
+
+4. **Run the test suite**
+   - From MATLAB:
+     ```matlab
+     results = runtests("tests", "IncludeSubfolders", true, "UseParallel", false);
+     table(results)
+     ```
+   - Iterate until the new test passes and the placeholder assertion is removed.
+
+Following this scaffold keeps modules, tests, and the identifier registry synchronized.

--- a/docs/step01_environment_tooling.md
+++ b/docs/step01_environment_tooling.md
@@ -5,6 +5,8 @@
 **Depends on:** None.
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Install **MATLAB R2024a** on your workstation.
 2. During installation, add these toolboxes:
    - Text Analytics

--- a/docs/step02_repository_setup.md
+++ b/docs/step02_repository_setup.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 1: Environment & Tooling](step01_environment_tooling.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Clone or unzip the project repository.
 2. In MATLAB, navigate to the project root and add all folders to the path:
    ```matlab

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`). Fetcher utilities save downloaded PDFs to `data/raw`.
 2. Before running `reg.ingest_pdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
 3. In MATLAB, call the ingestion routine:

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 3: Data Ingestion](step03_data_ingestion.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Load the ingested documents table:
    ```matlab
    load('data/docs.mat','docs')

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 4: Text Chunking](step04_text_chunking.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Load chunk data:
    ```matlab
    load('data/chunks.mat','chunks')

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 5: Weak Labeling](step05_weak_labeling.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Load chunk data:
    ```matlab
    load('data/chunks.mat','chunks')

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 6: Embedding Generation](step06_embedding_generation.md) and [Step 5: Weak Labeling](step05_weak_labeling.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Load embeddings and weak labels:
    ```matlab
    load('data/embeddings.mat','X');

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 7: Baseline Classifier & Retrieval](step07_baseline_classifier.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Load embeddings and weak labels as in Step 7.
 2. Train the projection head:
    ```matlab

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 8: Projection Head Workflow](step08_projection_head.md) and [Step 6: Embedding Generation](step06_embedding_generation.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Build the contrastive training dataset:
    ```matlab
    ds = reg.ft_build_contrastive_dataset(chunks, Yboot);

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -5,6 +5,8 @@
 **Depends on:** Model artifacts from [Step 7](step07_baseline_classifier.md), [Step 8](step08_projection_head.md), or [Step 9](step09_encoder_finetuning.md).
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Run the evaluation script to compute retrieval metrics and generate a PDF report:
    ```matlab
    reg_eval_and_report

--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -5,6 +5,8 @@
 **Depends on:** [Step 1: Environment & Tooling](step01_environment_tooling.md) and prior steps if integrating with the pipeline.
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. Synchronize the Common Rulebook (CRR) or similar sources:
    ```matlab
    reg_crr_sync

--- a/docs/step12_continuous_testing.md
+++ b/docs/step12_continuous_testing.md
@@ -5,6 +5,8 @@
 **Depends on:** Completion of prior steps.
 
 ## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
 1. In MATLAB, run the full test suite regularly:
    ```matlab
    results = runtests('tests','IncludeSubfolders',true,'UseParallel',false);


### PR DESCRIPTION
## Summary
- document +reg package layout, stub modules, and matching test skeletons in `docs/master_scaffold.md`
- describe TDD workflow for adding failing tests, running `runtests`, and updating `identifier_registry.md`
- link master scaffold from `SYSTEM_BUILD_PLAN.md` and all step guides for centralized instructions

## Testing
- `matlab -batch "results = runtests('tests','IncludeSubfolders',true,'UseParallel',false); table(results)"` *(command failed: matlab not found)*


------
https://chatgpt.com/codex/tasks/task_b_689b53fafe08833089ae83a1338ca2d1