### PR TITLE
Add environment fixture to stabilize tests

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -46,6 +46,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 | Name | Purpose | Scope | Owner | Related Files | Notes |
 |------|---------|-------|-------|---------------|-------|
+| EnvironmentFixture | Manage MATLAB format, RNG, and GPU state for tests | test | @todo | tests/+fixtures/EnvironmentFixture.m | |
 
 ## Functions
 

--- a/tests/+fixtures/EnvironmentFixture.m
+++ b/tests/+fixtures/EnvironmentFixture.m
@@ -1,0 +1,39 @@
+%% NAME-REGISTRY:CLASS EnvironmentFixture
+classdef EnvironmentFixture < matlab.unittest.fixtures.Fixture
+    %ENVIRONMENTFIXTURE Fixture to control MATLAB global state during tests.
+
+    properties (Access = private)
+        formatStr
+        rngStruct
+        gpuDeviceObj
+        hasGpuLogical
+    end
+
+    methods
+        function setup(fixture)
+            % Save current state
+            fixture.formatStr = get(0, 'Format');
+            fixture.rngStruct = rng;
+            try
+                fixture.gpuDeviceObj = gpuDevice;
+                fixture.hasGpuLogical = true;
+                reset(fixture.gpuDeviceObj);
+            catch
+                fixture.hasGpuLogical = false;
+            end
+
+            % Modify environment state
+            format('short');
+            rng('default');
+        end
+
+        function teardown(fixture)
+            % Restore original state
+            format(fixture.formatStr);
+            rng(fixture.rngStruct);
+            if fixture.hasGpuLogical
+                gpuDevice(fixture.gpuDeviceObj.Index);
+            end
+        end
+    end
+end

--- a/tests/testFeatures.m
+++ b/tests/testFeatures.m
@@ -9,6 +9,7 @@ tests = functiontests(localfunctions);
 end
 
 function testEmbeddingOutputs(testCase)
+    testCase.applyFixture(fixtures.EnvironmentFixture);
     chunkTbl = table();
 
     xMat = reg.docEmbeddingsBertGpu(chunkTbl);


### PR DESCRIPTION
## Summary
- add `EnvironmentFixture` to reset numeric format, RNG, and GPU state for tests
- apply the fixture in `testFeatures` and register the class

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b8ffc6a708330b4cf1a5f5e3a26a2