### PR TITLE
Add crrSync stub and register identifier

### DIFF
--- a/+reg/crrSync.m
+++ b/+reg/crrSync.m
@@ -1,0 +1,22 @@
+function crrSync(sourceUrl, destFolder)
+%CRRSYNC Synchronize the Code of Federal Regulations corpus.
+%
+%  crrSync(SOURCEURL, DESTFOLDER) is a placeholder function that currently
+%  performs no operations. It reserves the identifier and will eventually
+%  download the corpus from SOURCEURL into DESTFOLDER.
+%
+% Inputs
+%  sourceUrl  string or char: URL of the CRR source
+%  destFolder string or char: destination folder for the corpus
+%
+% Outputs
+%  none
+%
+%% NAME-REGISTRY:FUNCTION crrSync
+
+assert(isstring(sourceUrl) || ischar(sourceUrl))
+assert(isstring(destFolder) || ischar(destFolder))
+
+% No operation performed.
+end
+

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -67,6 +67,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
 | loadGold | Load gold annotation data | module | `pathStr` string | `goldTbl` table | @todo | stub |
+| crrSync | Synchronize the CRR corpus | module | `sourceUrl` string, `destFolder` string | none | @todo | no-op |
 | crrDiffVersions | Compare CRR versions | module | `oldPathStr` string, `newPathStr` string | diff struct | @todo | stub |
 | crrDiffArticles | Compare CRR articles | module | `articleId` string, `versionA` string, `versionB` string | diff struct | @todo | stub |
 | run_mlint | Run MATLAB code analyzer on repository | module | none | none | @todo | errors on lint |
@@ -92,7 +93,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
 | reg.evalPerLabel | predYMat matrix, trueYMat matrix | metrics table | none |
-| reg.crrSync | none | none | downloads corpus to `data/raw` |
+| reg.crrSync | sourceUrl string, destFolder string | none | downloads corpus to destFolder |
 | reg.crrDiffVersions | `vA` string, `vB` string | diff struct | none |
 | reg.crrDiffReport | none | none | writes HTML/PDF summaries |
 | runtests | testFolder string, IncludeSubfolders logical, UseParallel logical | results table | executes test suite |


### PR DESCRIPTION
## Summary
- add placeholder `reg.crrSync` function accepting `sourceUrl` and `destFolder`
- register `crrSync` in identifier registry

## Testing
- `matlab -batch "runtests"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bb96b5854833085bee7feb0c0d5a3