### PR TITLE
Add environment fixture and assertions for select tests

### DIFF
--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -1,6 +1,6 @@
 %% NAME-REGISTRY:TEST testFetchers
 function tests = testFetchers
-%TESTFETCHERS Placeholder tests for data fetch utilities.
+%TESTFETCHERS Tests for data fetch utilities.
 %
 % Outputs
 %   tests - handle to local tests
@@ -8,6 +8,14 @@ function tests = testFetchers
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+function testDiffFunctionsReturnStructs(testCase)
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
+    diffStruct = reg.crrDiffVersions("old", "new");
+    verifyClass(testCase, diffStruct, 'struct');
+    verifyNotEmpty(testCase, fieldnames(diffStruct));
+
+    articleStruct = reg.crrDiffArticles("1", "a", "b");
+    verifyClass(testCase, articleStruct, 'struct');
+    verifyNotEmpty(testCase, fieldnames(articleStruct));
 end

--- a/tests/testFetchersHandlesDiffs.m
+++ b/tests/testFetchersHandlesDiffs.m
@@ -1,23 +1,26 @@
 %% NAME-REGISTRY:TEST testFetchersHandlesDiffs
 function testFetchersHandlesDiffs(testCase)
 %TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
     [oldPathStr, newPathStr] = minimalVersionPaths();
     diffStruct = reg.crrDiffVersions(oldPathStr, newPathStr);
     testCase.verifyClass(diffStruct, 'struct');
+    testCase.verifyNotEmpty(fieldnames(diffStruct));
 
     [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs();
     articleStruct = reg.crrDiffArticles(articleIdStr, versionAStr, versionBStr);
     testCase.verifyClass(articleStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.verifyNotEmpty(fieldnames(articleStruct));
 end
 
 function [oldPathStr, newPathStr] = minimalVersionPaths()
-    oldPathStr = "";
-    newPathStr = "";
+    oldPathStr = "old";
+    newPathStr = "new";
 end
 
 function [articleIdStr, versionAStr, versionBStr] = minimalArticleInputs()
-    articleIdStr = "";
-    versionAStr = "";
-    versionBStr = "";
+    articleIdStr = "1";
+    versionAStr = "a";
+    versionBStr = "b";
 end

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -1,6 +1,6 @@
 %% NAME-REGISTRY:TEST testHybridSearch
 function tests = testHybridSearch
-%TESTHYBRIDSEARCH Placeholder tests for hybrid search module.
+%TESTHYBRIDSEARCH Tests for hybrid search module.
 %
 % Outputs
 %   tests - handle to local tests
@@ -8,6 +8,12 @@ function tests = testHybridSearch
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+function testReturnsResults(testCase)
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
+    queryStr = "query";
+    xMat = rand(1, 3);
+    docTbl = table("doc", 'VariableNames', "text");
+    resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
+    verifyGreaterThan(testCase, height(resultsTbl), 0);
 end

--- a/tests/testHybridSearchReturnsResults.m
+++ b/tests/testHybridSearchReturnsResults.m
@@ -1,14 +1,16 @@
 %% NAME-REGISTRY:TEST testHybridSearchReturnsResults
 function testHybridSearchReturnsResults(testCase)
 %TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
     [queryStr, xMat, docTbl] = minimalHybridInputs();
     resultsTbl = reg.hybridSearch(queryStr, xMat, docTbl);
     testCase.verifyClass(resultsTbl, 'table');
-    testCase.assumeFail('Not implemented yet');
+    testCase.verifyGreaterThan(height(resultsTbl), 0);
 end
 
 function [queryStr, xMat, docTbl] = minimalHybridInputs()
-    queryStr = "";
-    xMat = zeros(0, 0);
-    docTbl = table();
+    queryStr = "query";
+    xMat = rand(1, 3);
+    docTbl = table("doc", 'VariableNames', "text");
 end

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -1,6 +1,6 @@
 %% NAME-REGISTRY:TEST testReportArtifact
 function tests = testReportArtifact
-%TESTREPORTARTIFACT Placeholder tests for report generation.
+%TESTREPORTARTIFACT Tests for report generation.
 %
 % Outputs
 %   tests - handle to local tests
@@ -8,6 +8,12 @@ function tests = testReportArtifact
 tests = functiontests(localfunctions);
 end
 
-function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+function testGeneratesFile(testCase)
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
+    resultsTbl = table("doc", 'VariableNames', "document");
+    goldTbl = table("doc", 'VariableNames', "document");
+    reportPathStr = fullfile(tempdir, "report.html");
+    reg.reportArtifact(resultsTbl, goldTbl, reportPathStr);
+    verifyTrue(testCase, isfile(reportPathStr));
 end

--- a/tests/testReportArtifactGeneratesReport.m
+++ b/tests/testReportArtifactGeneratesReport.m
@@ -1,17 +1,19 @@
 %% NAME-REGISTRY:TEST testReportArtifactGeneratesReport
 function testReportArtifactGeneratesReport(testCase)
 %TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
+    import tests.fixtures.EnvironmentFixture
+    testCase.applyFixture(EnvironmentFixture);
     resultsTbl = minimalResultsTbl();
     goldTbl = minimalGoldTbl();
     metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
     testCase.verifyClass(metricsStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.verifyNotEmpty(fieldnames(metricsStruct));
 end
 
 function resultsTbl = minimalResultsTbl()
-    resultsTbl = table();
+    resultsTbl = table("doc", 'VariableNames', "document");
 end
 
 function goldTbl = minimalGoldTbl()
-    goldTbl = table();
+    goldTbl = table("doc", 'VariableNames', "document");
 end


### PR DESCRIPTION
## Summary
- use EnvironmentFixture to manage global state in hybrid search, report, and fetcher tests
- add basic assertions to exercise hybrid search, report generation, and diff fetch utilities

## Testing
- `matlab -batch "runtests('tests/testHybridSearchReturnsResults')"` *(fails: command not found)*
- `pre-commit run --files tests/testFetchers.m tests/testFetchersHandlesDiffs.m tests/testHybridSearch.m tests/testHybridSearchReturnsResults.m tests/testReportArtifact.m tests/testReportArtifactGeneratesReport.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bb7e864ac83309979451ecfc88531