### PR TITLE
Add setSeeds utility function

### DIFF
--- a/+reg/setSeeds.m
+++ b/+reg/setSeeds.m
@@ -1,0 +1,28 @@
+function setSeeds(seed)
+%SETSEEDS Set random seeds for reproducibility.
+%
+% Inputs
+%   seed (1,1 double) integer seed value
+%
+% Side Effects
+%   Initializes MATLAB RNG and GPU RNG (if available).
+%
+%% NAME-REGISTRY:FUNCTION setSeeds
+
+arguments
+  seed (1,1) double {mustBeInteger}
+end
+
+assert(seed >= 0, "setSeeds:NegativeSeed", "Seed must be non-negative");
+
+rng(seed, "twister");
+
+haveGpurng = (exist("gpurng", "file") == 2);
+haveGpu = haveGpurng && (gpuDeviceCount > 0);
+
+if haveGpu
+  gpurng(seed, "Philox4x32-10");
+else
+  warning("setSeeds:NoGPU", "GPU not available; skipping gpurng");
+end
+end

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -70,6 +70,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | crrDiffVersions | Compare CRR versions | module | `oldPathStr` string, `newPathStr` string | diff struct | @todo | stub |
 | crrDiffArticles | Compare CRR articles | module | `articleId` string, `versionA` string, `versionB` string | diff struct | @todo | stub |
 | run_mlint | Run MATLAB code analyzer on repository | module | none | none | @todo | errors on lint |
+| setSeeds | Set RNG and GPU seeds | module | `seed` integer scalar | none | @todo | |
 
 
 ## Function Interface Reference
@@ -95,6 +96,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.crrSync | none | none | downloads corpus to `data/raw` |
 | reg.crrDiffVersions | `vA` string, `vB` string | diff struct | none |
 | reg.crrDiffReport | none | none | writes HTML/PDF summaries |
+| reg.setSeeds | seed double | none | sets RNG and GPU seeds |
 | runtests | testFolder string, IncludeSubfolders logical, UseParallel logical | results table | executes test suite |
 
 


### PR DESCRIPTION
## Summary
- Add `reg.setSeeds` to initialize CPU and GPU RNGs
- Document `setSeeds` in the identifier registry

## Testing
- `matlab -batch "runtests"` *(command failed: `bash: command not found: matlab`)*

------
https://chatgpt.com/codex/tasks/task_b_689bb96a349083308bd926d50bbd5c8a