### PR TITLE
Handle mlint failures without exiting loop

### DIFF
--- a/scripts/run_mlint.sh
+++ b/scripts/run_mlint.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # Lint all MATLAB files using checkcode (mlint).
 # Exits with non-zero status if any issues are found.
-set -euo pipefail
+set -uo pipefail
 
 status=0
 while IFS= read -r file; do
   echo "Linting ${file}"
-  matlab -batch "issues = checkcode('${file}', '-id'); if ~isempty(issues); disp(issues); exit(1); end"
-  if [ $? -ne 0 ]; then
+  if ! matlab -batch "issues = checkcode('${file}', '-id'); if ~isempty(issues); disp(issues); exit(1); end"; then
     status=1
   fi
 done < <(find . -name '*.m')


### PR DESCRIPTION
## Summary
- Avoid aborting mlint loop on errors by dropping `set -e` and checking `matlab -batch` status explicitly.
- Continue linting files and track overall status with an `if !` guard.

## Testing
- `./scripts/run_mlint.sh >/tmp/run_mlint.log ; tail -n 20 /tmp/run_mlint.log` (fails: `matlab: command not found`)
- `matlab -batch "run_smoke_test" >/tmp/test.log ; tail -n 20 /tmp/test.log` (fails: `command not found`)


------
https://chatgpt.com/codex/tasks/task_b_689b6f33425c833099612e47e44e3df0