### PR TITLE
Add MATLAB lint script and CI workflow

### DIFF
--- a/.github/workflows/matlab-lint.yml
+++ b/.github/workflows/matlab-lint.yml
@@ -1,0 +1,15 @@
+name: matlab-lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  mlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup MATLAB
+        uses: matlab-actions/setup-matlab@v1
+      - name: Run mlint
+        run: scripts/run_mlint.sh

--- a/scripts/run_mlint.sh
+++ b/scripts/run_mlint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Lint all MATLAB files using checkcode (mlint).
+# Exits with non-zero status if any issues are found.
+set -euo pipefail
+
+status=0
+while IFS= read -r file; do
+  echo "Linting ${file}"
+  matlab -batch "issues = checkcode('${file}', '-id'); if ~isempty(issues); disp(issues); exit(1); end"
+  if [ $? -ne 0 ]; then
+    status=1
+  fi
+done < <(find . -name '*.m')
+
+exit $status


### PR DESCRIPTION
## Summary
- add `scripts/run_mlint.sh` to lint all MATLAB files with `checkcode`
- introduce GitHub Action `matlab-lint.yml` to run the lint script on push and PR

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `scripts/run_mlint.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b5d920a8483308e3becfc5c6412b8