### PR TITLE
Rename docs and chunks variables to table-based names

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -54,15 +54,15 @@ Keep the illustrative examples below in sync with the current naming conventions
 |------|---------|-------|----------------|-----------------|-------|------|
 | startup | RegClassifier project initialization | module | `project` object | none | @todo | |
 | shutdown | RegClassifier project cleanup | module | project object | none | @todo | |
-| ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
-| chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
-| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
-| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
+| ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docsTbl` table | @todo | stub |
+| chunkText | Split documents into token chunks | module | `docsTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunksTbl` table | @todo | stub |
+| weakRules | Generate weak labels for chunks | module | `chunksTbl` table | sparse matrix `yBootMat` | @todo | stub |
+| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunksTbl` table | embedding matrix `xMat` | @todo | stub |
+| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunksTbl` table | embedding matrix `xMat` | @todo | stub |
 | trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
-| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
+| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docsTbl` table | results table | @todo | stub |
 | trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunksTbl` table, `yMat` matrix | dataset struct | @todo | stub |
 | ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
@@ -84,15 +84,15 @@ Keep the illustrative examples below in sync with the current naming conventions
 | config | none | struct of settings from JSON files | reads configuration files |
 | startup | project object | none | adds repo paths, sets defaults |
 | shutdown | project object | none | removes repo paths, restores defaults |
-| reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
-| reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
+| reg.ingestPdfs | inputDir string | docsTbl table `{docId,text}` | reads PDFs, OCR fallback |
+| reg.chunkText | docsTbl table, chunkSizeTokens double, chunkOverlap double | chunksTbl table `{chunkId,docId,text}` | none |
 | reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
-| reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
+| reg.docEmbeddingsBertGpu | chunksTbl table | matrix `X` | loads model, uses GPU |
 | reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
 | reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
 | reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
 | reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
+| reg.ftBuildContrastiveDataset | chunksTbl table, `Yboot` matrix | dataset struct | none |
 | reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
@@ -264,8 +264,8 @@ Common test scopes or prefixes include:
 |--------------------|----------------|--------|-----------|-------|
 | ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
-| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
-| embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
+| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunksTbl` | see [Step 5](step05_weak_labeling.md) |
+| embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunksTbl` | see [Step 6](step06_embedding_generation.md) |
 | classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
 | retrieval → evaluation | RetrievalResult | MAT-file (`results.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -9,36 +9,36 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Load the ingested documents table:
    ```matlab
-   load('data/docs.mat','docs')
+   load('data/docs.mat','docsTbl')
    ```
 2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab
-   chunks = reg.chunkText(docs, 'chunkSizeTokens', 300, 'chunkOverlap', 80);
+   chunksTbl = reg.chunkText(docsTbl, 'chunkSizeTokens', 300, 'chunkOverlap', 80);
    ```
 3. Save the chunks for later modules:
    ```matlab
-   save('data/chunks.mat','chunks')
+   save('data/chunks.mat','chunksTbl')
    ```
 
 ## Function Interface
 
 ### reg.chunkText
 - **Parameters:**
-  - `docs` (table): from Step 3 with `docId` and `text` fields.
+  - `docsTbl` (table): from Step 3 with `docId` and `text` fields.
   - `'chunkSizeTokens'` (double): tokens per chunk.
   - `'chunkOverlap'` (double): overlap between chunks.
-- **Returns:** table `chunks` with columns `chunkId` (string), `docId` (string), and `text` (string).
+- **Returns:** table `chunksTbl` with columns `chunkId` (string), `docId` (string), and `text` (string).
 - **Side Effects:** none; pure transformation of input table.
 - **Usage Example:**
   ```matlab
-  chunks = reg.chunkText(docs, 'chunkSizeTokens', 100, 'chunkOverlap', 20);
+  chunksTbl = reg.chunkText(docsTbl, 'chunkSizeTokens', 100, 'chunkOverlap', 20);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.
 
 
 ## Verification
-- `chunks` contains `chunkId`, `docId`, and `text` for each segment.
+- `chunksTbl` contains `chunkId`, `docId`, and `text` for each segment.
 - Run the chunking test:
   ```matlab
   runtests('tests/testIngestAndChunk.m')


### PR DESCRIPTION
## Summary
- rename Step 4 text chunking inputs/outputs to `docsTbl` and `chunksTbl`
- align identifier registry entries with new `docsTbl` and `chunksTbl` names

## Testing
- `matlab -batch "runtests('tests/testIngestAndChunk.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fc996c833090e467a6f209dc42