### PR TITLE
Use null-delimited find in run_mlint

### DIFF
--- a/scripts/run_mlint.sh
+++ b/scripts/run_mlint.sh
@@ -3,13 +3,13 @@
 # Exits with non-zero status if any issues are found.
 set -euo pipefail
 
-status=0
-while IFS= read -r file; do
-  echo "Linting ${file}"
-  matlab -batch "issues = checkcode('${file}', '-id'); if ~isempty(issues); disp(issues); exit(1); end"
-  if [ $? -ne 0 ]; then
-    status=1
-  fi
-done < <(find . -name '*.m')
+find . -name '*.m' -print0 | (
+  status=0
+  while IFS= read -r -d '' file; do
+    echo "Linting ${file}"
+    matlab -batch "issues = checkcode('${file}', '-id'); if ~isempty(issues); disp(issues); exit(1); end" || status=1
+  done
+  exit $status
+)
 
-exit $status
+exit $?


### PR DESCRIPTION
## Summary
- Handle MATLAB files with spaces by scanning using `find -print0` and null-delimited reads

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b6f331cdc83309388e9a7f7dec1c5