### PR TITLE
docs: align step identifiers

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -8,6 +8,10 @@ files/modules, tests, and other identifiers are tracked in the
 `identifier_registry.md`.
 
 
+## Function and Script Names
+
+Use lowerCamelCase for all function and script names (e.g., `ingestPdfs`, `trainMultilabel`).
+
 ## Data-Type Suffixes
 
 Use suffixes to denote common data structures. Refer to the [Data-Type Suffixes](Matlab_Style_Guide.md#11-data-type-suffixes) section of the style guide for full details.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -78,21 +78,22 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Function | Parameters | Returns | Side Effects |
 |----------|------------|---------|--------------|
 | config | none | struct of settings from JSON files | reads configuration files |
-| reg.ingest_pdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
-| reg.chunk_text | docs table, chunk_size_tokens double, chunk_overlap double | chunks table `{chunkId,docId,text}` | none |
-| reg.weak_rules | text array, labels array | sparse matrix `Yweak` | none |
-| reg.doc_embeddings_bert_gpu | chunks table | matrix `X` | loads model, uses GPU |
-| reg.precompute_embeddings | `X` matrix, outPath string | none | writes embeddings to disk |
-| reg.train_multilabel | `X` matrix, `Yboot` matrix | model struct | none |
-| reg.hybrid_search | model struct, `X` matrix, query string | results table | none |
-| reg.train_projection_head | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ft_build_contrastive_dataset | chunks table, `Yboot` matrix | dataset struct | none |
-| reg.ft_train_encoder | dataset `ds`, unfreeze_top double | encoder struct | updates model weights |
-| reg_eval_and_report | none | metrics tables | writes report files |
-| reg_eval_gold | none | metrics tables | reads gold annotations |
-| reg_crr_sync | none | none | downloads corpus to `data/raw` |
-| reg.crr_diff_versions | `vA` string, `vB` string | diff struct | none |
-| reg_crr_diff_report | none | none | writes HTML/PDF summaries |
+| reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
+| reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
+| reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
+| reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
+| reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
+| reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
+| reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
+| reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
+| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
+| reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
+| reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
+| reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
+| reg.evalPerLabel | predYMat matrix, trueYMat matrix | metrics table | none |
+| reg.crrSync | none | none | downloads corpus to `data/raw` |
+| reg.crrDiffVersions | `vA` string, `vB` string | diff struct | none |
+| reg.crrDiffReport | none | none | writes HTML/PDF summaries |
 | runtests | testFolder string, IncludeSubfolders logical, UseParallel logical | results table | executes test suite |
 
 

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -21,14 +21,14 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.ingest_pdfs
+### reg.ingestPdfs
 - **Parameters:**
   - `inputDir` (string): folder containing source PDFs.
 - **Returns:** table `docs` with columns `docId` (string) and `text` (string).
 - **Side Effects:** reads PDFs from disk and uses OCR for image-only pages.
 - **Usage Example:**
   ```matlab
-  docs = reg.ingest_pdfs("data/pdfs_mock");
+  docs = reg.ingestPdfs("data/pdfs_mock");
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -22,16 +22,16 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.chunk_text
+### reg.chunkText
 - **Parameters:**
   - `docs` (table): from Step 3 with `docId` and `text` fields.
-  - `'chunk_size_tokens'` (double): tokens per chunk.
-  - `'chunk_overlap'` (double): overlap between chunks.
+  - `'chunkSizeTokens'` (double): tokens per chunk.
+  - `'chunkOverlap'` (double): overlap between chunks.
 - **Returns:** table `chunks` with columns `chunkId` (string), `docId` (string), and `text` (string).
 - **Side Effects:** none; pure transformation of input table.
 - **Usage Example:**
   ```matlab
-  chunks = reg.chunk_text(docs, 'chunk_size_tokens', 100, 'chunk_overlap', 20);
+  chunks = reg.chunkText(docs, 'chunkSizeTokens', 100, 'chunkOverlap', 20);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -14,7 +14,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 2. Generate weak labels with rule-based functions:
    ```matlab
    Yweak = reg.weakRules(chunks.text, C.labels);
-   Yboot = Yweak >= C.min_rule_conf; % optional threshold
+   Yboot = Yweak >= C.minRuleConf; % optional threshold
    ```
 3. Store the sparse label matrix for future training:
    ```matlab
@@ -23,7 +23,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.weak_rules
+### reg.weakRules
 - **Parameters:**
   - `text` (string array): chunk content.
   - `labels` (string array): list of topic names.
@@ -31,7 +31,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  Yweak = reg.weak_rules(["example"], ["topicA","topicB"]);
+  Yweak = reg.weakRules(["example"], ["topicA","topicB"]);
   ```
 
 ### Thresholding
@@ -48,8 +48,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `Yboot`.
 
 
-> **Note:** `reg.weak_rules` requires `chunks.text` and the label list `C.labels`
-> from [`config.m`](../config.m). The confidence cutoff `C.min_rule_conf` is
+> **Note:** `reg.weakRules` requires `chunks.text` and the label list `C.labels`
+> from [`config.m`](../config.m). The confidence cutoff `C.minRuleConf` is
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.
 
 ## Verification

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -23,17 +23,17 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.doc_embeddings_bert_gpu
+### reg.docEmbeddingsBertGpu
 - **Parameters:**
   - `chunks` (table): as defined in Step 4.
 - **Returns:** double matrix `X` of size `[numChunks x 768]` by default.
 - **Side Effects:** loads BERT weights and uses GPU when available.
 - **Usage Example:**
   ```matlab
-  X = reg.doc_embeddings_bert_gpu(chunks);
+  X = reg.docEmbeddingsBertGpu(chunks);
   ```
 
-### reg.precompute_embeddings
+### reg.precomputeEmbeddings
 - **Parameters:**
   - `X` (double matrix)
   - `outPath` (string): destination MAT-file path.
@@ -41,7 +41,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** writes embeddings to disk for reuse.
 - **Usage Example:**
   ```matlab
-  reg.precompute_embeddings(X, 'embeddings_mock.mat');
+  reg.precomputeEmbeddings(X, 'embeddings_mock.mat');
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `X`.

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -24,7 +24,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.train_multilabel
+### reg.trainMultilabel
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
@@ -32,10 +32,10 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  model = reg.train_multilabel(X, Yboot);
+  model = reg.trainMultilabel(X, Yboot);
   ```
 
-### reg.hybrid_search
+### reg.hybridSearch
 - **Parameters:**
   - `model` (struct)
   - `X` (double matrix)
@@ -44,7 +44,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  results = reg.hybrid_search(model, X, 'query', 'example');
+  results = reg.hybridSearch(model, X, 'query', 'example');
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, and model outputs.

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -17,7 +17,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg.train_projection_head
+### reg.trainProjectionHead
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
@@ -25,7 +25,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  head = reg.train_projection_head(X, Yboot);
+  head = reg.trainProjectionHead(X, Yboot);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references.

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -13,14 +13,14 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab
-   ftEncoder = reg.ftTrainEncoder(ds, 'unfreeze_top', 4);
+   ftEncoder = reg.ftTrainEncoder(ds, 'unfreezeTop', 4);
    save('models/fine_tuned_bert.mat','ftEncoder')
    ```
 3. Update pipeline settings to point to the fine-tuned encoder if needed.
 
 ## Function Interface
 
-### reg.ft_build_contrastive_dataset
+### reg.ftBuildContrastiveDataset
 - **Parameters:**
   - `chunks` (table): see Step 4.
   - `Yboot` (sparse logical matrix): weak labels.
@@ -28,18 +28,18 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  ds = reg.ft_build_contrastive_dataset(chunks, Yboot);
+  ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
   ```
 
-### reg.ft_train_encoder
+### reg.ftTrainEncoder
 - **Parameters:**
   - `ds` (dataset): training data.
-  - `'unfreeze_top'` (double): number of BERT layers to unfreeze.
+  - `'unfreezeTop'` (double): number of BERT layers to unfreeze.
 - **Returns:** struct `ftEncoder` with updated weights.
 - **Side Effects:** updates encoder weights during training.
 - **Usage Example:**
   ```matlab
-  ftEncoder = reg.ft_train_encoder(ds, 'unfreeze_top', 4);
+  ftEncoder = reg.ftTrainEncoder(ds, 'unfreezeTop', 4);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact schema.

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -22,25 +22,37 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg_eval_and_report
-- **Parameters:** none.
+### reg.evalRetrieval
+- **Parameters:** `resultsTbl` table, `goldTbl` table.
 - **Returns:** metrics tables and generates `reg_eval_report.pdf`.
 - **Side Effects:** reads model artifacts and writes report files to disk.
 - **Usage Example:**
   ```matlab
-  reg_eval_and_report
+  reg.evalRetrieval(resultsTbl, goldTbl);
   ```
 
-### reg_eval_gold
-- **Parameters:** none.
-- **Returns:** metrics tables comparing predictions to gold annotations.
+### reg.loadGold
+- **Parameters:**
+  - `pathStr` (string): location of gold annotations.
+- **Returns:** table `goldTbl` of annotations.
 - **Side Effects:** reads curated annotation packs if available.
 - **Usage Example:**
   ```matlab
-  reg_eval_gold
+  goldTbl = reg.loadGold('path/to/gold');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
+### reg.evalPerLabel
+- **Parameters:**
+  - `predYMat` (matrix): predicted labels.
+  - `trueYMat` (matrix): gold labels.
+- **Returns:** table of per-label metrics.
+- **Side Effects:** none.
+- **Usage Example:**
+  ```matlab
+  reg.evalPerLabel(predYMat, goldTbl.y);
+  ```
+
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references. – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
 
 
 ## Verification

--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -20,16 +20,16 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ## Function Interface
 
-### reg_crr_sync
+### reg.crrSync
 - **Parameters:** none.
 - **Returns:** none.
 - **Side Effects:** downloads the latest corpus to `data/raw`.
 - **Usage Example:**
   ```matlab
-  reg_crr_sync
+  reg.crrSync
   ```
 
-### reg.crr_diff_versions
+### reg.crrDiffVersions
 - **Parameters:**
   - `vA` (string): version identifier A.
   - `vB` (string): version identifier B.
@@ -37,16 +37,16 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  diff = reg.crr_diff_versions('v1','v2');
+  diff = reg.crrDiffVersions('v1','v2');
   ```
 
-### reg_crr_diff_report
+### reg.crrDiffReport
 - **Parameters:** none.
 - **Returns:** none.
 - **Side Effects:** renders HTML/PDF summaries to disk.
 - **Usage Example:**
   ```matlab
-  reg_crr_diff_report
+  reg.crrDiffReport
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for corpus schema references.


### PR DESCRIPTION
## Summary
- Use lowerCamelCase function names in all step docs per identifier registry
- Document lowerCamelCase preference for functions and scripts in README_NAMING
- Sync identifier registry interface table with canonical names

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b5cac4154833097ca31f9c19299c9