### PR TITLE
docs: rename projection head variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -61,7 +61,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | precomputeEmbeddings | Precompute embeddings for chunks | module | `chunkTbl` table | embedding matrix `embeddingMat` | @todo | stub |
 | trainMultilabel | Train multi-label classifier | module | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | @todo | stub |
 | hybridSearch | Retrieve documents with hybrid search | module | `baselineModelStruct` struct, `embeddingMat` matrix, `queryStr` string | results table | @todo | stub |
-| trainProjectionHead | Train projection head on embeddings | module | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | @todo | stub |
+| trainProjectionHead | Train projection head on embeddings | module | `embeddingMat` matrix, `bootLabelMat` matrix | `projectionHeadStruct` struct | @todo | stub |
 | ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | dataset struct | @todo | stub |
 | ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
@@ -91,7 +91,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.precomputeEmbeddings | `embeddingMat` matrix, outPath string | none | writes embeddings to disk |
 | reg.trainMultilabel | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | none |
 | reg.hybridSearch | `baselineModelStruct` struct, `embeddingMat` matrix, query string | `resultsTbl` table | none |
-| reg.trainProjectionHead | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | none |
+| reg.trainProjectionHead | `embeddingMat` matrix, `bootLabelMat` matrix | `projectionHeadStruct` struct | none |
 | reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | dataset struct | none |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
@@ -241,7 +241,7 @@ Common test scopes or prefixes include:
 | weights | double `[embeddingDim x numClasses]` | Classifier weights |
 | bias | double `[1 x numClasses]` | Classifier bias |
 
-#### ProjectionHead
+#### ProjectionHeadStruct
 | Field | Type | Description |
 |-------|------|-------------|
 | weights | double `[embeddingDim x embeddingDim]` | Projection weights |
@@ -269,7 +269,7 @@ Common test scopes or prefixes include:
 | weak labeling → classifier | Label | MAT-file (`bootLabelMat.mat`) | matches size of `chunks` | see [Step 5](step05_weak_labeling.md) |
 | embedding generation → classifier | Embedding | MAT-file (`embeddingMat.mat`) | matches size of `chunks` | see [Step 6](step06_embedding_generation.md) |
 | classifier → retrieval / eval | BaselineModelStruct | MAT-file (`baseline_model.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
-| projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
+| projection head training → retrieval | ProjectionHeadStruct | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
 | retrieval → evaluation | RetrievalResult | MAT-file (`resultsTbl.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | dataset build → fine-tune | ContrastiveDataset | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -11,8 +11,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 2. Train the projection head:
    ```matlab
 
-   projectionHeadStruct = reg.trainProjectionHead(embeddingMat, bootLabelMat);
-   save('models/projection_head.mat','projectionHeadStruct')
+    projectionHeadStruct = reg.trainProjectionHead(embeddingMat, bootLabelMat);
+    save('models/projection_head.mat','projectionHeadStruct');
 
    ```
 3. The pipeline automatically uses `projection_head.mat` when present.
@@ -25,7 +25,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   - `embeddingMat` (double matrix): embeddings from Step 6.
 
   - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
-- **Returns:** struct `projectionHeadStruct` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHead](identifier_registry.md#projectionhead)).
+- **Returns:** struct `projectionHeadStruct` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHeadStruct](identifier_registry.md#projectionheadstruct)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
@@ -34,7 +34,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHead`.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema references including `ProjectionHeadStruct`.
 
 
 ## Verification
@@ -45,8 +45,8 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   ```
 - Run projection head tests:
   ```matlab
-  runtests({'tests/testProjectionHeadSimulated.m', ...
-            'tests/testProjectionAutoloadPipeline.m'})
+    runtests({'tests/testProjectionHeadSimulated.m', ...
+              'tests/testProjectionAutoloadPipeline.m'});
   ```
   Tests verify improved Recall@n and automatic loading by `reg_pipeline`.
 


### PR DESCRIPTION
## Summary
- rename projection head variables in step08 docs to `projectionHeadStruct`, `embeddingMat`, and `bootLabelMat`
- document `projectionHeadStruct` interface in identifier registry

## Testing
- `matlab -batch "runtests({'tests/testProjectionHeadSimulated.m', 'tests/testProjectionAutoloadPipeline.m'})"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bcefbd5a483309439d1a46ee624b2