### PR TITLE
docs: rename weak labeling variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -86,7 +86,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | shutdown | project object | none | removes repo paths, restores defaults |
 | reg.ingestPdfs | inputDir string | docsTbl table `{docId,text}` | reads PDFs, OCR fallback |
 | reg.chunkText | docsTbl table, chunkSizeTokens double, chunkOverlap double | chunksTbl table `{chunkId,docId,text}` | none |
-| reg.weakRules | text array, labels array | sparse matrix `Yweak` | none |
+| reg.weakRules | text array, labels array | sparse matrix `weakLabelMat` | none |
 | reg.docEmbeddingsBertGpu | chunks table | matrix `embeddingMat` | loads model, uses GPU |
 | reg.precomputeEmbeddings | `embeddingMat` matrix, outPath string | none | writes embeddings to disk |
 | reg.trainMultilabel | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | none |
@@ -222,6 +222,7 @@ Common test scopes or prefixes include:
 #### Label
 | Name | Type | Description |
 |------|------|-------------|
+| weakLabelMat | sparse double `[numChunks x numClasses]` | Confidence scores per label |
 | bootLabelMat | sparse logical `[numChunks x numClasses]` | Weak labels matrix |
 
 #### Embedding

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -1,6 +1,6 @@
 # Step 5: Weak Labeling
 
-**Goal:** Bootstrap class labels for each text chunk using heuristic rules.
+**Goal:** Generate `weakLabelMat` and `bootLabelMat` for each text chunk using heuristic rules.
 
 **Depends on:** [Step 4: Text Chunking](step04_text_chunking.md).
 
@@ -18,7 +18,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    bootLabelMat = weakLabelMat >= configStruct.minRuleConf; % optional threshold
 
    ```
-3. Store the sparse label matrix for future training:
+3. Store the thresholded label matrix for future training:
    ```matlab
    save('data/bootLabelMat.mat','bootLabelMat')
    ```
@@ -47,7 +47,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   bootLabelMat = weakLabelMat >= 0.5;
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema of `bootLabelMat`.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `weakLabelMat` and `bootLabelMat`.
 
 
 > **Note:** `reg.weakRules` requires `chunks.text` and the label list `configStruct.labels`
@@ -55,6 +55,7 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.
 
 ## Verification
+- `weakLabelMat` contains confidence scores per label.
 - `bootLabelMat` is a sparse matrix with rows matching `chunks` and columns representing topics.
 - Run the labeling test:
   ```matlab


### PR DESCRIPTION
## Summary
- clarify weak labeling outputs and config usage in step 5 guide
- register new weakLabelMat identifier in registry

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bcedc0130833090a76d5f6ac8c18a