### PR TITLE
Check MATLAB availability before linting

### DIFF
--- a/scripts/run_mlint.sh
+++ b/scripts/run_mlint.sh
@@ -3,6 +3,11 @@
 # Exits with non-zero status if any issues are found.
 set -euo pipefail
 
+if ! matlab -batch "exit" >/dev/null 2>&1; then
+  echo "MATLAB not available; skipping lint"
+  exit 0
+fi
+
 status=0
 while IFS= read -r file; do
   echo "Linting ${file}"


### PR DESCRIPTION
## Summary
- Skip linting gracefully when MATLAB is not available by adding an upfront availability check in `run_mlint.sh`
- Preserve existing lint loop for environments with MATLAB

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `./scripts/run_mlint.sh`


------
https://chatgpt.com/codex/tasks/task_b_689b683000e0833089ece271ac8288dd