### PR TITLE
Rename placeholder tests to descriptive scenarios

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -160,6 +160,19 @@ Common test scopes or prefixes include:
 | testGoldMetrics | Test gold metrics evaluation | unit | @todo | loadGold, evalPerLabel | stub |
 | testReportArtifact | Test report generation | unit | @todo | evalRetrieval | stub |
 | testFetchers | Test fetch utilities | unit | @todo | crrDiffVersions, crrDiffArticles | stub |
+| testFetchersHandlesDiffs | Ensure diff fetch utilities run without errors | test | @todo | crrDiffVersions, crrDiffArticles | placeholder |
+| testFineTuneResumePersistsState | Verify fine-tune resume persists training state | test | @todo | ftTrainEncoder | placeholder |
+| testFineTuneSmokeRunsEndToEnd | Run encoder fine-tuning end-to-end | test | @todo | ftBuildContrastiveDataset, ftTrainEncoder | placeholder |
+| testHybridSearchReturnsResults | Ensure hybrid search returns results | test | @todo | hybridSearch | placeholder |
+| testIngestAndChunkProcessesDocuments | Validate document ingestion and chunking pipeline | test | @todo | ingestPdfs, chunkText | placeholder |
+| testMetricsExpectedJSONMatchesSchema | Confirm metrics JSON matches expected schema | test | @todo | evalRetrieval | placeholder |
+| testPDFIngestReadsPdfs | Verify PDF ingestion reads provided files | test | @todo | ingestPdfs | placeholder |
+| testProjectionAutoloadPipelineLoadsHead | Ensure projection head autoloads correctly | test | @todo | trainProjectionHead | placeholder |
+| testProjectionHeadSimulatedTrainsHead | Check projection head training pathway | test | @todo | trainProjectionHead | placeholder |
+| testRegressionMetricsSimulatedComputesMetrics | Compute regression metrics on simulated data | test | @todo | trainMultilabel, evalPerLabel | placeholder |
+| testReportArtifactGeneratesReport | Generate evaluation report artifact | test | @todo | evalRetrieval | placeholder |
+| testRulesAndModelTrainsModel | Train weak rules and baseline model | test | @todo | weakRules, trainMultilabel | placeholder |
+| testGoldMetricsEvaluatesGold | Evaluate gold data metrics | test | @todo | loadGold, evalPerLabel | placeholder |
 
 ---
 

--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -8,7 +8,8 @@ function tests = testFetchers
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
+function testFetchersHandlesDiffs(testCase)
     reg.crrDiffVersions('', '');
     reg.crrDiffArticles('', '', '');
     testCase.assumeFail('Not implemented yet');

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -8,7 +8,8 @@ function tests = testFineTuneResume
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
+function testFineTuneResumePersistsState(testCase)
     reg.ftTrainEncoder(struct());
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -8,7 +8,8 @@ function tests = testFineTuneSmoke
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
+function testFineTuneSmokeRunsEndToEnd(testCase)
     reg.ftBuildContrastiveDataset(table(), []);
     reg.ftTrainEncoder(struct());
     testCase.assumeFail('Not implemented yet');

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -8,7 +8,8 @@ function tests = testGoldMetrics
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
+function testGoldMetricsEvaluatesGold(testCase)
     reg.loadGold('');
     reg.evalPerLabel([], []);
     testCase.assumeFail('Not implemented yet');

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -8,7 +8,8 @@ function tests = testHybridSearch
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
+function testHybridSearchReturnsResults(testCase)
     reg.hybridSearch('', [], table());
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -8,7 +8,8 @@ function tests = testIngestAndChunk
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
+function testIngestAndChunkProcessesDocuments(testCase)
     reg.ingestPdfs({});
     reg.chunkText(table(), 0, 0);
     testCase.assumeFail('Not implemented yet');

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -8,7 +8,8 @@ function tests = testMetricsExpectedJSON
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
+function testMetricsExpectedJSONMatchesSchema(testCase)
     reg.evalRetrieval(table(), table());
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -8,7 +8,8 @@ function tests = testPDFIngest
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
+function testPDFIngestReadsPdfs(testCase)
     reg.ingestPdfs({});
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -8,7 +8,8 @@ function tests = testProjectionAutoloadPipeline
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
+function testProjectionAutoloadPipelineLoadsHead(testCase)
     reg.trainProjectionHead([], []);
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -8,7 +8,8 @@ function tests = testProjectionHeadSimulated
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
+function testProjectionHeadSimulatedTrainsHead(testCase)
     reg.trainProjectionHead([], []);
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -8,7 +8,8 @@ function tests = testRegressionMetricsSimulated
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
+function testRegressionMetricsSimulatedComputesMetrics(testCase)
     reg.trainMultilabel([], []);
     reg.evalPerLabel([], []);
     testCase.assumeFail('Not implemented yet');

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -8,7 +8,8 @@ function tests = testReportArtifact
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
+function testReportArtifactGeneratesReport(testCase)
     reg.evalRetrieval(table(), table());
     testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -8,7 +8,8 @@ function tests = testRulesAndModel
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
+%TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
+function testRulesAndModelTrainsModel(testCase)
     reg.weakRules(table());
     reg.trainMultilabel([], []);
     testCase.assumeFail('Not implemented yet');


### PR DESCRIPTION
## Summary
- Replace `testPlaceholder` in regression tests with descriptive names like `testFetchersHandlesDiffs`
- Document new test identifiers in `docs/identifier_registry.md`

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b88b3663083308e8353eada35bc8a