### PR TITLE
docs: require tests with module updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,8 @@ repos:
         entry: python scripts/validate_scaffold.py
         language: python
         pass_filenames: false
+      - id: ensure-tests
+        name: ensure tests accompany code changes
+        entry: python scripts/check_tests_modified.py
+        language: python
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,4 +16,5 @@
 1. Consult the canonical documents before adding identifiers.
 2. Search the repo (e.g., `rg <identifier>` or MATLAB `which <identifier>`) to avoid name collisions.
 3. Update code and `docs/identifier_registry.md` with any new identifiers.
-4. Run tests locally (`matlab -batch "run_smoke_test"` or `matlab -batch "runtests"`) before committing.
+4. Commit tests alongside code changes: add a corresponding file in `tests/` for every new module or function, and update existing tests when module behavior changes.
+5. Run tests locally (`matlab -batch "run_smoke_test"` or `matlab -batch "runtests"`) before committing.

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -49,16 +49,17 @@ Place tests in the `tests/` folder and name each file `testName.m`. Refer to [Te
      (`which <identifier>`) to confirm the name is not already in use.
 3. Note identifiers currently in use, use these consistently in your code, if required.
 4. Update the codebase accordingly.
-5. When introducing new identifiers in your code, **always** crosscheck this
+5. Add or update tests: any new module or function must include a corresponding test file in `tests/`, and existing tests must be updated when module behavior changes.
+6. When introducing new identifiers in your code, **always** crosscheck this
    name isnt in use and **always** update the `identifier_registry.md` with
    new classes, functions, variables, constants, files/modules, tests, and
    other identifiers through a PR with your new code.
-6. Verify that any new or modified identifier has a corresponding entry in
+7. Verify that any new or modified identifier has a corresponding entry in
    [`docs/identifier_registry.md`](identifier_registry.md).
-7. Run the full test suite locally:
+8. Run the full test suite locally:
    - Placeholder tests must fail rather than being skipped or assumed.
    - Confirm that tests use fixtures via `testCase.applyFixture`.
-8. Run CI to ensure naming checks and tests pass. Locally, you can execute
+9. Run CI to ensure naming checks and tests pass. Locally, you can execute
    `runtests` or the `run_smoke_test` script to verify.
 
 ### Example

--- a/scripts/check_tests_modified.py
+++ b/scripts/check_tests_modified.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Fail if .m module files change without corresponding tests."""
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_staged_files():
+    proc = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        print("Failed to obtain staged files", file=sys.stderr)
+        return []
+    return [Path(p) for p in proc.stdout.splitlines() if p]
+
+
+def main() -> int:
+    files = get_staged_files()
+    if not files:
+        return 0
+    code_changes = [f for f in files if f.suffix == ".m" and not str(f).startswith("tests/")]
+    test_changes = [f for f in files if str(f).startswith("tests/") and f.suffix == ".m"]
+    if code_changes and not test_changes:
+        print("Error: module changes detected without corresponding tests:")
+        for f in code_changes:
+            print(f"  {f}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- document explicit requirement for tests alongside new modules
- remind contributors in AGENTS to commit tests with code changes
- add pre-commit hook to detect module changes lacking tests

## Testing
- `python scripts/check_tests_modified.py`
- `pre-commit run --files .pre-commit-config.yaml AGENTS.md docs/README_NAMING.md scripts/check_tests_modified.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: ProxyError 403 Forbidden)*
- `apt-get update` *(fails: 403 Forbidden)*
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc4d4ce088330a257cc0c4ca98a20