### PR TITLE
Expand regression test coverage with minimal reg fixtures

### DIFF
--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -10,7 +10,22 @@ end
 
 %TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
 function testFetchersHandlesDiffs(testCase)
-    reg.crrDiffVersions('', '');
-    reg.crrDiffArticles('', '', '');
-    testCase.assumeFail('Not implemented yet');
+    [oldPathStr, newPathStr] = minimalVersionPaths();
+    diffStruct = reg.crrDiffVersions(oldPathStr, newPathStr);
+    testCase.verifyClass(diffStruct, 'struct');
+
+    [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs();
+    articleStruct = reg.crrDiffArticles(articleIdStr, versionAStr, versionBStr);
+    testCase.verifyClass(articleStruct, 'struct');
+end
+
+function [oldPathStr, newPathStr] = minimalVersionPaths()
+    oldPathStr = "";
+    newPathStr = "";
+end
+
+function [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs()
+    articleIdStr = "";
+    versionAStr = "";
+    versionBStr = "";
 end

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -10,6 +10,11 @@ end
 
 %TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
 function testFineTuneResumePersistsState(testCase)
-    reg.ftTrainEncoder(struct());
-    testCase.assumeFail('Not implemented yet');
+    dsStruct = minimalDatasetStruct();
+    encoderStruct = reg.ftTrainEncoder(dsStruct);
+    testCase.verifyClass(encoderStruct, 'struct');
+end
+
+function dsStruct = minimalDatasetStruct()
+    dsStruct = struct();
 end

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -10,7 +10,15 @@ end
 
 %TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
 function testFineTuneSmokeRunsEndToEnd(testCase)
-    reg.ftBuildContrastiveDataset(table(), []);
-    reg.ftTrainEncoder(struct());
-    testCase.assumeFail('Not implemented yet');
+    chunkTbl = minimalChunkTbl();
+    yMat = zeros(0, 0);
+    dsStruct = reg.ftBuildContrastiveDataset(chunkTbl, yMat);
+    testCase.verifyClass(dsStruct, 'struct');
+
+    encoderStruct = reg.ftTrainEncoder(dsStruct);
+    testCase.verifyClass(encoderStruct, 'struct');
+end
+
+function chunkTbl = minimalChunkTbl()
+    chunkTbl = table();
 end

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -10,7 +10,19 @@ end
 
 %TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
 function testGoldMetricsEvaluatesGold(testCase)
-    reg.loadGold('');
-    reg.evalPerLabel([], []);
-    testCase.assumeFail('Not implemented yet');
+    goldTbl = reg.loadGold(minimalGoldPath());
+    testCase.verifyClass(goldTbl, 'table');
+
+    [predYMat, trueYMat] = minimalLabelMats();
+    perLabelTbl = reg.evalPerLabel(predYMat, trueYMat);
+    testCase.verifyClass(perLabelTbl, 'table');
+end
+
+function goldPathStr = minimalGoldPath()
+    goldPathStr = "";
+end
+
+function [predYMat, trueYMat] = minimalLabelMats()
+    predYMat = zeros(0, 0);
+    trueYMat = zeros(0, 0);
 end

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -10,6 +10,13 @@ end
 
 %TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
 function testHybridSearchReturnsResults(testCase)
-    reg.hybridSearch('', [], table());
-    testCase.assumeFail('Not implemented yet');
+    [queryStr, xMat, docTbl] = minimalHybridInputs();
+    resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
+    testCase.verifyClass(resultsTbl, 'table');
+end
+
+function [queryStr, xMat, docTbl] = minimalHybridInputs()
+    queryStr = "";
+    xMat = zeros(0, 0);
+    docTbl = table();
 end

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -10,7 +10,14 @@ end
 
 %TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
 function testIngestAndChunkProcessesDocuments(testCase)
-    reg.ingestPdfs({});
-    reg.chunkText(table(), 0, 0);
-    testCase.assumeFail('Not implemented yet');
+    pdfPathsCell = minimalPdfPathsCell();
+    docTbl = reg.ingestPdfs(pdfPathsCell);
+    testCase.verifyClass(docTbl, 'table');
+
+    chunkTbl = reg.chunkText(docTbl, 0, 0);
+    testCase.verifyClass(chunkTbl, 'table');
+end
+
+function pdfPathsCell = minimalPdfPathsCell()
+    pdfPathsCell = {};
 end

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -10,6 +10,16 @@ end
 
 %TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
 function testMetricsExpectedJSONMatchesSchema(testCase)
-    reg.evalRetrieval(table(), table());
-    testCase.assumeFail('Not implemented yet');
+    resultsTbl = minimalResultsTbl();
+    goldTbl = minimalGoldTbl();
+    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
+    testCase.verifyClass(metricsStruct, 'struct');
+end
+
+function resultsTbl = minimalResultsTbl()
+    resultsTbl = table();
+end
+
+function goldTbl = minimalGoldTbl()
+    goldTbl = table();
 end

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -10,6 +10,11 @@ end
 
 %TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
 function testPDFIngestReadsPdfs(testCase)
-    reg.ingestPdfs({});
-    testCase.assumeFail('Not implemented yet');
+    pdfPathsCell = minimalPdfPathsCell();
+    docTbl = reg.ingestPdfs(pdfPathsCell);
+    testCase.verifyClass(docTbl, 'table');
+end
+
+function pdfPathsCell = minimalPdfPathsCell()
+    pdfPathsCell = {};
 end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -10,6 +10,12 @@ end
 
 %TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
 function testProjectionAutoloadPipelineLoadsHead(testCase)
-    reg.trainProjectionHead([], []);
-    testCase.assumeFail('Not implemented yet');
+    [xMat, yMat] = minimalTrainingMats();
+    headStruct = reg.trainProjectionHead(xMat, yMat);
+    testCase.verifyClass(headStruct, 'struct');
+end
+
+function [xMat, yMat] = minimalTrainingMats()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
 end

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -10,6 +10,12 @@ end
 
 %TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
 function testProjectionHeadSimulatedTrainsHead(testCase)
-    reg.trainProjectionHead([], []);
-    testCase.assumeFail('Not implemented yet');
+    [xMat, yMat] = minimalTrainingMats();
+    headStruct = reg.trainProjectionHead(xMat, yMat);
+    testCase.verifyClass(headStruct, 'struct');
+end
+
+function [xMat, yMat] = minimalTrainingMats()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
 end

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -10,7 +10,15 @@ end
 
 %TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
 function testRegressionMetricsSimulatedComputesMetrics(testCase)
-    reg.trainMultilabel([], []);
-    reg.evalPerLabel([], []);
-    testCase.assumeFail('Not implemented yet');
+    [xMat, yMat] = minimalTrainingData();
+    modelStruct = reg.trainMultilabel(xMat, yMat);
+    testCase.verifyClass(modelStruct, 'struct');
+
+    perLabelTbl = reg.evalPerLabel(xMat, yMat);
+    testCase.verifyClass(perLabelTbl, 'table');
+end
+
+function [xMat, yMat] = minimalTrainingData()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
 end

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -10,6 +10,16 @@ end
 
 %TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
 function testReportArtifactGeneratesReport(testCase)
-    reg.evalRetrieval(table(), table());
-    testCase.assumeFail('Not implemented yet');
+    resultsTbl = minimalResultsTbl();
+    goldTbl = minimalGoldTbl();
+    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
+    testCase.verifyClass(metricsStruct, 'struct');
+end
+
+function resultsTbl = minimalResultsTbl()
+    resultsTbl = table();
+end
+
+function goldTbl = minimalGoldTbl()
+    goldTbl = table();
 end

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -10,7 +10,20 @@ end
 
 %TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
 function testRulesAndModelTrainsModel(testCase)
-    reg.weakRules(table());
-    reg.trainMultilabel([], []);
-    testCase.assumeFail('Not implemented yet');
+    chunkTbl = minimalChunkTbl();
+    yBootMat = reg.weakRules(chunkTbl);
+    testCase.verifyTrue(issparse(yBootMat));
+
+    [xMat, yMat] = minimalTrainingData();
+    modelStruct = reg.trainMultilabel(xMat, yMat);
+    testCase.verifyClass(modelStruct, 'struct');
+end
+
+function chunkTbl = minimalChunkTbl()
+    chunkTbl = table();
+end
+
+function [xMat, yMat] = minimalTrainingData()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
 end


### PR DESCRIPTION
## Summary
- Replace `testCase.assumeFail` placeholders in regression tests with minimal fixtures
- Verify each `reg.*` stub returns the expected table or struct types

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b8fd3b59883309b8b607706541793