### PR TITLE
Use matlab-actions run-tests workflow

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -9,8 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2024b
       - name: Run MATLAB tests
-        uses: mathworks/run-tests@v1
+        uses: matlab-actions/run-tests@v2
         with:
           command: "runtests('tests','IncludeSubfolders',true,'UseParallel',false)"


### PR DESCRIPTION
## Summary
- Use `matlab-actions/setup-matlab@v2` with MATLAB R2024b
- Use `matlab-actions/run-tests@v2` and latest checkout action

## Testing
- `matlab -batch "run_smoke_test"` (fails: command not found: matlab)
- `pip install pre-commit` (fails: Could not find a version that satisfies the requirement pre-commit (proxy error))
- `pre-commit run --files .github/workflows/matlab-tests.yml` (fails: command not found: pre-commit)


------
https://chatgpt.com/codex/tasks/task_b_689b66d3a69c83308297f4b6670b2db8