### PR TITLE
refactor: name precompute embeddings input

### DIFF
--- a/+reg/precomputeEmbeddings.m
+++ b/+reg/precomputeEmbeddings.m
@@ -1,8 +1,8 @@
-function xMat = precomputeEmbeddings(~)
+function xMat = precomputeEmbeddings(chunkTbl) %#ok<INUSD>
 %PRECOMPUTEEMBEDDINGS Precompute embeddings for text chunks.
 %
 % Inputs
-%   chunkTbl - table of chunks (unused)
+%   chunkTbl - table of chunks (currently unused)
 %
 % Outputs
 %   xMat - matrix of embeddings


### PR DESCRIPTION
## Summary
- name parameter in `precomputeEmbeddings` and note it's unused

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b82d242688330acbbf75912b20a15