### PR TITLE
ci: upgrade MATLAB setup action

### DIFF
--- a/.github/workflows/matlab-lint.yml
+++ b/.github/workflows/matlab-lint.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
       - name: Run mlint
         run: scripts/run_mlint.sh


### PR DESCRIPTION
## Summary
- use matlab-actions/setup-matlab v2 in lint workflow

## Testing
- `pre-commit run --files .github/workflows/matlab-lint.yml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `matlab -batch "run_smoke_test"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689b63b57af8833081c30d9002538df7