### PR TITLE
docs: add retrieval and model contract schemas

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -198,6 +198,31 @@ Common test scopes or prefixes include:
 | metric | string | Metric name |
 | value | double | Metric value |
 
+#### BaselineModel
+| Field | Type | Description |
+|-------|------|-------------|
+| weights | double `[embeddingDim x numClasses]` | Classifier weights |
+| bias | double `[1 x numClasses]` | Classifier bias |
+
+#### ProjectionHead
+| Field | Type | Description |
+|-------|------|-------------|
+| weights | double `[embeddingDim x embeddingDim]` | Projection weights |
+| bias | double `[1 x embeddingDim]` | Projection bias |
+
+#### RetrievalResult
+| Field | Type | Description |
+|-------|------|-------------|
+| docId | string | Retrieved document identifier |
+| score | double | Retrieval relevance score |
+
+#### ContrastiveDataset
+| Field | Type | Description |
+|-------|------|-------------|
+| anchorIdx | double array | Index of anchor chunk |
+| posIdx | double array | Index of positive chunk |
+| negIdx | double array | Index of negative chunk |
+
 ### Flows
 
 | Producer → Consumer | Payload Schema | Format | Validation | Notes |
@@ -206,8 +231,10 @@ Common test scopes or prefixes include:
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
 | weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
 | embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
-| classifier → retrieval / eval | model struct `{ weights: double[embeddingDim x numClasses], bias: double[1 x numClasses] }` | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
-| projection head training → retrieval | head struct `{ weights: double[?], bias: double[?] }` | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
+| classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
+| retrieval → evaluation | RetrievalResult | MAT-file (`results.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| dataset build → fine-tune | ContrastiveDataset | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | evaluation → reports | Metric | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
 

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -28,7 +28,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
-- **Returns:** struct `model` with fields `weights` and `bias`.
+- **Returns:** struct `model` with fields `weights` and `bias` (see [BaselineModel](identifier_registry.md#baselinemodel)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
@@ -40,24 +40,32 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   - `model` (struct)
   - `X` (double matrix)
   - `'query'` (string): search text.
-- **Returns:** table `results` containing `docId` and score fields.
+- **Returns:** table `results` containing `docId` and `score` fields (see [RetrievalResult](identifier_registry.md#retrievalresult)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
   results = reg.hybrid_search(model, X, 'query', 'example');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, and model outputs.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, `BaselineModel`, and `RetrievalResult` outputs.
 
 
 ## Verification
 - Classifier training completes and saves `baseline_model.mat`.
+- Verify model schema:
+  ```matlab
+  assert(all(isfield(model, {'weights','bias'})));
+  ```
 - Run baseline tests:
   ```matlab
   runtests({'tests/testRegressionMetricsSimulated.m', ...
             'tests/testHybridSearch.m'})
   ```
   Tests confirm baseline metrics and retrieval behavior.
+- Retrieval results contain expected fields:
+  ```matlab
+  assert(all(ismember({'docId','score'}, results.Properties.VariableNames)));
+  ```
 
 ## Next Steps
 Continue to [Step 8: Projection Head Workflow](step08_projection_head.md).

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -21,18 +21,22 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
-- **Returns:** struct `head` with fields `weights` and `bias` used for retrieval enhancement.
+- **Returns:** struct `head` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
   head = reg.train_projection_head(X, Yboot);
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHead`.
 
 
 ## Verification
 - `projection_head.mat` exists in the `models` folder.
+- Validate head schema:
+  ```matlab
+  assert(all(isfield(head, {'weights','bias'})));
+  ```
 - Run projection head tests:
   ```matlab
   runtests({'tests/testProjectionHeadSimulated.m', ...

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -24,7 +24,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `chunks` (table): see Step 4.
   - `Yboot` (sparse logical matrix): weak labels.
-- **Returns:** dataset `ds` containing contrastive pairs.
+- **Returns:** dataset `ds` containing contrastive pairs (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
@@ -42,11 +42,15 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   ftEncoder = reg.ft_train_encoder(ds, 'unfreeze_top', 4);
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact schema.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact and `ContrastiveDataset` schemas.
 
 
 ## Verification
 - `fine_tuned_bert.mat` is saved and contains updated weights.
+- Contrastive dataset has expected fields:
+  ```matlab
+  assert(all(isfield(ds, {'anchorIdx','posIdx','negIdx'})));
+  ```
 - Run fine-tuning tests:
   ```matlab
   runtests({'tests/testFineTuneSmoke.m', ...

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -40,11 +40,15 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   reg_eval_gold
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric and `RetrievalResult` schema references.
 
 
 ## Verification
 - Report files such as `reg_eval_report.pdf` and metric CSVs are created.
+- Retrieval results table includes expected columns:
+  ```matlab
+  assert(all(ismember({'docId','score'}, resultsTbl.Properties.VariableNames)));
+  ```
 - Run evaluation tests:
   ```matlab
   runtests({'tests/testMetricsExpectedJSON.m', ...


### PR DESCRIPTION
## Summary
- document baseline model, projection head, retrieval result, and contrastive dataset schemas
- reference new schemas from step guides and add verification assertions

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b5cb4ea9c8330bf5012da91edfcb6