### PR TITLE
tag tests per style guide

### DIFF
--- a/tests/testFeatures.m
+++ b/tests/testFeatures.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testFeatures
 function tests = testFeatures
 %TESTFEATURES Tests for embedding generation.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Unit'}; % testEmbeddingOutputs
 end
 
 function testEmbeddingOutputs(testCase)

--- a/tests/testFetchers.m
+++ b/tests/testFetchers.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testFetchers
 function tests = testFetchers
 %TESTFETCHERS Tests for data fetch utilities.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Unit'}; % testDiffFunctionsReturnStructs
 end
 
 function testDiffFunctionsReturnStructs(testCase)

--- a/tests/testFetchersHandlesDiffs.m
+++ b/tests/testFetchersHandlesDiffs.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testFetchersHandlesDiffs
-function testFetchersHandlesDiffs(testCase)
+function tests = testFetchersHandlesDiffs
 %TESTFETCHERSHANDLESDIFFS Ensure diff fetch utilities run without errors.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testHandlesDiffs
+end
+
+function testHandlesDiffs(testCase)
     import tests.fixtures.EnvironmentFixture
     testCase.applyFixture(EnvironmentFixture);
     [oldPathStr, newPathStr] = minimalVersionPaths();

--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testFineTuneResume
 function tests = testFineTuneResume
 %TESTFINETUNERESUME Placeholder tests for encoder fine-tuning resume.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testFineTuneResumePersistsState.m
+++ b/tests/testFineTuneResumePersistsState.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testFineTuneResumePersistsState
-function testFineTuneResumePersistsState(testCase)
+function tests = testFineTuneResumePersistsState
 %TESTFINETUNERESUMEPERSISTSSTATE Verify fine-tune resume persists training state.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testPersistsState
+end
+
+function testPersistsState(testCase)
     dsStruct = minimalDatasetStruct();
     encoderStruct = reg.ftTrainEncoder(dsStruct);
     testCase.verifyClass(encoderStruct, 'struct');

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testFineTuneSmoke
 function tests = testFineTuneSmoke
 %TESTFINETUNESMOKE Placeholder tests for encoder fine-tuning smoke test.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testFineTuneSmokeRunsEndToEnd.m
+++ b/tests/testFineTuneSmokeRunsEndToEnd.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testFineTuneSmokeRunsEndToEnd
-function testFineTuneSmokeRunsEndToEnd(testCase)
+function tests = testFineTuneSmokeRunsEndToEnd
 %TESTFINETUNESMOKERUNSENDTOEND Run encoder fine-tuning end-to-end.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testRunsEndToEnd
+end
+
+function testRunsEndToEnd(testCase)
     chunkTbl = minimalChunkTbl();
     yMat = zeros(0, 0);
     dsStruct = reg.ftBuildContrastiveDataset(chunkTbl, yMat);

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testGoldMetrics
 function tests = testGoldMetrics
 %TESTGOLDMETRICS Placeholder tests for gold data metrics.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testGoldMetricsEvaluatesGold.m
+++ b/tests/testGoldMetricsEvaluatesGold.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testGoldMetricsEvaluatesGold
-function testGoldMetricsEvaluatesGold(testCase)
+function tests = testGoldMetricsEvaluatesGold
 %TESTGOLDMETRICSEVALUATESGOLD Evaluate gold data metrics.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testEvaluatesGold
+end
+
+function testEvaluatesGold(testCase)
     goldTbl = reg.loadGold(minimalGoldPath());
     testCase.verifyClass(goldTbl, 'table');
 

--- a/tests/testHybridSearch.m
+++ b/tests/testHybridSearch.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testHybridSearch
 function tests = testHybridSearch
 %TESTHYBRIDSEARCH Tests for hybrid search module.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Unit'}; % testReturnsResults
 end
 
 function testReturnsResults(testCase)

--- a/tests/testHybridSearchReturnsResults.m
+++ b/tests/testHybridSearchReturnsResults.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testHybridSearchReturnsResults
-function testHybridSearchReturnsResults(testCase)
+function tests = testHybridSearchReturnsResults
 %TESTHYBRIDSEARCHRETURNSRESULTS Ensure hybrid search returns results.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Unit'}; % testReturnsResults
+end
+
+function testReturnsResults(testCase)
     import tests.fixtures.EnvironmentFixture
     testCase.applyFixture(EnvironmentFixture);
     [queryStr, xMat, docTbl] = minimalHybridInputs();

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testIngestAndChunk
 function tests = testIngestAndChunk
 %TESTINGESTANDCHUNK Placeholder tests for ingest and chunk modules.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testIngestAndChunkProcessesDocuments.m
+++ b/tests/testIngestAndChunkProcessesDocuments.m
@@ -1,7 +1,16 @@
 %% NAME-REGISTRY:TEST testIngestAndChunkProcessesDocuments
-function testIngestAndChunkProcessesDocuments(testCase)
+function tests = testIngestAndChunkProcessesDocuments
 %TESTINGESTANDCHUNKPROCESSESDOCUMENTS Validate document ingestion and chunking pipeline.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testProcessesDocuments
+end
 
+function testProcessesDocuments(testCase)
   tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
   pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
   fid = fopen(pdfPath, "w"); fclose(fid);
@@ -9,5 +18,4 @@ function testIngestAndChunkProcessesDocuments(testCase)
   reg.ingestPdfs(pdfPathsCell);
   reg.chunkText(table(), 0, 0);
   testCase.assumeFail('Not implemented yet');
-
 end

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testMetricsExpectedJSON
 function tests = testMetricsExpectedJSON
 %TESTMETRICSEXPECTEDJSON Placeholder tests for metrics JSON comparison.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Regression'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testMetricsExpectedJSONMatchesSchema.m
+++ b/tests/testMetricsExpectedJSONMatchesSchema.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testMetricsExpectedJSONMatchesSchema
-function testMetricsExpectedJSONMatchesSchema(testCase)
+function tests = testMetricsExpectedJSONMatchesSchema
 %TESTMETRICSEXPECTEDJSONMATCHESSCHEMA Confirm metrics JSON matches expected schema.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Regression'}; % testMatchesSchema
+end
+
+function testMatchesSchema(testCase)
     resultsTbl = minimalResultsTbl();
     goldTbl = minimalGoldTbl();
     metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testPDFIngest
 function tests = testPDFIngest
 %TESTPDFINGEST Placeholder tests for PDF ingestion module.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testPDFIngestReadsPdfs.m
+++ b/tests/testPDFIngestReadsPdfs.m
@@ -1,12 +1,20 @@
 %% NAME-REGISTRY:TEST testPDFIngestReadsPdfs
-function testPDFIngestReadsPdfs(testCase)
+function tests = testPDFIngestReadsPdfs
 %TESTPDFINGESTREADSPDFS Verify PDF ingestion reads provided files.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testReadsPdfs
+end
 
+function testReadsPdfs(testCase)
   tmpFolderFixture = testCase.applyFixture(matlab.unittest.fixtures.TemporaryFolderFixture);
   pdfPath = fullfile(tmpFolderFixture.Folder, "dummy.pdf");
   fid = fopen(pdfPath, "w"); fclose(fid);
   pdfPathsCell = {pdfPath};
   reg.ingestPdfs(pdfPathsCell);
   testCase.assumeFail('Not implemented yet');
-
 end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testProjectionAutoloadPipeline
 function tests = testProjectionAutoloadPipeline
 %TESTPROJECTIONAUTOLOADPIPELINE Placeholder tests for projection head autoloading.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testProjectionAutoloadPipelineLoadsHead.m
+++ b/tests/testProjectionAutoloadPipelineLoadsHead.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testProjectionAutoloadPipelineLoadsHead
-function testProjectionAutoloadPipelineLoadsHead(testCase)
+function tests = testProjectionAutoloadPipelineLoadsHead
 %TESTPROJECTIONAUTOLOADPIPELINELOADSHEAD Ensure projection head autoloads correctly.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testLoadsHead
+end
+
+function testLoadsHead(testCase)
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testProjectionHeadSimulated
 function tests = testProjectionHeadSimulated
 %TESTPROJECTIONHEADSIMULATED Placeholder tests for projection head training.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testProjectionHeadSimulatedTrainsHead.m
+++ b/tests/testProjectionHeadSimulatedTrainsHead.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testProjectionHeadSimulatedTrainsHead
-function testProjectionHeadSimulatedTrainsHead(testCase)
+function tests = testProjectionHeadSimulatedTrainsHead
 %TESTPROJECTIONHEADSIMULATEDTRAINSHEAD Check projection head training pathway.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testTrainsHead
+end
+
+function testTrainsHead(testCase)
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testRegressionMetricsSimulated
 function tests = testRegressionMetricsSimulated
 %TESTREGRESSIONMETRICSSIMULATED Placeholder tests for regression metrics.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Regression'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testRegressionMetricsSimulatedComputesMetrics.m
+++ b/tests/testRegressionMetricsSimulatedComputesMetrics.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testRegressionMetricsSimulatedComputesMetrics
-function testRegressionMetricsSimulatedComputesMetrics(testCase)
+function tests = testRegressionMetricsSimulatedComputesMetrics
 %TESTREGRESSIONMETRICSSIMULATEDCOMPUTESMETRICS Compute regression metrics on simulated data.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Regression'}; % testComputesMetrics
+end
+
+function testComputesMetrics(testCase)
     [xMat, yMat] = minimalTrainingData();
     modelStruct = reg.trainMultilabel(xMat, yMat);
     testCase.verifyClass(modelStruct, 'struct');

--- a/tests/testReportArtifact.m
+++ b/tests/testReportArtifact.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testReportArtifact
 function tests = testReportArtifact
 %TESTREPORTARTIFACT Tests for report generation.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testGeneratesFile
 end
 
 function testGeneratesFile(testCase)

--- a/tests/testReportArtifactGeneratesReport.m
+++ b/tests/testReportArtifactGeneratesReport.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testReportArtifactGeneratesReport
-function testReportArtifactGeneratesReport(testCase)
+function tests = testReportArtifactGeneratesReport
 %TESTREPORTARTIFACTGENERATESREPORT Generate evaluation report artifact.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testGeneratesReport
+end
+
+function testGeneratesReport(testCase)
     import tests.fixtures.EnvironmentFixture
     testCase.applyFixture(EnvironmentFixture);
     resultsTbl = minimalResultsTbl();

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -1,11 +1,13 @@
 %% NAME-REGISTRY:TEST testRulesAndModel
 function tests = testRulesAndModel
 %TESTRULESANDMODEL Placeholder tests for weak rules and model training.
+%   Each local test must assign Tags per the test style guide.
 %
 % Outputs
 %   tests - handle to local tests
-
+%
 tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)

--- a/tests/testRulesAndModelTrainsModel.m
+++ b/tests/testRulesAndModelTrainsModel.m
@@ -1,6 +1,16 @@
 %% NAME-REGISTRY:TEST testRulesAndModelTrainsModel
-function testRulesAndModelTrainsModel(testCase)
+function tests = testRulesAndModelTrainsModel
 %TESTRULESANDMODELTRAINSMODEL Train weak rules and baseline model.
+%   Each local test must assign Tags per the test style guide.
+%
+% Outputs
+%   tests - handle to local tests
+%
+tests = functiontests(localfunctions);
+tests(1).Tags = {'Integration'}; % testTrainsModel
+end
+
+function testTrainsModel(testCase)
     chunkTbl = minimalChunkTbl();
     yBootMat = reg.weakRules(chunkTbl);
     testCase.verifyTrue(issparse(yBootMat));


### PR DESCRIPTION
## Summary
- annotate all MATLAB tests with Unit/Smoke/Integration/Regression tags
- add header comments reminding authors to tag new tests

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bbda20ffc83308121a0c56f1fa633