### PR TITLE
Fix MATLAB workflow setup step

### DIFF
--- a/.github/workflows/matlab-tests.yml
+++ b/.github/workflows/matlab-tests.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up MATLAB
-=======
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:


### PR DESCRIPTION
## Summary
- remove leftover merge conflict marker and duplicate setup step from MATLAB CI workflow

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `pre-commit run --files .github/workflows/matlab-tests.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b6f3226748330b4733cae948ce860