### PR TITLE
Replace assumeFail with fatalAssertFail in placeholder tests

### DIFF
--- a/tests/testFineTuneResume.m
+++ b/tests/testFineTuneResume.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testFineTuneResumePersistsState.m
+++ b/tests/testFineTuneResumePersistsState.m
@@ -14,7 +14,7 @@ function testPersistsState(testCase)
     dsStruct = minimalDatasetStruct();
     encoderStruct = reg.ftTrainEncoder(dsStruct);
     testCase.verifyClass(encoderStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function dsStruct = minimalDatasetStruct()

--- a/tests/testFineTuneSmoke.m
+++ b/tests/testFineTuneSmoke.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testFineTuneSmokeRunsEndToEnd.m
+++ b/tests/testFineTuneSmokeRunsEndToEnd.m
@@ -18,7 +18,7 @@ function testRunsEndToEnd(testCase)
 
     encoderStruct = reg.ftTrainEncoder(dsStruct);
     testCase.verifyClass(encoderStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function chunkTbl = minimalChunkTbl()

--- a/tests/testGoldMetrics.m
+++ b/tests/testGoldMetrics.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testGoldMetricsEvaluatesGold.m
+++ b/tests/testGoldMetricsEvaluatesGold.m
@@ -17,7 +17,7 @@ function testEvaluatesGold(testCase)
     [predYMat, trueYMat] = minimalLabelMats();
     perLabelTbl = reg.evalPerLabel(predYMat, trueYMat);
     testCase.verifyClass(perLabelTbl, 'table');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function goldPathStr = minimalGoldPath()

--- a/tests/testIngestAndChunk.m
+++ b/tests/testIngestAndChunk.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testIngestAndChunkProcessesDocuments.m
+++ b/tests/testIngestAndChunkProcessesDocuments.m
@@ -17,5 +17,5 @@ function testProcessesDocuments(testCase)
   pdfPathsCell = {pdfPath};
   reg.ingestPdfs(pdfPathsCell);
   reg.chunkText(table(), 0, 0);
-  testCase.assumeFail('Not implemented yet');
+  testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testMetricsExpectedJSON.m
+++ b/tests/testMetricsExpectedJSON.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Regression'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testMetricsExpectedJSONMatchesSchema.m
+++ b/tests/testMetricsExpectedJSONMatchesSchema.m
@@ -15,7 +15,7 @@ function testMatchesSchema(testCase)
     goldTbl = minimalGoldTbl();
     metricsStruct = reg.evalRetrieval(resultsTbl, goldTbl);
     testCase.verifyClass(metricsStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function resultsTbl = minimalResultsTbl()

--- a/tests/testPDFIngest.m
+++ b/tests/testPDFIngest.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testPDFIngestReadsPdfs.m
+++ b/tests/testPDFIngestReadsPdfs.m
@@ -16,5 +16,5 @@ function testReadsPdfs(testCase)
   fid = fopen(pdfPath, "w"); fclose(fid);
   pdfPathsCell = {pdfPath};
   reg.ingestPdfs(pdfPathsCell);
-  testCase.assumeFail('Not implemented yet');
+  testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testProjectionAutoloadPipeline.m
+++ b/tests/testProjectionAutoloadPipeline.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testProjectionAutoloadPipelineLoadsHead.m
+++ b/tests/testProjectionAutoloadPipelineLoadsHead.m
@@ -14,7 +14,7 @@ function testLoadsHead(testCase)
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function [xMat, yMat] = minimalTrainingMats()

--- a/tests/testProjectionHeadSimulated.m
+++ b/tests/testProjectionHeadSimulated.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Smoke'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testProjectionHeadSimulatedTrainsHead.m
+++ b/tests/testProjectionHeadSimulatedTrainsHead.m
@@ -14,7 +14,7 @@ function testTrainsHead(testCase)
     [xMat, yMat] = minimalTrainingMats();
     headStruct = reg.trainProjectionHead(xMat, yMat);
     testCase.verifyClass(headStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function [xMat, yMat] = minimalTrainingMats()

--- a/tests/testRegressionMetricsSimulated.m
+++ b/tests/testRegressionMetricsSimulated.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Regression'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testRegressionMetricsSimulatedComputesMetrics.m
+++ b/tests/testRegressionMetricsSimulatedComputesMetrics.m
@@ -17,7 +17,7 @@ function testComputesMetrics(testCase)
 
     perLabelTbl = reg.evalPerLabel(xMat, yMat);
     testCase.verifyClass(perLabelTbl, 'table');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function [xMat, yMat] = minimalTrainingData()

--- a/tests/testRulesAndModel.m
+++ b/tests/testRulesAndModel.m
@@ -11,5 +11,5 @@ tests(1).Tags = {'Integration'}; % testPlaceholder
 end
 
 function testPlaceholder(testCase)
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end

--- a/tests/testRulesAndModelTrainsModel.m
+++ b/tests/testRulesAndModelTrainsModel.m
@@ -18,7 +18,7 @@ function testTrainsModel(testCase)
     [xMat, yMat] = minimalTrainingData();
     modelStruct = reg.trainMultilabel(xMat, yMat);
     testCase.verifyClass(modelStruct, 'struct');
-    testCase.assumeFail('Not implemented yet');
+    testCase.fatalAssertFail('Not implemented yet');
 end
 
 function chunkTbl = minimalChunkTbl()


### PR DESCRIPTION
## Summary
- Replace `testCase.assumeFail` with `testCase.fatalAssertFail` in all tests to ensure they fail explicitly until logic is implemented.

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `pre-commit run --files $(git ls-files tests)` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc1bcd5208330988ed9347e54d417