### PR TITLE
docs: rename fine-tuning variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -62,8 +62,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
 | hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
 | trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
-| ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | `contrastiveDatasetTbl` table | @todo | stub |
+| ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `contrastiveDatasetTbl` table | `fineTunedEncoderStruct` struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
 | loadGold | Load gold annotation data | module | `pathStr` string | `goldTbl` table | @todo | stub |
@@ -92,8 +92,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
 | reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
 | reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
-| reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
+| reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | `contrastiveDatasetTbl` table | none |
+| reg.ftTrainEncoder | `contrastiveDatasetTbl` table, unfreezeTop double | `fineTunedEncoderStruct` struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
 | reg.evalPerLabel | predYMat matrix, trueYMat matrix | metrics table | none |
@@ -110,6 +110,9 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Name | Purpose | Scope | Type | Default | Constraints | Notes |
 |------|---------|-------|------|---------|-------------|-------|
 | docIndex | Tracks current document position | local | double | 0 | non-negative | example |
+| bootLabelMat | Weak labels matrix | module | sparse logical `[numChunks x numClasses]` | n/a | matches size of `chunks` | used in Step 9 |
+| contrastiveDatasetTbl | Contrastive training pairs | module | table | n/a | fields `{anchorIdx,posIdx,negIdx}` | from ftBuildContrastiveDataset |
+| fineTunedEncoderStruct | Encoder weights after fine-tuning | module | struct | n/a | contains updated BERT layers | saved to `fine_tuned_bert.mat` |
 |  |  |  |  |  |  |
 
 ## Constants / Enums
@@ -269,8 +272,8 @@ Common test scopes or prefixes include:
 | classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
 | retrieval → evaluation | RetrievalResult | MAT-file (`results.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
-| dataset build → fine-tune | ContrastiveDataset | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
-| fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
+| dataset build → fine-tune | contrastiveDatasetTbl | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
+| fine-tune → evaluation | fineTunedEncoderStruct struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | evaluation → reports | Metric | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
 
 ---

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -9,12 +9,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Build the contrastive training dataset:
    ```matlab
-   ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
+   contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab
-   ftEncoder = reg.ftTrainEncoder(ds, 'unfreezeTop', 4);
-   save('models/fine_tuned_bert.mat','ftEncoder')
+   fineTunedEncoderStruct = reg.ftTrainEncoder(contrastiveDatasetTbl, 'unfreezeTop', 4);
+   save('models/fine_tuned_bert.mat','fineTunedEncoderStruct')
    ```
 3. Update pipeline settings to point to the fine-tuned encoder if needed.
 
@@ -23,23 +23,23 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 ### reg.ftBuildContrastiveDataset
 - **Parameters:**
   - `chunks` (table): see Step 4.
-  - `Yboot` (sparse logical matrix): weak labels.
-- **Returns:** dataset `ds` containing contrastive pairs (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
+  - `bootLabelMat` (sparse logical matrix): bootstrapped labels.
+- **Returns:** table `contrastiveDatasetTbl` containing contrastive pairs (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  ds = reg.ftBuildContrastiveDataset(chunks, Yboot);
+  contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
   ```
 
 ### reg.ftTrainEncoder
 - **Parameters:**
-  - `ds` (dataset): training data.
+  - `contrastiveDatasetTbl` (table): training data.
   - `'unfreezeTop'` (double): number of BERT layers to unfreeze.
-- **Returns:** struct `ftEncoder` with updated weights.
+- **Returns:** struct `fineTunedEncoderStruct` with updated weights.
 - **Side Effects:** updates encoder weights during training.
 - **Usage Example:**
   ```matlab
-  ftEncoder = reg.ftTrainEncoder(ds, 'unfreezeTop', 4);
+  fineTunedEncoderStruct = reg.ftTrainEncoder(contrastiveDatasetTbl, 'unfreezeTop', 4);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for encoder artifact and `ContrastiveDataset` schemas.
@@ -49,7 +49,7 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
 - `fine_tuned_bert.mat` is saved and contains updated weights.
 - Contrastive dataset has expected fields:
   ```matlab
-  assert(all(isfield(ds, {'anchorIdx','posIdx','negIdx'})));
+  assert(all(isfield(contrastiveDatasetTbl, {'anchorIdx','posIdx','negIdx'})));
   ```
 - Run fine-tuning tests:
   ```matlab


### PR DESCRIPTION
## Summary
- rename fine-tuning variables in step09 documentation
- update identifier registry for new dataset and encoder identifiers

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc40160c08330971272819f52beb7