### PR TITLE
fix: allow startup without matlab project

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -5,8 +5,21 @@ function startup(project)
 % Adds all project folders to the path and enables common defaults
 % so helpers like reg.ftBuildContrastiveDataset are discoverable.
 
+    if nargin < 1
+        try
+            project = matlab.project.currentProject;
+        catch
+            project = [];
+        end
+    end
+    if isempty(project)
+        rootDir = fileparts(mfilename('fullpath'));
+    else
+        rootDir = project.RootFolder;
+    end
+
     % 1. Add entire repository (packages, tests, scripts) to path
-    repoRoot = project.RootFolder;
+    repoRoot = rootDir;
     addpath(genpath(repoRoot));
 
     % 2. Optional: persist path for non‑project sessions


### PR DESCRIPTION
## Summary
- support running `startup` without a MATLAB project by falling back to script directory
- use `rootDir` for path setup

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b98fc5a448330b349003d7c78b683