### PR TITLE
docs: clarify diffStruct example in data acquisition step

### DIFF
--- a/docs/step11_data_acquisition_diffs.md
+++ b/docs/step11_data_acquisition_diffs.md
@@ -11,12 +11,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```matlab
    reg.crrSync();
    ```
-2. Generate diff reports between document versions:
+2. Generate diffStruct reports between document versions:
    ```matlab
-   reg.crrDiffVersions('versionA','versionB');
+   diffStruct = reg.crrDiffVersions('versionA','versionB');
    reg.crrDiffReport;
    ```
-3. Review HTML or PDF diff outputs for changes.
+3. Review HTML or PDF diffStruct outputs for changes.
 
 ## Function Interface
 


### PR DESCRIPTION
## Summary
- Update Step 11 documentation to capture `reg.crrDiffVersions` output as `diffStruct`
- Clarify text to refer to `diffStruct` when reviewing outputs

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689bcf0db9c0833080e5d49fc049edd8