### PR TITLE
Mark placeholder MATLAB tests as incomplete

### DIFF
--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -8,25 +8,6 @@ function tests = testFetchers
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testFetchersHandlesDiffs
-function testFetchersHandlesDiffs(testCase)
-%TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
-    [oldPathStr, newPathStr] = minimalVersionPaths();
-    diffStruct = reg.crrDiffVersions(oldPathStr, newPathStr);
-    testCase.verifyClass(diffStruct, 'struct');
-
-    [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs();
-    articleStruct = reg.crrDiffArticles(articleIdStr, versionAStr, versionBStr);
-    testCase.verifyClass(articleStruct, 'struct');
-end
-
-function [oldPathStr, newPathStr] = minimalVersionPaths()
-    oldPathStr = "";
-    newPathStr = "";
-end
-
-function [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs()
-    articleIdStr = "";
-    versionAStr = "";
-    versionBStr = "";
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFetchersHandlesDiffs.m
+++ b/tests/testFetchersHandlesDiffs.m
@@ -1,0 +1,23 @@
+%% NAME-REGISTRY:TEST testFetchersHandlesDiffs
+function testFetchersHandlesDiffs(testCase)
+%TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
+    [oldPathStr, newPathStr] = minimalVersionPaths();
+    diffStruct = reg.crrDiffVersions(oldPathStr, newPathStr);
+    testCase.verifyClass(diffStruct, 'struct');
+
+    [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs();
+    articleStruct = reg.crrDiffArticles(articleIdStr, versionAStr, versionBStr);
+    testCase.verifyClass(articleStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function [oldPathStr, newPathStr] = minimalVersionPaths()
+    oldPathStr = "";
+    newPathStr = "";
+end
+
+function [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs()
+    articleIdStr = "";
+    versionAStr = "";
+    versionBStr = "";
+end

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -8,14 +8,6 @@ function tests = testFineTuneResume
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testFineTuneResumePersistsState
-function testFineTuneResumePersistsState(testCase)
-%TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
-    dsStruct = minimalDatasetStruct();
-    encoderStruct = reg.ftTrainEncoder(dsStruct);
-    testCase.verifyClass(encoderStruct, 'struct');
-end
-
-function dsStruct = minimalDatasetStruct()
-    dsStruct = struct();
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFineTuneResumePersistsState.m
+++ b/tests/testFineTuneResumePersistsState.m
@@ -1,0 +1,12 @@
+%% NAME-REGISTRY:TEST testFineTuneResumePersistsState
+function testFineTuneResumePersistsState(testCase)
+%TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
+    dsStruct = minimalDatasetStruct();
+    encoderStruct = reg.ftTrainEncoder(dsStruct);
+    testCase.verifyClass(encoderStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function dsStruct = minimalDatasetStruct()
+    dsStruct = struct();
+end

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -8,18 +8,6 @@ function tests = testFineTuneSmoke
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testFineTuneSmokeRunsEndToEnd
-function testFineTuneSmokeRunsEndToEnd(testCase)
-%TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
-    chunkTbl = minimalChunkTbl();
-    yMat = zeros(0, 0);
-    dsStruct = reg.ftBuildContrastiveDataset(chunkTbl, yMat);
-    testCase.verifyClass(dsStruct, 'struct');
-
-    encoderStruct = reg.ftTrainEncoder(dsStruct);
-    testCase.verifyClass(encoderStruct, 'struct');
-end
-
-function chunkTbl = minimalChunkTbl()
-    chunkTbl = table();
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testFineTuneSmokeRunsEndToEnd.m
+++ b/tests/testFineTuneSmokeRunsEndToEnd.m
@@ -1,0 +1,16 @@
+%% NAME-REGISTRY:TEST testFineTuneSmokeRunsEndToEnd
+function testFineTuneSmokeRunsEndToEnd(testCase)
+%TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
+    chunkTbl = minimalChunkTbl();
+    yMat = zeros(0, 0);
+    dsStruct = reg.ftBuildContrastiveDataset(chunkTbl, yMat);
+    testCase.verifyClass(dsStruct, 'struct');
+
+    encoderStruct = reg.ftTrainEncoder(dsStruct);
+    testCase.verifyClass(encoderStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function chunkTbl = minimalChunkTbl()
+    chunkTbl = table();
+end

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -8,22 +8,6 @@ function tests = testGoldMetrics
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testGoldMetricsEvaluatesGold
-function testGoldMetricsEvaluatesGold(testCase)
-%TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
-    goldTbl = reg.loadGold(minimalGoldPath());
-    testCase.verifyClass(goldTbl, 'table');
-
-    [predYMat, trueYMat] = minimalLabelMats();
-    perLabelTbl = reg.evalPerLabel(predYMat, trueYMat);
-    testCase.verifyClass(perLabelTbl, 'table');
-end
-
-function goldPathStr = minimalGoldPath()
-    goldPathStr = "";
-end
-
-function [predYMat, trueYMat] = minimalLabelMats()
-    predYMat = zeros(0, 0);
-    trueYMat = zeros(0, 0);
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testGoldMetricsEvaluatesGold.m
+++ b/tests/testGoldMetricsEvaluatesGold.m
@@ -1,0 +1,20 @@
+%% NAME-REGISTRY:TEST testGoldMetricsEvaluatesGold
+function testGoldMetricsEvaluatesGold(testCase)
+%TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
+    goldTbl = reg.loadGold(minimalGoldPath());
+    testCase.verifyClass(goldTbl, 'table');
+
+    [predYMat, trueYMat] = minimalLabelMats();
+    perLabelTbl = reg.evalPerLabel(predYMat, trueYMat);
+    testCase.verifyClass(perLabelTbl, 'table');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function goldPathStr = minimalGoldPath()
+    goldPathStr = "";
+end
+
+function [predYMat, trueYMat] = minimalLabelMats()
+    predYMat = zeros(0, 0);
+    trueYMat = zeros(0, 0);
+end

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -8,16 +8,6 @@ function tests = testHybridSearch
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testHybridSearchReturnsResults
-function testHybridSearchReturnsResults(testCase)
-%TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
-    [queryStr, xMat, docTbl] = minimalHybridInputs();
-    resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
-    testCase.verifyClass(resultsTbl, 'table');
-end
-
-function [queryStr, xMat, docTbl] = minimalHybridInputs()
-    queryStr = "";
-    xMat = zeros(0, 0);
-    docTbl = table();
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testHybridSearchReturnsResults.m
+++ b/tests/testHybridSearchReturnsResults.m
@@ -1,0 +1,14 @@
+%% NAME-REGISTRY:TEST testHybridSearchReturnsResults
+function testHybridSearchReturnsResults(testCase)
+%TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
+    [queryStr, xMat, docTbl] = minimalHybridInputs();
+    resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
+    testCase.verifyClass(resultsTbl, 'table');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function [queryStr, xMat, docTbl] = minimalHybridInputs()
+    queryStr = "";
+    xMat = zeros(0, 0);
+    docTbl = table();
+end

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -8,16 +8,6 @@ function tests = testIngestAndChunk
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testIngestAndChunkProcessesDocuments
-function testIngestAndChunkProcessesDocuments(testCase)
-%TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
-
-  tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
-  pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
-  fid = fopen(pdfPath, "w"); fclose(fid);
-  pdfPathsCell = {pdfPath};
-  reg.ingestPdfs(pdfPathsCell);
-  reg.chunkText(table(), 0, 0);
-  testCase.assumeFail('Not implemented yet');
-
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testIngestAndChunkProcessesDocuments.m
+++ b/tests/testIngestAndChunkProcessesDocuments.m
@@ -1,0 +1,13 @@
+%% NAME-REGISTRY:TEST testIngestAndChunkProcessesDocuments
+function testIngestAndChunkProcessesDocuments(testCase)
+%TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
+
+  tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+  pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
+  fid = fopen(pdfPath, "w"); fclose(fid);
+  pdfPathsCell = {pdfPath};
+  reg.ingestPdfs(pdfPathsCell);
+  reg.chunkText(table(), 0, 0);
+  testCase.assumeFail('Not implemented yet');
+
+end

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -8,19 +8,6 @@ function tests = testMetricsExpectedJSON
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testMetricsExpectedJSONMatchesSchema
-function testMetricsExpectedJSONMatchesSchema(testCase)
-%TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
-    resultsTbl = minimalResultsTbl();
-    goldTbl = minimalGoldTbl();
-    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
-    testCase.verifyClass(metricsStruct, 'struct');
-end
-
-function resultsTbl = minimalResultsTbl()
-    resultsTbl = table();
-end
-
-function goldTbl = minimalGoldTbl()
-    goldTbl = table();
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testMetricsExpectedJSONMatchesSchema.m
+++ b/tests/testMetricsExpectedJSONMatchesSchema.m
@@ -1,0 +1,17 @@
+%% NAME-REGISTRY:TEST testMetricsExpectedJSONMatchesSchema
+function testMetricsExpectedJSONMatchesSchema(testCase)
+%TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
+    resultsTbl = minimalResultsTbl();
+    goldTbl = minimalGoldTbl();
+    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
+    testCase.verifyClass(metricsStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function resultsTbl = minimalResultsTbl()
+    resultsTbl = table();
+end
+
+function goldTbl = minimalGoldTbl()
+    goldTbl = table();
+end

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -8,15 +8,6 @@ function tests = testPDFIngest
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testPDFIngestReadsPdfs
-function testPDFIngestReadsPdfs(testCase)
-%TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
-
-  tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
-  pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
-  fid = fopen(pdfPath, "w"); fclose(fid);
-  pdfPathsCell = {pdfPath};
-  reg.ingestPdfs(pdfPathsCell);
-  testCase.assumeFail('Not implemented yet');
-
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testPDFIngestReadsPdfs.m
+++ b/tests/testPDFIngestReadsPdfs.m
@@ -1,0 +1,12 @@
+%% NAME-REGISTRY:TEST testPDFIngestReadsPdfs
+function testPDFIngestReadsPdfs(testCase)
+%TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
+
+  tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
+  pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
+  fid = fopen(pdfPath, "w"); fclose(fid);
+  pdfPathsCell = {pdfPath};
+  reg.ingestPdfs(pdfPathsCell);
+  testCase.assumeFail('Not implemented yet');
+
+end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -8,15 +8,6 @@ function tests = testProjectionAutoloadPipeline
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testProjectionAutoloadPipelineLoadsHead
-function testProjectionAutoloadPipelineLoadsHead(testCase)
-%TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
-    [xMat, yMat] = minimalTrainingMats();
-    headStruct = reg.trainProjectionHead(xMat, yMat);
-    testCase.verifyClass(headStruct, 'struct');
-end
-
-function [xMat, yMat] = minimalTrainingMats()
-    xMat = zeros(0, 0);
-    yMat = zeros(0, 0);
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionAutoloadPipelineLoadsHead.m
+++ b/tests/testProjectionAutoloadPipelineLoadsHead.m
@@ -1,0 +1,13 @@
+%% NAME-REGISTRY:TEST testProjectionAutoloadPipelineLoadsHead
+function testProjectionAutoloadPipelineLoadsHead(testCase)
+%TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
+    [xMat, yMat] = minimalTrainingMats();
+    headStruct = reg.trainProjectionHead(xMat, yMat);
+    testCase.verifyClass(headStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function [xMat, yMat] = minimalTrainingMats()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
+end

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -8,15 +8,6 @@ function tests = testProjectionHeadSimulated
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testProjectionHeadSimulatedTrainsHead
-function testProjectionHeadSimulatedTrainsHead(testCase)
-%TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
-    [xMat, yMat] = minimalTrainingMats();
-    headStruct = reg.trainProjectionHead(xMat, yMat);
-    testCase.verifyClass(headStruct, 'struct');
-end
-
-function [xMat, yMat] = minimalTrainingMats()
-    xMat = zeros(0, 0);
-    yMat = zeros(0, 0);
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testProjectionHeadSimulatedTrainsHead.m
+++ b/tests/testProjectionHeadSimulatedTrainsHead.m
@@ -1,0 +1,13 @@
+%% NAME-REGISTRY:TEST testProjectionHeadSimulatedTrainsHead
+function testProjectionHeadSimulatedTrainsHead(testCase)
+%TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
+    [xMat, yMat] = minimalTrainingMats();
+    headStruct = reg.trainProjectionHead(xMat, yMat);
+    testCase.verifyClass(headStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function [xMat, yMat] = minimalTrainingMats()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
+end

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -8,18 +8,6 @@ function tests = testRegressionMetricsSimulated
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testRegressionMetricsSimulatedComputesMetrics
-function testRegressionMetricsSimulatedComputesMetrics(testCase)
-%TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
-    [xMat, yMat] = minimalTrainingData();
-    modelStruct = reg.trainMultilabel(xMat, yMat);
-    testCase.verifyClass(modelStruct, 'struct');
-
-    perLabelTbl = reg.evalPerLabel(xMat, yMat);
-    testCase.verifyClass(perLabelTbl, 'table');
-end
-
-function [xMat, yMat] = minimalTrainingData()
-    xMat = zeros(0, 0);
-    yMat = zeros(0, 0);
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRegressionMetricsSimulatedComputesMetrics.m
+++ b/tests/testRegressionMetricsSimulatedComputesMetrics.m
@@ -1,0 +1,16 @@
+%% NAME-REGISTRY:TEST testRegressionMetricsSimulatedComputesMetrics
+function testRegressionMetricsSimulatedComputesMetrics(testCase)
+%TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
+    [xMat, yMat] = minimalTrainingData();
+    modelStruct = reg.trainMultilabel(xMat, yMat);
+    testCase.verifyClass(modelStruct, 'struct');
+
+    perLabelTbl = reg.evalPerLabel(xMat, yMat);
+    testCase.verifyClass(perLabelTbl, 'table');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function [xMat, yMat] = minimalTrainingData()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
+end

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -8,19 +8,6 @@ function tests = testReportArtifact
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testReportArtifactGeneratesReport
-function testReportArtifactGeneratesReport(testCase)
-%TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
-    resultsTbl = minimalResultsTbl();
-    goldTbl = minimalGoldTbl();
-    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
-    testCase.verifyClass(metricsStruct, 'struct');
-end
-
-function resultsTbl = minimalResultsTbl()
-    resultsTbl = table();
-end
-
-function goldTbl = minimalGoldTbl()
-    goldTbl = table();
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testReportArtifactGeneratesReport.m
+++ b/tests/testReportArtifactGeneratesReport.m
@@ -1,0 +1,17 @@
+%% NAME-REGISTRY:TEST testReportArtifactGeneratesReport
+function testReportArtifactGeneratesReport(testCase)
+%TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
+    resultsTbl = minimalResultsTbl();
+    goldTbl = minimalGoldTbl();
+    metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
+    testCase.verifyClass(metricsStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function resultsTbl = minimalResultsTbl()
+    resultsTbl = table();
+end
+
+function goldTbl = minimalGoldTbl()
+    goldTbl = table();
+end

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -8,23 +8,6 @@ function tests = testRulesAndModel
 tests = functiontests(localfunctions);
 end
 
-%% NAME-REGISTRY:TEST testRulesAndModelTrainsModel
-function testRulesAndModelTrainsModel(testCase)
-%TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
-    chunkTbl = minimalChunkTbl();
-    yBootMat = reg.weakRules(chunkTbl);
-    testCase.verifyTrue(issparse(yBootMat));
-
-    [xMat, yMat] = minimalTrainingData();
-    modelStruct = reg.trainMultilabel(xMat, yMat);
-    testCase.verifyClass(modelStruct, 'struct');
-end
-
-function chunkTbl = minimalChunkTbl()
-    chunkTbl = table();
-end
-
-function [xMat, yMat] = minimalTrainingData()
-    xMat = zeros(0, 0);
-    yMat = zeros(0, 0);
+function testPlaceholder(testCase)
+    testCase.assumeFail('Not implemented yet');
 end

--- a/tests/testRulesAndModelTrainsModel.m
+++ b/tests/testRulesAndModelTrainsModel.m
@@ -1,0 +1,21 @@
+%% NAME-REGISTRY:TEST testRulesAndModelTrainsModel
+function testRulesAndModelTrainsModel(testCase)
+%TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
+    chunkTbl = minimalChunkTbl();
+    yBootMat = reg.weakRules(chunkTbl);
+    testCase.verifyTrue(issparse(yBootMat));
+
+    [xMat, yMat] = minimalTrainingData();
+    modelStruct = reg.trainMultilabel(xMat, yMat);
+    testCase.verifyClass(modelStruct, 'struct');
+    testCase.assumeFail('Not implemented yet');
+end
+
+function chunkTbl = minimalChunkTbl()
+    chunkTbl = table();
+end
+
+function [xMat, yMat] = minimalTrainingData()
+    xMat = zeros(0, 0);
+    yMat = zeros(0, 0);
+end


### PR DESCRIPTION
## Summary
- Flag all placeholder MATLAB tests with `assumeFail` so test runner reports them as incomplete
- Move placeholder test definitions into their own files and trim wrapper files to simple placeholders

## Testing
- `python3 scripts/check_identifier_registry.py`
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b9d3f34588330a29602e0fe61ef32