### PR TITLE
docs: rename embeddings variable to embeddingMat

### DIFF
--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -51,7 +51,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Depends on:** Text Chunking Module.
 - **Implementation:** `reg.doc_embeddings_bert_gpu` & `reg.precompute_embeddings`.
 - **Testing:** `tests/testFeatures.m` checks embedding shapes & backend selection.
-- **Output:** Matrix `X` of embeddings per chunk.
+- **Output:** Matrix `embeddingMat` of embeddings per chunk.
 
 ## 7. Baseline Classifier & Retrieval
 - **Goal:** Train a multi-label classifier and enable hybrid search.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -87,11 +87,11 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
 | reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
 | reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
-| reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
-| reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
-| reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
-| reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
-| reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
+| reg.docEmbeddingsBertGpu | chunks table | matrix `embeddingMat` | loads model, uses GPU |
+| reg.precomputeEmbeddings | `embeddingMat` matrix, outPath string | none | writes embeddings to disk |
+| reg.trainMultilabel | `embeddingMat` matrix, `Yboot` matrix | model struct | none |
+| reg.hybridSearch | model struct, `embeddingMat` matrix, query string | results table | none |
+| reg.trainProjectionHead | `embeddingMat` matrix, `Yboot` matrix | head struct | none |
 | reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
 | reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
@@ -225,7 +225,7 @@ Common test scopes or prefixes include:
 #### Embedding
 | Name | Type | Description |
 |------|------|-------------|
-| X | double `[numChunks x embeddingDim]` | Chunk embeddings |
+| embeddingMat | double `[numChunks x embeddingDim]` | Chunk embeddings |
 
 #### Metric
 | Field | Type | Description |

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -13,12 +13,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```
 2. Generate embeddings with the GPU-enabled BERT encoder:
    ```matlab
-   X = reg.docEmbeddingsBertGpu(chunks);
+   embeddingMat = reg.docEmbeddingsBertGpu(chunks);
    ```
    If a GPU is unavailable, the function automatically falls back to a CPU-friendly model.
 3. Cache embeddings for reuse:
    ```matlab
-   reg.precomputeEmbeddings(X,'data/embeddings.mat');
+   reg.precomputeEmbeddings(embeddingMat,'data/embeddings.mat');
    ```
 
 ## Function Interface
@@ -26,29 +26,29 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.docEmbeddingsBertGpu
 - **Parameters:**
   - `chunks` (table): as defined in Step 4.
-- **Returns:** double matrix `X` of size `[numChunks x 768]` by default.
+- **Returns:** double matrix `embeddingMat` of size `[numChunks x 768]` by default.
 - **Side Effects:** loads BERT weights and uses GPU when available.
 - **Usage Example:**
   ```matlab
-  X = reg.docEmbeddingsBertGpu(chunks);
+  embeddingMat = reg.docEmbeddingsBertGpu(chunks);
   ```
 
 ### reg.precomputeEmbeddings
 - **Parameters:**
-  - `X` (double matrix)
+  - `embeddingMat` (double matrix)
   - `outPath` (string): destination MAT-file path.
 - **Returns:** none.
 - **Side Effects:** writes embeddings to disk for reuse.
 - **Usage Example:**
   ```matlab
-  reg.precomputeEmbeddings(X, 'embeddings_mock.mat');
+  reg.precomputeEmbeddings(embeddingMat, 'embeddings_mock.mat');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `X`.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `embeddingMat`.
 
 
 ## Verification
-- `X` has one row per chunk and 768 columns (BERT base dimension).
+- `embeddingMat` has one row per chunk and 768 columns (BERT base dimension).
 - Run the features test:
   ```matlab
   runtests('tests/testFeatures.m')

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -9,45 +9,45 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Load embeddings and weak labels:
    ```matlab
-   load('data/embeddings.mat','X');
+   load('data/embeddings.mat','embeddingMat');
    load('data/Yboot.mat','Yboot');
    ```
 2. Train the baseline classifier:
    ```matlab
-   model = reg.trainMultilabel(X, Yboot);
+   model = reg.trainMultilabel(embeddingMat, Yboot);
    save('models/baseline_model.mat','model')
    ```
 3. Enable hybrid retrieval combining cosine similarity and BM25:
    ```matlab
-   results = reg.hybridSearch(model, X, 'query', 'sample text');
+   results = reg.hybridSearch(model, embeddingMat, 'query', 'sample text');
    ```
 
 ## Function Interface
 
 ### reg.trainMultilabel
 - **Parameters:**
-  - `X` (double matrix): embeddings from Step 6.
+  - `embeddingMat` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
 - **Returns:** struct `model` with fields `weights` and `bias` (see [BaselineModel](identifier_registry.md#baselinemodel)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  model = reg.trainMultilabel(X, Yboot);
+  model = reg.trainMultilabel(embeddingMat, Yboot);
   ```
 
 ### reg.hybridSearch
 - **Parameters:**
   - `model` (struct)
-  - `X` (double matrix)
+  - `embeddingMat` (double matrix)
   - `'query'` (string): search text.
 - **Returns:** table `results` containing `docId` and `score` fields (see [RetrievalResult](identifier_registry.md#retrievalresult)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  results = reg.hybridSearch(model, X, 'query', 'example');
+  results = reg.hybridSearch(model, embeddingMat, 'query', 'example');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, `BaselineModel`, and `RetrievalResult` outputs.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `embeddingMat`, `Yboot`, `BaselineModel`, and `RetrievalResult` outputs.
 
 
 ## Verification

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -10,7 +10,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 1. Load embeddings and weak labels as in Step 7.
 2. Train the projection head:
    ```matlab
-   head = reg.trainProjectionHead(X, Yboot);
+   head = reg.trainProjectionHead(embeddingMat, Yboot);
    save('models/projection_head.mat','head')
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
@@ -19,13 +19,13 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### reg.trainProjectionHead
 - **Parameters:**
-  - `X` (double matrix): embeddings from Step 6.
+  - `embeddingMat` (double matrix): embeddings from Step 6.
   - `Yboot` (sparse logical matrix): weak labels from Step 5.
 - **Returns:** struct `head` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  head = reg.trainProjectionHead(X, Yboot);
+  head = reg.trainProjectionHead(embeddingMat, Yboot);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHead`.


### PR DESCRIPTION
## Summary
- rename embedding matrix variable to `embeddingMat` in step 6 docs
- propagate `embeddingMat` usage through subsequent step docs and identifier registry
- align system build plan output naming with new variable

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fe65188330a114a2b58f2a4ee9