### PR TITLE
docs: rename environment variables in environment tooling guide

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -110,7 +110,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Name | Purpose | Scope | Type | Default | Constraints | Notes |
 |------|---------|-------|------|---------|-------------|-------|
 | docIndex | Tracks current document position | local | double | 0 | non-negative | example |
-|  |  |  |  |  |  |
+| gpuInfoStruct | GPU device information | local | struct | n/a | CUDA-enabled | obtained via `gpuDevice` |
+| productsTbl | Installed MATLAB products | local | table | n/a | includes required toolboxes | obtained via `ver` |
 
 ## Constants / Enums
 

--- a/docs/step01_environment_tooling.md
+++ b/docs/step01_environment_tooling.md
@@ -18,12 +18,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 3. From the MATLAB Add-On Explorer, install *Deep Learning Toolbox Model for BERT-Base, English*.
 4. Launch MATLAB and verify GPU access:
    ```matlab
-   gpuDevice
+   gpuInfoStruct = gpuDevice;
    ```
    The command should list your CUDA-enabled GPU (e.g., RTX 4060 Ti).
 5. Save a snapshot of installed products for future reference:
    ```matlab
-   ver
+   productsTbl = ver;
    ```
 
 ## Function Interface
@@ -33,7 +33,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** selects the GPU device for subsequent operations.
 - **Usage Example:**
   ```matlab
-  info = gpuDevice;
+  gpuInfoStruct = gpuDevice;
   ```
 
 ### ver
@@ -42,14 +42,14 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Side Effects:** prints version information to the console.
 - **Usage Example:**
   ```matlab
-  products = ver;
+  productsTbl = ver;
   ```
 
 Subsequent modules rely on this environment. See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for data artifacts produced later in the pipeline.
 
 ## Verification
-- `gpuDevice` reports a supported GPU and its memory.
-- `ver` lists all required toolboxes and the BERT add-on.
+- `gpuInfoStruct` reports a supported GPU and its memory.
+- `productsTbl` lists all required toolboxes and the BERT add-on.
 
 ## Next Steps
 Continue to [Step 2: Repository Setup](step02_repository_setup.md).


### PR DESCRIPTION
## Summary
- rename `info` to `gpuInfoStruct` and `products` to `productsTbl` in step01 environment tooling guide
- document new identifiers in the registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fab4b4833097864fc8c9539de1