### PR TITLE
docs: rename docs variable to docsTbl

### DIFF
--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -1,6 +1,6 @@
 # Step 3: Data Ingestion
 
-**Goal:** Convert PDF documents into raw text records.
+**Goal:** Convert PDF documents into a `docsTbl` table of raw text records.
 
 **Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
 
@@ -13,8 +13,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```matlab
    docsTbl = reg.ingestPdfs('data/pdfs');
    ```
-4. The function extracts text from each PDF. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
-5. Save the resulting table for later steps:
+4. The function extracts text from each PDF into `docsTbl`. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
+5. Save `docsTbl` for later steps:
    ```matlab
    save('data/docsTbl.mat','docsTbl')
    ```

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -7,9 +7,9 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-1. Load the ingested documents table:
+1. Load the ingested documents table `docsTbl`:
    ```matlab
-   load('data/docs.mat','docsTbl')
+   load('data/docsTbl.mat','docsTbl')
    ```
 2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab


### PR DESCRIPTION
## Summary
- Clarify Step 3 instructions to produce and persist `docsTbl`, including saving to `docsTbl.mat`
- Update Step 4 chunking guide to load `docsTbl.mat` as the ingested documents table

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bcec82ea4833081ce69de712d9b86