### PR TITLE
docs: rename tables in chunking step

### DIFF
--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -1,6 +1,6 @@
 # Step 4: Text Chunking
 
-**Goal:** Split long documents into overlapping token chunks.
+**Goal:** Split long documents into overlapping token chunksTbl.
 
 **Depends on:** [Step 3: Data Ingestion](step03_data_ingestion.md).
 
@@ -9,15 +9,15 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Load the ingested documents table:
    ```matlab
-   load('data/docs.mat','docsTbl')
+   load('data/docsTbl.mat','docsTbl')
    ```
 2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab
    chunksTbl = reg.chunkText(docsTbl, 'chunkSizeTokens', 300, 'chunkOverlap', 80);
    ```
-3. Save the chunks for later modules:
+3. Save the chunksTbl for later modules:
    ```matlab
-   save('data/chunks.mat','chunksTbl')
+   save('data/chunksTbl.mat','chunksTbl')
    ```
 
 ## Function Interface
@@ -26,7 +26,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `docsTbl` (table): from Step 3 with `docId` and `text` fields.
   - `'chunkSizeTokens'` (double): tokens per chunk.
-  - `'chunkOverlap'` (double): overlap between chunks.
+  - `'chunkOverlap'` (double): overlap between chunksTbl.
 - **Returns:** table `chunksTbl` with columns `chunkId` (string), `docId` (string), and `text` (string).
 - **Side Effects:** none; pure transformation of input table.
 - **Usage Example:**


### PR DESCRIPTION
## Summary
- clarify text chunking instructions to use docsTbl and chunksTbl naming

## Testing
- `matlab -batch "runtests"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689bcecf52e08330bd9c56d5424a3ee6