### PR TITLE
docs: rename projection head variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -56,13 +56,13 @@ Keep the illustrative examples below in sync with the current naming conventions
 | shutdown | RegClassifier project cleanup | module | project object | none | @todo | |
 | ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
 | chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
-| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
-| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
-| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
-| trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
+| weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `bootLabelMat` | @todo | stub |
+| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `embeddingMat` | @todo | stub |
+| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `embeddingMat` | @todo | stub |
+| trainMultilabel | Train multi-label classifier | module | `embeddingMat` matrix, `bootLabelMat` matrix | model struct | @todo | stub |
+| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `embeddingMat` matrix, `docTbl` table | results table | @todo | stub |
+| trainProjectionHead | Train projection head on embeddings | module | `embeddingMat` matrix, `bootLabelMat` matrix | projectionHeadStruct struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | dataset struct | @todo | stub |
 | ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
@@ -87,12 +87,12 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
 | reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
 | reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
-| reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
-| reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
-| reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
-| reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
-| reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
+| reg.docEmbeddingsBertGpu | chunks table | matrix `embeddingMat` | loads model, uses GPU |
+| reg.precomputeEmbeddings | `embeddingMat` matrix, outPath string | none | writes embeddings to disk |
+| reg.trainMultilabel | `embeddingMat` matrix, `bootLabelMat` matrix | model struct | none |
+| reg.hybridSearch | model struct, `embeddingMat` matrix, query string | results table | none |
+| reg.trainProjectionHead | `embeddingMat` matrix, `bootLabelMat` matrix | projectionHeadStruct struct | none |
+| reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | dataset struct | none |
 | reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
@@ -220,12 +220,12 @@ Common test scopes or prefixes include:
 #### Label
 | Name | Type | Description |
 |------|------|-------------|
-| Yboot | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
+| bootLabelMat | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
 
 #### Embedding
 | Name | Type | Description |
 |------|------|-------------|
-| X | double `[numChunks x embeddingDim]` | Chunk embeddings |
+| embeddingMat | double `[numChunks x embeddingDim]` | Chunk embeddings |
 
 #### Metric
 | Field | Type | Description |
@@ -264,7 +264,7 @@ Common test scopes or prefixes include:
 |--------------------|----------------|--------|-----------|-------|
 | ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
-| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
+| weak labeling → classifier | Label | MAT-file (`boot_labels.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
 | embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
 | classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -7,11 +7,11 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-1. Load embeddings and weak labels as in Step 7.
+1. Load `embeddingMat` and `bootLabelMat` as in Step 7.
 2. Train the projection head:
    ```matlab
-   head = reg.trainProjectionHead(X, Yboot);
-   save('models/projection_head.mat','head')
+   projectionHeadStruct = reg.trainProjectionHead(embeddingMat, bootLabelMat);
+   save('models/projection_head.mat','projectionHeadStruct')
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
 
@@ -19,13 +19,13 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### reg.trainProjectionHead
 - **Parameters:**
-  - `X` (double matrix): embeddings from Step 6.
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.
-- **Returns:** struct `head` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
+  - `embeddingMat` (double matrix): embeddings from Step 6.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
+- **Returns:** struct `projectionHeadStruct` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  head = reg.trainProjectionHead(X, Yboot);
+  projectionHeadStruct = reg.trainProjectionHead(embeddingMat, bootLabelMat);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHead`.
@@ -33,9 +33,9 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
 
 ## Verification
 - `projection_head.mat` exists in the `models` folder.
-- Validate head schema:
+- Validate projection head schema:
   ```matlab
-  assert(all(isfield(head, {'weights','bias'})));
+  assert(all(isfield(projectionHeadStruct, {'weights','bias'})));
   ```
 - Run projection head tests:
   ```matlab


### PR DESCRIPTION
## Summary
- rename projection head workflow variables to `projectionHeadStruct`, `embeddingMat`, and `bootLabelMat`
- align identifier registry with new projection head and data contract names

## Testing
- `pre-commit run --files docs/step08_projection_head.md docs/identifier_registry.md` *(fails: command not found)*
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc400c58883309d8e6f1611064265