### PR TITLE
Rename docs to docsTbl in ingestion docs

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -84,8 +84,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | config | none | struct of settings from JSON files | reads configuration files |
 | startup | project object | none | adds repo paths, sets defaults |
 | shutdown | project object | none | removes repo paths, restores defaults |
-| reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
-| reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
+| reg.ingestPdfs | inputDir string | docsTbl table `{docId,text}` | reads PDFs, OCR fallback |
+| reg.chunkText | docsTbl table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
 | reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
 | reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
 | reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
@@ -262,7 +262,7 @@ Common test scopes or prefixes include:
 
 | Producer → Consumer | Payload Schema | Format | Validation | Notes |
 |--------------------|----------------|--------|-----------|-------|
-| ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
+| ingest → chunking | Document | MAT-file (`docsTbl.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
 | weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
 | embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -11,12 +11,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 2. Before running `reg.ingestPdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
 3. In MATLAB, call the ingestion routine:
    ```matlab
-   docs = reg.ingestPdfs('data/pdfs');
+   docsTbl = reg.ingestPdfs('data/pdfs');
    ```
 4. The function extracts text from each PDF. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
 5. Save the resulting table for later steps:
    ```matlab
-   save('data/docs.mat','docs')
+   save('data/docsTbl.mat','docsTbl')
    ```
 
 ## Function Interface
@@ -24,18 +24,18 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.ingestPdfs
 - **Parameters:**
   - `inputDir` (string): folder containing source PDFs.
-- **Returns:** table `docs` with columns `docId` (string) and `text` (string).
+- **Returns:** table `docsTbl` with columns `docId` (string) and `text` (string).
 - **Side Effects:** reads PDFs from disk and uses OCR for image-only pages.
 - **Usage Example:**
   ```matlab
-  docs = reg.ingestPdfs("data/pdfs_mock");
+  docsTbl = reg.ingestPdfs("data/pdfs_mock");
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
 
 
 ## Verification
-- `docs` is a table with columns such as `docId` and `text`.
+- `docsTbl` is a table with columns such as `docId` and `text`.
 - Run the unit test for ingestion:
   ```matlab
   runtests('tests/testPDFIngest.m')


### PR DESCRIPTION
## Summary
- rename the Step 3 ingestion examples to use `docsTbl`
- save the ingested records as `docsTbl.mat`
- update identifier registry entries to match `docsTbl` naming

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fc717883308fb88a66498dd241