### PR TITLE
docs: rename fine-tuning variables

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -62,8 +62,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | trainMultilabel | Train multi-label classifier | module | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | @todo | stub |
 | hybridSearch | Retrieve documents with hybrid search | module | `baselineModelStruct` struct, `embeddingMat` matrix, `queryStr` string | results table | @todo | stub |
 | trainProjectionHead | Train projection head on embeddings | module | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | @todo | stub |
-| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | dataset struct | @todo | stub |
-| ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `dsStruct` struct | encoder struct | @todo | stub |
+| ftBuildContrastiveDataset | Build dataset for encoder fine-tuning | module | `chunkTbl` table, `bootLabelMat` matrix | `contrastiveDatasetTbl` table | @todo | stub |
+| ftTrainEncoder | Fine-tune encoder on contrastive dataset | module | `contrastiveDatasetTbl` table, `unfreezeTop` double | `fineTunedEncoderStruct` struct | @todo | stub |
 | evalRetrieval | Evaluate retrieval metrics | module | `resultsTbl` table, `goldTbl` table | metrics struct | @todo | stub |
 | evalPerLabel | Compute per-label metrics | module | `predYMat` matrix, `trueYMat` matrix | metrics table | @todo | stub |
 | loadGold | Load gold annotation data | module | `pathStr` string | `goldTbl` table | @todo | stub |
@@ -92,7 +92,8 @@ Keep the illustrative examples below in sync with the current naming conventions
 | reg.trainMultilabel | `embeddingMat` matrix, `bootLabelMat` matrix | `baselineModelStruct` struct | none |
 | reg.hybridSearch | `baselineModelStruct` struct, `embeddingMat` matrix, query string | `resultsTbl` table | none |
 | reg.trainProjectionHead | `embeddingMat` matrix, `bootLabelMat` matrix | head struct | none |
-| reg.ftBuildContrastiveDataset | chunks table, `bootLabelMat` matrix | dataset struct | none |
+| reg.ftBuildContrastiveDataset | chunksTbl table, `bootLabelMat` matrix | `contrastiveDatasetTbl` table | none |
+| reg.ftTrainEncoder | contrastiveDatasetTbl table, unfreezeTop double | `fineTunedEncoderStruct` struct | none |
 | reg.evalRetrieval | resultsTbl table, goldTbl table | metrics tables | writes report files |
 | reg.loadGold | pathStr string | goldTbl table | reads gold annotations |
 | reg.evalPerLabel | predYMat matrix, trueYMat matrix | metrics table | none |
@@ -112,6 +113,9 @@ Keep the illustrative examples below in sync with the current naming conventions
 | configStruct | Configuration settings loaded from JSON files | module | struct | n/a | fields must exist | returned by config |
 | gpuInfoStruct | GPU device information | local | struct | n/a | CUDA-enabled | obtained via `gpuDevice` |
 | productsTbl | Installed MATLAB products | local | table | n/a | includes required toolboxes | obtained via `ver` |
+| bootLabelMat | Bootstrapped weak labels for chunks | module | sparse logical matrix | n/a | size matches `chunksTbl` | produced by `weakRules` |
+| contrastiveDatasetTbl | Contrastive training pairs | module | table | n/a | fields `anchorIdx`, `posIdx`, `negIdx` | output of `ftBuildContrastiveDataset` |
+| fineTunedEncoderStruct | Fine-tuned encoder weights | module | struct | n/a | fields exist | output of `ftTrainEncoder` |
 
 ## Constants / Enums
 
@@ -272,7 +276,7 @@ Common test scopes or prefixes include:
 | projection head training → retrieval | ProjectionHead | MAT-file (`projection_head.mat`) | fields exist | see [Step 8](step08_projection_head.md) |
 | retrieval → evaluation | RetrievalResult | MAT-file (`resultsTbl.mat`) | fields exist | see [Step 7](step07_baseline_classifier.md) |
 | dataset build → fine-tune | ContrastiveDataset | MAT-file (`contrastive_ds.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
-| fine-tune → evaluation | ftEncoder struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
+| fine-tune → evaluation | fineTunedEncoderStruct struct with BERT weights | MAT-file (`fine_tuned_bert.mat`) | fields exist | see [Step 9](step09_encoder_finetuning.md) |
 | evaluation → reports | Metric | CSV/PDF | schema check | see [Step 10](step10_evaluation_reporting.md) |
 
 ---

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -9,10 +9,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 1. Build the contrastive training dataset:
    ```matlab
-
-
-   contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
-
+   contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunksTbl, bootLabelMat);
+   save('data/contrastive_ds.mat', 'contrastiveDatasetTbl')
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab
@@ -25,13 +23,13 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### reg.ftBuildContrastiveDataset
 - **Parameters:**
-  - `chunks` (table): see Step 4.
-  - `bootLabelMat` (sparse logical matrix): bootstrapped labels.
-- **Returns:** table `contrastiveDatasetTbl` containing contrastive pairs (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
+  - `chunksTbl` (table): see Step 4.
+  - `bootLabelMat` (sparse logical `[numChunks x numClasses]`): bootstrapped labels.
+- **Returns:** table `contrastiveDatasetTbl` with columns `anchorIdx`, `posIdx`, and `negIdx` (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunks, bootLabelMat);
+  contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunksTbl, bootLabelMat);
   ```
 
 ### reg.ftTrainEncoder


### PR DESCRIPTION
## Summary
- clarify fine-tuning workflow docs to use `contrastiveDatasetTbl`, `bootLabelMat`, and `fineTunedEncoderStruct`
- record new identifiers and updated interfaces in `identifier_registry.md`

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bcf0462f88330877228344f233a90