### PR TITLE
Add scaffold validation script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,8 @@ repos:
         entry: python scripts/check_identifier_registry.py
         language: python
         pass_filenames: false
+      - id: validate-scaffold
+        name: validate scaffold
+        entry: python scripts/validate_scaffold.py
+        language: python
+        pass_filenames: false

--- a/scripts/validate_scaffold.py
+++ b/scripts/validate_scaffold.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Validate that stub modules and tests listed in docs/master_scaffold.md exist."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    scaffold = repo_root / "docs" / "master_scaffold.md"
+    text = scaffold.read_text(encoding="utf-8")
+
+    stub_paths = set(re.findall(r"`(\+reg/[^`]+)`", text))
+    test_paths = set(re.findall(r"`(tests/[^`]+)`", text))
+
+    missing: list[str] = []
+    for rel in sorted(stub_paths.union(test_paths)):
+        if not (repo_root / rel).exists():
+            missing.append(rel)
+
+    if missing:
+        for path in missing:
+            print(f"Missing expected file: {path}", file=sys.stderr)
+        return 1
+
+    print("All scaffold files are present.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add script to parse `docs/master_scaffold.md` and ensure listed stub modules and tests exist
- wire script into pre-commit so missing files trigger CI failures

## Testing
- `python scripts/validate_scaffold.py`
- `pre-commit run --all-files` *(fails: command not found: pre-commit)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `matlab -batch "run_smoke_test"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689b5d7516988330afc75ebccdd8d94e