### PR TITLE
feat: add configuration loader

### DIFF
--- a/config.m
+++ b/config.m
@@ -1,0 +1,59 @@
+function configStruct = config()
+%CONFIG Load configuration from JSON files with overrides.
+%
+% Outputs
+%   configStruct (1,1 struct): merged configuration settings
+%
+%% NAME-REGISTRY:FUNCTION config
+
+% jsonFilesCell (1x3 cell): configuration files in precedence order
+jsonFilesCell = {'pipeline.json', 'knobs.json', 'params.json'};
+% configStruct (1x1 struct): merged configuration settings
+configStruct = struct();
+
+for idx = 1:numel(jsonFilesCell)
+  fileNameStr = jsonFilesCell{idx};
+  if exist(fileNameStr, 'file') == 2
+    try
+      fileTextStr = fileread(fileNameStr);
+      fileStruct = jsondecode(fileTextStr);
+      assert(isstruct(fileStruct), ...
+        'File %s must decode to a struct.', fileNameStr);
+      configStruct = mergeStructs(configStruct, fileStruct);
+    catch err
+      warning('Could not process %s: %s', fileNameStr, err.message);
+    end
+  else
+    warning('Missing configuration file: %s', fileNameStr);
+  end
+end
+
+assert(~isempty(fieldnames(configStruct)), ...
+  'configStruct is empty after reading JSON files.');
+
+try
+  reg.validateKnobs(configStruct);
+catch err
+  warning('validateKnobs failed: %s', err.message);
+end
+
+end
+
+function outStruct = mergeStructs(baseStruct, overrideStruct)
+%MERGESTRUCTS Merge two structs with override precedence.
+%
+% Inputs
+%   baseStruct (1,1 struct): base configuration
+%   overrideStruct (1,1 struct): values to override
+%
+% Outputs
+%   outStruct (1,1 struct): merged configuration
+
+outStruct = baseStruct;
+fieldsCell = fieldnames(overrideStruct);
+for idx = 1:numel(fieldsCell)
+  fieldStr = fieldsCell{idx};
+  outStruct.(fieldStr) = overrideStruct.(fieldStr);
+end
+
+end

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -52,6 +52,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 | Name | Purpose | Scope | Input Contract | Output Contract | Owner | Notes |
 |------|---------|-------|----------------|-----------------|-------|------|
+| config | Load configuration from JSON files | module | none | `configStruct` struct | @todo | |
 | startup | RegClassifier project initialization | module | `project` object | none | @todo | |
 | shutdown | RegClassifier project cleanup | module | project object | none | @todo | |
 | ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
@@ -79,7 +80,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 | Function | Parameters | Returns | Side Effects |
 |----------|------------|---------|--------------|
-| config | none | struct of settings from JSON files | reads configuration files |
+| config | none | `configStruct` struct | reads configuration files |
 | startup | project object | none | adds repo paths, sets defaults |
 | shutdown | project object | none | removes repo paths, restores defaults |
 | reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |


### PR DESCRIPTION
## Summary
- add `config` function to load JSON knob files and merge overrides
- register `config` in identifier registry

## Testing
- `pre-commit run --files config.m docs/identifier_registry.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc18c44c48330bd95794350371b30