### PR TITLE
docs: rename baseline classifier variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -57,12 +57,12 @@ Keep the illustrative examples below in sync with the current naming conventions
 | ingestPdfs | Convert PDFs into text documents | module | `pdfPathsCell` cell array | `docTbl` table | @todo | stub |
 | chunkText | Split documents into token chunks | module | `docTbl`, `chunkSizeTokens`, `chunkOverlap` | `chunkTbl` table | @todo | stub |
 | weakRules | Generate weak labels for chunks | module | `chunkTbl` table | sparse matrix `yBootMat` | @todo | stub |
-| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `xMat` | @todo | stub |
-| trainMultilabel | Train multi-label classifier | module | `xMat` matrix, `yMat` matrix | model struct | @todo | stub |
-| hybridSearch | Retrieve documents with hybrid search | module | `queryStr` string, `xMat` matrix, `docTbl` table | results table | @todo | stub |
-| trainProjectionHead | Train projection head on embeddings | module | `xMat` matrix, `yMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `yMat` matrix | dataset struct | @todo | stub |
+| docEmbeddingsBertGpu | Embed chunks using BERT on GPU | module | `chunkTbl` table | embedding matrix `embeddingMat` | @todo | stub |
+| precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `embeddingMat` | @todo | stub |
+| trainMultilabel | Train multi-label classifier | module | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | @todo | stub |
+| hybridSearch | Retrieve documents with hybrid search | module | `baselineModelStruct` struct, `embeddingMat` matrix, `queryStr` string | results table | @todo | stub |
+| trainProjectionHead | Train projection head on embeddings | module | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | dataset struct | @todo | stub |
 | ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
@@ -87,12 +87,12 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.ingestPdfs | inputDir string | docs table `{docId,text}` | reads PDFs, OCR fallback |
 | reg.chunkText | docs table, chunkSizeTokens double, chunkOverlap double | chunks table `{chunkId,docId,text}` | none |
 | reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
-| reg.docEmbeddingsBertGpu | chunks table | matrix `X` | loads model, uses GPU |
-| reg.precomputeEmbeddings | `X` matrix, outPath string | none | writes embeddings to disk |
-| reg.trainMultilabel | `X` matrix, `Yboot` matrix | model struct | none |
-| reg.hybridSearch | model struct, `X` matrix, query string | results table | none |
-| reg.trainProjectionHead | `X` matrix, `Yboot` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `Yboot` matrix | dataset struct | none |
+| reg.docEmbeddingsBertGpu | chunks table | matrix `embeddingMat` | loads model, uses GPU |
+| reg.precomputeEmbeddings | `embeddingMat` matrix, outPath string | none | writes embeddings to disk |
+| reg.trainMultilabel | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | none |
+| reg.hybridSearch | `baselineModelStruct` struct, `embeddingMat` matrix, query string | `resultsTbl` table | none |
+| reg.trainProjectionHead | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | none |
+| reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | dataset struct | none |
 | reg.ftTrainEncoder | dataset `ds`, unfreezeTop double | encoder struct | updates model weights |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
@@ -220,12 +220,12 @@ Common test scopes or prefixes include:
 #### Label
 | Name | Type | Description |
 |------|------|-------------|
-| Yboot | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
+| bootLabelMat | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
 
 #### Embedding
 | Name | Type | Description |
 |------|------|-------------|
-| X | double `[numChunks x embeddingDim]` | Chunk embeddings |
+| embeddingMat | double `[numChunks x embeddingDim]` | Chunk embeddings |
 
 #### Metric
 | Field | Type | Description |
@@ -233,7 +233,7 @@ Common test scopes or prefixes include:
 | metric | string | Metric name |
 | value | double | Metric value |
 
-#### BaselineModel
+#### BaselineModelStruct
 | Field | Type | Description |
 |-------|------|-------------|
 | weights | double `[embeddingDim x numClasses]` | Classifier weights |
@@ -264,11 +264,11 @@ Common test scopes or prefixes include:
 |--------------------|----------------|--------|-----------|-------|
 | ingest → chunking | Document | MAT-file (`docs.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
 | chunking → weak labeling / embeddings | Chunk | MAT-file (`chunks.mat`) | unique `chunkId` | see [Step 4](step04_text_chunking.md) |
-| weak labeling → classifier | Label | MAT-file (`Yboot.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
-| embedding generation → classifier | Embedding | MAT-file (`embeddings.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
-| classifier → retrieval / eval | BaselineModel | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| weak labeling → classifier | Label | MAT-file (`bootLabelMat.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
+| embedding generation → classifier | Embedding | MAT-file (`embeddingMat.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
+| classifier → retrieval / eval | BaselineModelStruct | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
-| retrieval → evaluation | RetrievalResult | MAT-file (`results.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
+| retrieval → evaluation | RetrievalResult | MAT-file (`resultsTbl.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | dataset build → fine-tune | ContrastiveDataset | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | evaluation → reports | Metric | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -9,52 +9,52 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Load embeddings and weak labels:
    ```matlab
-   load('data/embeddings.mat','X');
-   load('data/Yboot.mat','Yboot');
+   load('data/embeddingMat.mat','embeddingMat');
+   load('data/bootLabelMat.mat','bootLabelMat');
    ```
 2. Train the baseline classifier:
    ```matlab
-   model = reg.trainMultilabel(X, Yboot);
-   save('models/baseline_model.mat','model')
+   baselineModelStruct = reg.trainMultilabel(embeddingMat, bootLabelMat);
+   save('models/baseline_model.mat','baselineModelStruct')
    ```
 3. Enable hybrid retrieval combining cosine similarity and BM25:
    ```matlab
-   results = reg.hybridSearch(model, X, 'query', 'sample text');
+   resultsTbl = reg.hybridSearch(baselineModelStruct, embeddingMat, 'query', 'sample text');
    ```
 
 ## Function Interface
 
 ### reg.trainMultilabel
 - **Parameters:**
-  - `X` (double matrix): embeddings from Step 6.
-  - `Yboot` (sparse logical matrix): weak labels from Step 5.
-- **Returns:** struct `model` with fields `weights` and `bias` (see [BaselineModel](identifier_registry.md#baselinemodel)).
+  - `embeddingMat` (double matrix): embeddings from Step 6.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
+- **Returns:** struct `baselineModelStruct` with fields `weights` and `bias` (see [BaselineModelStruct](identifier_registry.md#baselinemodelstruct)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  model = reg.trainMultilabel(X, Yboot);
+  baselineModelStruct = reg.trainMultilabel(embeddingMat, bootLabelMat);
   ```
 
 ### reg.hybridSearch
 - **Parameters:**
-  - `model` (struct)
-  - `X` (double matrix)
+  - `baselineModelStruct` (struct)
+  - `embeddingMat` (double matrix)
   - `'query'` (string): search text.
-- **Returns:** table `results` containing `docId` and `score` fields (see [RetrievalResult](identifier_registry.md#retrievalresult)).
+- **Returns:** table `resultsTbl` containing `docId` and `score` fields (see [RetrievalResult](identifier_registry.md#retrievalresult)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  results = reg.hybridSearch(model, X, 'query', 'example');
+  resultsTbl = reg.hybridSearch(baselineModelStruct, embeddingMat, 'query', 'example');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `X`, `Yboot`, `BaselineModel`, and `RetrievalResult` outputs.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `embeddingMat`, `bootLabelMat`, `BaselineModelStruct`, and `RetrievalResult` outputs.
 
 
 ## Verification
 - Classifier training completes and saves `baseline_model.mat`.
 - Verify model schema:
   ```matlab
-  assert(all(isfield(model, {'weights','bias'})));
+  assert(all(isfield(baselineModelStruct, {'weights','bias'})));
   ```
 - Run baseline tests:
   ```matlab
@@ -64,7 +64,7 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   Tests confirm baseline metrics and retrieval behavior.
 - Retrieval results contain expected fields:
   ```matlab
-  assert(all(ismember({'docId','score'}, results.Properties.VariableNames)));
+  assert(all(ismember({'docId','score'}, resultsTbl.Properties.VariableNames)));
   ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- update baseline classifier guide to use embeddingMat, bootLabelMat, baselineModelStruct, and resultsTbl
- align identifier registry with renamed variables and data contracts

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bc3fea27483308b1b0d50a762ad9e