### PR TITLE
docs: clarify diff output structure

### DIFF
--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -33,12 +33,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `vA` (string): version identifier A.
   - `vB` (string): version identifier B.
-- **Returns:** structure describing added, removed, and changed documents.
+- **Returns:** `diffStruct` (struct) describing added, removed, and changed documents.
 - **Side Effects:** none.
 - **Usage Example:**
-  ```matlab
-  diff = reg.crrDiffVersions('v1','v2');
-  ```
+   ```matlab
+   diffStruct = reg.crrDiffVersions('v1','v2');
+   ```
 
 ### reg.crrDiffReport
 - **Parameters:** none.


### PR DESCRIPTION
## Summary
- rename `diff` example variable to `diffStruct`
- specify `diffStruct` as return type in diff utility documentation

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc40186bc833081029ee320660de1