### PR TITLE
Rename root scripts to lowerCamelCase

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -143,6 +143,13 @@ Keep the illustrative examples below in sync with the current naming conventions
 | run_mlint.m | Lint MATLAB files | run_mlint | @todo | errors on lint |
 | startup.m | Initialize project paths and defaults | startup | @todo | |
 | shutdown.m | Remove project paths and restore defaults | shutdown | @todo | |
+| regPipeline.m | Orchestrate end-to-end workflow | regPipeline | @todo | stub |
+| regProjectionWorkflow.m | Train projection head | regProjectionWorkflow | @todo | stub |
+| regFineTuneEncoderWorkflow.m | Fine-tune encoder with contrastive loss | regFineTuneEncoderWorkflow | @todo | stub |
+| regEvalAndReport.m | Evaluate models and generate reports | regEvalAndReport | @todo | stub |
+| regEvalGold.m | Evaluate metrics on gold dataset | regEvalGold | @todo | stub |
+| regCrrDiffReport.m | Produce PDF diff report for CRR versions | regCrrDiffReport | @todo | stub |
+| regCrrDiffReportHtml.m | Produce HTML diff report for CRR versions | regCrrDiffReportHtml | @todo | stub |
 
 
 

--- a/regCrrDiffReport.m
+++ b/regCrrDiffReport.m
@@ -1,0 +1,5 @@
+%% regCrrDiffReport
+% NAME-REGISTRY:FILE regCrrDiffReport
+%
+% Generate PDF diff report for CRR versions.
+% TODO: implement diff reporting.

--- a/regCrrDiffReportHtml.m
+++ b/regCrrDiffReportHtml.m
@@ -1,0 +1,5 @@
+%% regCrrDiffReportHtml
+% NAME-REGISTRY:FILE regCrrDiffReportHtml
+%
+% Generate HTML diff report for CRR versions.
+% TODO: implement diff reporting.

--- a/regEvalAndReport.m
+++ b/regEvalAndReport.m
@@ -1,0 +1,5 @@
+%% regEvalAndReport
+% NAME-REGISTRY:FILE regEvalAndReport
+%
+% Evaluate models and generate reports.
+% TODO: implement evaluation logic.

--- a/regEvalGold.m
+++ b/regEvalGold.m
@@ -1,0 +1,5 @@
+%% regEvalGold
+% NAME-REGISTRY:FILE regEvalGold
+%
+% Evaluate model metrics on gold data.
+% TODO: implement gold evaluation logic.

--- a/regFineTuneEncoderWorkflow.m
+++ b/regFineTuneEncoderWorkflow.m
@@ -1,0 +1,5 @@
+%% regFineTuneEncoderWorkflow
+% NAME-REGISTRY:FILE regFineTuneEncoderWorkflow
+%
+% Workflow script for fine-tuning the encoder.
+% TODO: implement workflow.

--- a/regPipeline.m
+++ b/regPipeline.m
@@ -1,0 +1,5 @@
+%% regPipeline
+% NAME-REGISTRY:FILE regPipeline
+%
+% Entry point for the RegClassifier end-to-end pipeline.
+% TODO: implement pipeline logic.

--- a/regProjectionWorkflow.m
+++ b/regProjectionWorkflow.m
@@ -1,0 +1,5 @@
+%% regProjectionWorkflow
+% NAME-REGISTRY:FILE regProjectionWorkflow
+%
+% Workflow script for training the projection head.
+% TODO: implement workflow.


### PR DESCRIPTION
## Summary
- add lowerCamelCase entry scripts (regPipeline, regProjectionWorkflow, regFineTuneEncoderWorkflow, regEvalAndReport, regEvalGold, regCrrDiffReport, regCrrDiffReportHtml)
- register new script names in identifier registry

## Testing
- `python scripts/check_identifier_registry.py`
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bbe9ac7e08330b5dc2fa92e801769