### PR TITLE
fix: use settings API for numeric format in tests fixture

### DIFF
--- a/tests/+fixtures/EnvironmentFixture.m
+++ b/tests/+fixtures/EnvironmentFixture.m
@@ -12,7 +12,8 @@ classdef EnvironmentFixture < matlab.unittest.fixtures.Fixture
     methods
         function setup(fixture)
             % Save current state
-            fixture.formatStr = get(0, 'Format');
+            s = settings;
+            fixture.formatStr = s.matlab.commandwindow.NumericFormat.ActiveValue;
             fixture.rngStruct = rng;
             try
                 fixture.gpuDeviceObj = gpuDevice;
@@ -23,13 +24,14 @@ classdef EnvironmentFixture < matlab.unittest.fixtures.Fixture
             end
 
             % Modify environment state
-            format('short');
+            s.matlab.commandwindow.NumericFormat.TemporaryValue = 'short';
             rng('default');
         end
 
         function teardown(fixture)
             % Restore original state
-            format(fixture.formatStr);
+            s = settings;
+            s.matlab.commandwindow.NumericFormat.TemporaryValue = fixture.formatStr;
             rng(fixture.rngStruct);
             if fixture.hasGpuLogical
                 gpuDevice(fixture.gpuDeviceObj.Index);


### PR DESCRIPTION
## Summary
- Use MATLAB settings API to capture and restore numeric format
- Set temporary numeric format via settings during tests

## Testing
- `pre-commit run --files tests/+fixtures/EnvironmentFixture.m` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b945428348330a22c8c75dd48c695