### PR TITLE
Add crrDiffReport no-op and register identifier

### DIFF
--- a/+reg/crrDiffReport.m
+++ b/+reg/crrDiffReport.m
@@ -1,0 +1,20 @@
+function outPathStr = crrDiffReport(diffStruct)
+%CRRDIFFREPORT Generate placeholder report for CRR diffs.
+%   outPathStr = crrDiffReport(diffStruct) returns the path to a placeholder
+%   report file summarizing differences in the CRR corpus.
+%
+% Inputs
+%   diffStruct (struct, optional): diff details.
+%
+% Outputs
+%   outPathStr (string): path to the generated report (placeholder).
+%
+%% NAME-REGISTRY:FUNCTION crrDiffReport
+if nargin < 1
+  diffStruct = struct();
+end
+assert(isstruct(diffStruct), 'diffStruct must be a struct.');
+
+outPathStr = string(fullfile(tempdir, 'crr_diff_report_placeholder.txt'));
+warning('crrDiffReport:noOp', 'crrDiffReport is a no-op.');
+end

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -70,6 +70,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | crrSync | Synchronize the CRR corpus | module | `sourceUrl` string, `destFolder` string | none | @todo | no-op |
 | crrDiffVersions | Compare CRR versions | module | `oldPathStr` string, `newPathStr` string | diff struct | @todo | stub |
 | crrDiffArticles | Compare CRR articles | module | `articleId` string, `versionA` string, `versionB` string | diff struct | @todo | stub |
+| crrDiffReport | Summarize CRR diffs | module | `diffStruct` struct (optional) | `outPathStr` string | @todo | no-op |
 | validateKnobs | Validate knobs struct | module | `knobsStruct` struct | none | @todo | stub |
 | run_mlint | Run MATLAB code analyzer on repository | module | none | none | @todo | errors on lint |
 | setSeeds | Set RNG and GPU seeds | module | `seed` integer scalar | none | @todo | |
@@ -139,6 +140,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | loadGold.m | Load gold annotation data | loadGold | @todo | stub |
 | crrDiffVersions.m | Compare CRR versions | crrDiffVersions | @todo | stub |
 | crrDiffArticles.m | Compare CRR articles | crrDiffArticles | @todo | stub |
+| crrDiffReport.m | Summarize CRR diffs | crrDiffReport | @todo | no-op |
 | validateKnobs.m | Validate knobs struct | validateKnobs | @todo | stub |
 | run_mlint.m | Lint MATLAB files | run_mlint | @todo | errors on lint |
 | startup.m | Initialize project paths and defaults | startup | @todo | |


### PR DESCRIPTION
## Summary
- add no-op `crrDiffReport` function that validates input and returns a placeholder report path
- register `crrDiffReport` in identifier registry under Functions and Files/Modules

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc19a216c8330840b578b8d5aa79e