### PR TITLE
refactor: document configStruct usage

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -110,6 +110,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Name | Purpose | Scope | Type | Default | Constraints | Notes |
 |------|---------|-------|------|---------|-------------|-------|
 | docIndex | Tracks current document position | local | double | 0 | non-negative | example |
+| configStruct | Configuration settings loaded from JSON files | module | struct | n/a | fields must exist | returned by config |
 |  |  |  |  |  |  |
 
 ## Constants / Enums

--- a/docs/step02_repository_setup.md
+++ b/docs/step02_repository_setup.md
@@ -34,11 +34,11 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### config
 - **Parameters:** none.
-- **Returns:** struct `C` with fields derived from `pipeline.json`, `knobs.json`, and `params.json` overrides.
+- **Returns:** struct `configStruct` with fields derived from `pipeline.json`, `knobs.json`, and `params.json` overrides.
 - **Side Effects:** reads configuration files from disk.
 - **Usage Example:**
   ```matlab
-  C = config;
+  configStruct = config;
   ```
 
 Data structures referenced in later modules are detailed in [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts).

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -13,8 +13,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
-   Yweak = reg.weakRules(chunks.text, C.labels);
-   Yboot = Yweak >= C.minRuleConf; % optional threshold
+   Yweak = reg.weakRules(chunks.text, configStruct.labels);
+   Yboot = Yweak >= configStruct.minRuleConf; % optional threshold
    ```
 3. Store the sparse label matrix for future training:
    ```matlab
@@ -48,8 +48,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `Yboot`.
 
 
-> **Note:** `reg.weakRules` requires `chunks.text` and the label list `C.labels`
-> from [`config.m`](../config.m). The confidence cutoff `C.minRuleConf` is
+> **Note:** `reg.weakRules` requires `chunks.text` and the label list `configStruct.labels`
+> from [`config.m`](../config.m). The confidence cutoff `configStruct.minRuleConf` is
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.
 
 ## Verification


### PR DESCRIPTION
## Summary
- replace variable `C` with `configStruct` in repository setup docs
- update weak labeling docs to use `configStruct`
- register `configStruct` in identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `pre-commit run --files docs/step02_repository_setup.md docs/step05_weak_labeling.md docs/identifier_registry.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fafa20833084b1335f9cd80fd8