### PR TITLE
chore: update matlab lint workflow

### DIFF
--- a/.github/workflows/matlab-lint.yml
+++ b/.github/workflows/matlab-lint.yml
@@ -8,8 +8,10 @@ jobs:
   mlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2024b
       - name: Run mlint
         run: scripts/run_mlint.sh


### PR DESCRIPTION
## Summary
- use checkout v4 in MATLAB lint workflow
- specify MATLAB release R2024b for lint job

## Testing
- `pre-commit run --files .github/workflows/matlab-lint.yml` *(command not found)*
- `matlab -batch "runtests"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b6bd4287483308c6f49cf07324157