### PR TITLE
docs: standardize results variable naming

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -102,7 +102,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.crrDiffReport | none | none | writes HTML/PDF summaries |
 | reg.printActiveKnobs | knobsStruct struct | none | prints knob values to stdout |
 | reg.setSeeds | seed double | none | sets RNG and GPU seeds |
-| runtests | testFolder string, IncludeSubfolders logical, UseParallel logical | results table | executes test suite |
+| runtests | testFolder string, IncludeSubfolders logical, UseParallel logical | `resultsTbl` table | executes test suite |
 
 
 ## Variables

--- a/docs/step12_continuous_testing.md
+++ b/docs/step12_continuous_testing.md
@@ -9,8 +9,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. In MATLAB, run the full test suite regularly:
    ```matlab
-   results = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
-   table(results)
+   resultsTbl = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
+   table(resultsTbl)
    ```
 2. Investigate any failures before committing changes.
 3. Optional: configure continuous integration (e.g., GitHub Actions) to run the same command on each push.
@@ -21,11 +21,11 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   - `testFolder` (string): path to test suite, e.g., `'tests'`.
   - `'IncludeSubfolders'` (logical): include nested tests.
   - `'UseParallel'` (logical): run tests in parallel.
-- **Returns:** table `results` with fields `Name`, `Passed`, `Failed`, `Incomplete`, and `Duration`.
+  - **Returns:** table `resultsTbl` with fields `Name`, `Passed`, `Failed`, `Incomplete`, and `Duration`.
 - **Side Effects:** executes all MATLAB tests in the project.
 - **Usage Example:**
   ```matlab
-  results = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
+  resultsTbl = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for any test-related artifacts.


### PR DESCRIPTION
## Summary
- Rename `results` to `resultsTbl` in the continuous testing guide for consistency with naming conventions
- Align identifier registry entry for `runtests` to note the `resultsTbl` return table

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc4033cf883308b91b1249799d9c6