### PR TITLE
chore: mark unused chunk table

### DIFF
--- a/+reg/precomputeEmbeddings.m
+++ b/+reg/precomputeEmbeddings.m
@@ -1,8 +1,8 @@
-function xMat = precomputeEmbeddings(chunkTbl)
+function xMat = precomputeEmbeddings(~)
 %PRECOMPUTEEMBEDDINGS Precompute embeddings for text chunks.
 %
 % Inputs
-%   chunkTbl - table of chunks
+%   chunkTbl - table of chunks (unused)
 %
 % Outputs
 %   xMat - matrix of embeddings
@@ -10,7 +10,7 @@ function xMat = precomputeEmbeddings(chunkTbl)
 %% NAME-REGISTRY:FUNCTION precomputeEmbeddings
 
 % Placeholder implementation
-% TODO: implement embedding precomputation
+% TODO: implement embedding precomputation; currently returns empty matrix.
 
 xMat = [];
 end


### PR DESCRIPTION
## Summary
- clarify that precomputeEmbeddings currently ignores its chunk table input

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b640028bc8330bce01e564d391ae3