### PR TITLE
docs: rename weak label matrices

### DIFF
--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -44,7 +44,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Depends on:** Text Chunking Module.
 - **Implementation:** `reg.weak_rules` returning label matrix.
 - **Testing:** `tests/testRulesAndModel.m` confirms label coverage and format.
-- **Output:** Sparse label matrix `Yboot`.
+ - **Output:** Sparse label matrix `bootLabelMat`.
 
 ## 6. Embedding Generation Module
 - **Goal:** Embed chunks using BERT (GPU) or FastText fallback.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -56,13 +56,13 @@ Keep the illustrative examples below in sync with the current naming conventions
 | shutdown | RegClassifier project cleanup | module | project object | none | @todo | |
 | ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
 | chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
-| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
+| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `weakLabelMat` | @todo | stub |
 | docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
 | precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
+| trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `bootLabelMat` matrix | model struct | @todo | stub |
 | hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
-| trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
+| trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `bootLabelMat` matrix | head struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | dataset struct | @todo | stub |
 | ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
@@ -86,13 +86,13 @@ Keep the illustrative examples below in sync with the current naming conventions
 | shutdown | project object | none | removes repo paths, restores defaults |
 | reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
 | reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
-| reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
+| reg.weakRules | text array, labels array | sparse matrix `weakLabelMat` | none |
 | reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
 | reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
-| reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
+| reg.trainMultilabel | `X` matrix, `bootLabelMat` matrix | model struct | none |
 | reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
-| reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
+| reg.trainProjectionHead | `X` matrix, `bootLabelMat` matrix | head struct | none |
+| reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | dataset struct | none |
 | reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
@@ -220,7 +220,7 @@ Common test scopes or prefixes include:
 #### Label
 | Name | Type | Description |
 |------|------|-------------|
-| Yboot | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
+| bootLabelMat | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
 
 #### Embedding
 | Name | Type | Description |
@@ -264,7 +264,7 @@ Common test scopes or prefixes include:
 |--------------------|----------------|--------|-----------|-------|
 | ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
-| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
+| weak labeling → classifier | Label | MAT-file (`bootLabelMat.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
 | embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
 | classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -13,12 +13,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
-   Yweak = reg.weakRules(chunks.text, C.labels);
-   Yboot = Yweak >= C.minRuleConf; % optional threshold
+   weakLabelMat = reg.weakRules(chunks.text, configStruct.labels);
+   bootLabelMat = weakLabelMat >= configStruct.minRuleConf; % optional threshold
    ```
 3. Store the sparse label matrix for future training:
    ```matlab
-   save('data/Yboot.mat','Yboot')
+   save('data/bootLabelMat.mat','bootLabelMat')
    ```
 
 ## Function Interface
@@ -27,33 +27,33 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `text` (string array): chunk content.
   - `labels` (string array): list of topic names.
-- **Returns:** sparse double matrix `Yweak` containing confidence scores per label.
+- **Returns:** sparse double matrix `weakLabelMat` containing confidence scores per label.
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  Yweak = reg.weakRules(["example"], ["topicA","topicB"]);
+  weakLabelMat = reg.weakRules(["example"], ["topicA","topicB"]);
   ```
 
 ### Thresholding
 - **Parameters:**
-  - `Yweak` (double sparse matrix)
+  - `weakLabelMat` (double sparse matrix)
   - `threshold` (double)
-- **Returns:** sparse logical matrix `Yboot`.
+- **Returns:** sparse logical matrix `bootLabelMat`.
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  Yboot = Yweak >= 0.5;
+  bootLabelMat = weakLabelMat >= 0.5;
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `Yboot`.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `bootLabelMat`.
 
 
-> **Note:** `reg.weakRules` requires `chunks.text` and the label list `C.labels`
-> from [`config.m`](../config.m). The confidence cutoff `C.minRuleConf` is
+> **Note:** `reg.weakRules` requires `chunks.text` and the label list `configStruct.labels`
+> from [`config.m`](../config.m). The confidence cutoff `configStruct.minRuleConf` is
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.
 
 ## Verification
-- `Yboot` is a sparse matrix with rows matching `chunks` and columns representing topics.
+- `bootLabelMat` is a sparse matrix with rows matching `chunks` and columns representing topics.
 - Run the labeling test:
   ```matlab
   runtests('tests/testRulesAndModel.m')

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -10,11 +10,11 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 1. Load embeddings and weak labels:
    ```matlab
    load('data/embeddings.mat','X');
-   load('data/Yboot.mat','Yboot');
+   load('data/bootLabelMat.mat','bootLabelMat');
    ```
 2. Train the baseline classifier:
    ```matlab
-   model = reg.trainMultilabel(X, Yboot);
+   model = reg.trainMultilabel(X, bootLabelMat);
    save('models/baseline_model.mat','model')
    ```
 3. Enable hybrid retrieval combining cosine similarity and BM25:
@@ -27,12 +27,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.trainMultilabel
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
 - **Returns:** struct `model` with fields `weights` and `bias` (see [BaselineModel](identifier_registry.md#baselinemodel)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  model = reg.trainMultilabel(X, Yboot);
+  model = reg.trainMultilabel(X, bootLabelMat);
   ```
 
 ### reg.hybridSearch
@@ -47,7 +47,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   results = reg.hybridSearch(model, X, 'query', 'example');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, `BaselineModel`, and `RetrievalResult` outputs.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `bootLabelMat`, `BaselineModel`, and `RetrievalResult` outputs.
 
 
 ## Verification

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -10,7 +10,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 1. Load embeddings and weak labels as in Step 7.
 2. Train the projection head:
    ```matlab
-   head = reg.trainProjectionHead(X, Yboot);
+   head = reg.trainProjectionHead(X, bootLabelMat);
    save('models/projection_head.mat','head')
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
@@ -20,12 +20,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.trainProjectionHead
 - **Parameters:**
   - `X` (double matrix): embeddings from Step 6.
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
 - **Returns:** struct `head` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  head = reg.trainProjectionHead(X, Yboot);
+  head = reg.trainProjectionHead(X, bootLabelMat);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHead`.

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -9,7 +9,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Build the contrastive training dataset:
    ```matlab
-   ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
+   ds = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab
@@ -23,12 +23,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.ftBuildContrastiveDataset
 - **Parameters:**
   - `chunks` (table): see Step 4.
-  - `Yboot` (sparse logical matrix): weak labels.
+  - `bootLabelMat` (sparse logical matrix): weak labels.
 - **Returns:** dataset `ds` containing contrastive pairs (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
+  ds = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
   ```
 
 ### reg.ftTrainEncoder


### PR DESCRIPTION
## Summary
- rename weak-label variables `Yweak`/`Yboot` to `weakLabelMat`/`bootLabelMat`
- update step guides for baseline classifier, projection head, and fine-tuning workflows
- synchronize identifier registry and system build plan with new names

## Testing
- `matlab -batch "runtests"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fd48148330b6a57a6f23ede7c7