### PR TITLE
docs: update baseline classifier variable names

### DIFF
--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -9,8 +9,6 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Load embeddings and weak labels:
    ```matlab
-
-
    load('data/embeddingMat.mat','embeddingMat');
    load('data/bootLabelMat.mat','bootLabelMat');
    ```
@@ -22,49 +20,38 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 3. Enable hybrid retrieval combining cosine similarity and BM25:
    ```matlab
    resultsTbl = reg.hybridSearch(baselineModelStruct, embeddingMat, 'query', 'sample text');
-
    ```
 
 ## Function Interface
 
 ### reg.trainMultilabel
 - **Parameters:**
-
   - `embeddingMat` (double matrix): embeddings from Step 6.
-
-
   - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
 - **Returns:** struct `baselineModelStruct` with fields `weights` and `bias` (see [BaselineModelStruct](identifier_registry.md#baselinemodelstruct)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
   baselineModelStruct = reg.trainMultilabel(embeddingMat, bootLabelMat);
-
-
   ```
 
 ### reg.hybridSearch
 - **Parameters:**
-
-  - `baselineModelStruct` (struct)
-  - `embeddingMat` (double matrix)
+  - `baselineModelStruct` (struct): trained baseline classifier.
+  - `embeddingMat` (double matrix): document embeddings.
   - `'query'` (string): search text.
 - **Returns:** table `resultsTbl` containing `docId` and `score` fields (see [RetrievalResult](identifier_registry.md#retrievalresult)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-
   resultsTbl = reg.hybridSearch(baselineModelStruct, embeddingMat, 'query', 'example');
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `embeddingMat`, `bootLabelMat`, `BaselineModelStruct`, and `RetrievalResult` outputs.
-
-
-
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `embeddingMat`, `bootLabelMat`, `baselineModelStruct`, and `RetrievalResult` outputs.
 
 ## Verification
 - Classifier training completes and saves `baseline_model.mat`.
-- Verify model schema:
+- Verify `baselineModelStruct` schema:
   ```matlab
   assert(all(isfield(baselineModelStruct, {'weights','bias'})));
   ```
@@ -74,7 +61,7 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
             'tests/testHybridSearch.m'})
   ```
   Tests confirm baseline metrics and retrieval behavior.
-- Retrieval results contain expected fields:
+- Verify `resultsTbl` contains expected fields:
   ```matlab
   assert(all(ismember({'docId','score'}, resultsTbl.Properties.VariableNames)));
   ```


### PR DESCRIPTION
## Summary
- clarify Step 7 instructions and function interfaces with explicit variable names (`embeddingMat`, `bootLabelMat`, `baselineModelStruct`, `resultsTbl`)
- update verification steps to check `baselineModelStruct` and `resultsTbl`

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bceeda48c8330bd5ae4bbe932c6cc