### PR TITLE
chore: register test identifiers

### DIFF
--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -8,8 +8,9 @@ function tests = testFetchers
 tests = functiontests(localfunctions);
 end
 
-%TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
+%% NAME-REGISTRY:TEST testFetchersHandlesDiffs
 function testFetchersHandlesDiffs(testCase)
+%TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
     [oldPathStr, newPathStr] = minimalVersionPaths();
     diffStruct = reg.crrDiffVersions(oldPathStr, newPathStr);
     testCase.verifyClass(diffStruct, 'struct');

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -8,8 +8,9 @@ function tests = testFineTuneResume
 tests = functiontests(localfunctions);
 end
 
-%TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
+%% NAME-REGISTRY:TEST testFineTuneResumePersistsState
 function testFineTuneResumePersistsState(testCase)
+%TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
     dsStruct = minimalDatasetStruct();
     encoderStruct = reg.ftTrainEncoder(dsStruct);
     testCase.verifyClass(encoderStruct, 'struct');

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -8,8 +8,9 @@ function tests = testFineTuneSmoke
 tests = functiontests(localfunctions);
 end
 
-%TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
+%% NAME-REGISTRY:TEST testFineTuneSmokeRunsEndToEnd
 function testFineTuneSmokeRunsEndToEnd(testCase)
+%TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
     chunkTbl = minimalChunkTbl();
     yMat = zeros(0, 0);
     dsStruct = reg.ftBuildContrastiveDataset(chunkTbl, yMat);

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -8,8 +8,9 @@ function tests = testGoldMetrics
 tests = functiontests(localfunctions);
 end
 
-%TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
+%% NAME-REGISTRY:TEST testGoldMetricsEvaluatesGold
 function testGoldMetricsEvaluatesGold(testCase)
+%TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
     goldTbl = reg.loadGold(minimalGoldPath());
     testCase.verifyClass(goldTbl, 'table');
 

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -8,8 +8,9 @@ function tests = testHybridSearch
 tests = functiontests(localfunctions);
 end
 
-%TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
+%% NAME-REGISTRY:TEST testHybridSearchReturnsResults
 function testHybridSearchReturnsResults(testCase)
+%TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
     [queryStr, xMat, docTbl] = minimalHybridInputs();
     resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
     testCase.verifyClass(resultsTbl, 'table');

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -8,8 +8,9 @@ function tests = testIngestAndChunk
 tests = functiontests(localfunctions);
 end
 
-%TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
+%% NAME-REGISTRY:TEST testIngestAndChunkProcessesDocuments
 function testIngestAndChunkProcessesDocuments(testCase)
+%TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
 
   tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
   pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -8,8 +8,9 @@ function tests = testMetricsExpectedJSON
 tests = functiontests(localfunctions);
 end
 
-%TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
+%% NAME-REGISTRY:TEST testMetricsExpectedJSONMatchesSchema
 function testMetricsExpectedJSONMatchesSchema(testCase)
+%TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
     resultsTbl = minimalResultsTbl();
     goldTbl = minimalGoldTbl();
     metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -8,8 +8,9 @@ function tests = testPDFIngest
 tests = functiontests(localfunctions);
 end
 
-%TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
+%% NAME-REGISTRY:TEST testPDFIngestReadsPdfs
 function testPDFIngestReadsPdfs(testCase)
+%TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
 
   tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
   pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -8,8 +8,9 @@ function tests = testProjectionAutoloadPipeline
 tests = functiontests(localfunctions);
 end
 
-%TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
+%% NAME-REGISTRY:TEST testProjectionAutoloadPipelineLoadsHead
 function testProjectionAutoloadPipelineLoadsHead(testCase)
+%TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -8,8 +8,9 @@ function tests = testProjectionHeadSimulated
 tests = functiontests(localfunctions);
 end
 
-%TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
+%% NAME-REGISTRY:TEST testProjectionHeadSimulatedTrainsHead
 function testProjectionHeadSimulatedTrainsHead(testCase)
+%TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -8,8 +8,9 @@ function tests = testRegressionMetricsSimulated
 tests = functiontests(localfunctions);
 end
 
-%TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
+%% NAME-REGISTRY:TEST testRegressionMetricsSimulatedComputesMetrics
 function testRegressionMetricsSimulatedComputesMetrics(testCase)
+%TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
     [xMat, yMat] = minimalTrainingData();
     modelStruct = reg.trainMultilabel(xMat, yMat);
     testCase.verifyClass(modelStruct, 'struct');

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -8,8 +8,9 @@ function tests = testReportArtifact
 tests = functiontests(localfunctions);
 end
 
-%TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
+%% NAME-REGISTRY:TEST testReportArtifactGeneratesReport
 function testReportArtifactGeneratesReport(testCase)
+%TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
     resultsTbl = minimalResultsTbl();
     goldTbl = minimalGoldTbl();
     metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -8,8 +8,9 @@ function tests = testRulesAndModel
 tests = functiontests(localfunctions);
 end
 
-%TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
+%% NAME-REGISTRY:TEST testRulesAndModelTrainsModel
 function testRulesAndModelTrainsModel(testCase)
+%TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
     chunkTbl = minimalChunkTbl();
     yBootMat = reg.weakRules(chunkTbl);
     testCase.verifyTrue(issparse(yBootMat));


### PR DESCRIPTION
## Summary
- add NAME-REGISTRY tags above each test function to link tests with identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b977a420083308669436002ef1740