### PR TITLE
Mark placeholder tests as incomplete

### DIFF
--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -8,8 +8,8 @@ function tests = testFetchers
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.crrDiffVersions('', '');
     reg.crrDiffArticles('', '', '');
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -8,7 +8,7 @@ function tests = testFineTuneResume
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.ftTrainEncoder(struct());
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -8,8 +8,8 @@ function tests = testFineTuneSmoke
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.ftBuildContrastiveDataset(table(), []);
     reg.ftTrainEncoder(struct());
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -8,8 +8,8 @@ function tests = testGoldMetrics
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.loadGold('');
     reg.evalPerLabel([], []);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -8,7 +8,7 @@ function tests = testHybridSearch
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.hybridSearch('', [], table());
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -8,8 +8,8 @@ function tests = testIngestAndChunk
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.ingestPdfs({});
     reg.chunkText(table(), 0, 0);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -8,7 +8,7 @@ function tests = testMetricsExpectedJSON
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.evalRetrieval(table(), table());
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -8,7 +8,7 @@ function tests = testPDFIngest
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.ingestPdfs({});
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -8,7 +8,7 @@ function tests = testProjectionAutoloadPipeline
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.trainProjectionHead([], []);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -8,7 +8,7 @@ function tests = testProjectionHeadSimulated
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.trainProjectionHead([], []);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -8,8 +8,8 @@ function tests = testRegressionMetricsSimulated
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.trainMultilabel([], []);
     reg.evalPerLabel([], []);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -8,7 +8,7 @@ function tests = testReportArtifact
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.evalRetrieval(table(), table());
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -8,8 +8,8 @@ function tests = testRulesAndModel
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(~)
+function testPlaceholder(testCase)
     reg.weakRules(table());
     reg.trainMultilabel([], []);
-    assert(false, 'Not implemented yet');
+    testCase.assumeFail('Not implemented yet');
 end


### PR DESCRIPTION
## Summary
- mark placeholder tests as incomplete using `testCase.assumeFail`
- ensure test functions accept `testCase`

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b8616e60483308534e4d4f5b60d92