### PR TITLE
docs: clarify class interface and testing requirements

### DIFF
--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -6,6 +6,8 @@ See [Master Scaffold](master_scaffold.md) for module stubs and test skeletons.
 
 This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic classifier. Each task is scoped to minimize coupling and lists prerequisites so the system can be assembled and tested incrementally.
 
+Every module must expose a MATLAB class with a clearly defined public interface (methods/properties) and, where appropriate, an abstract superclass or interface class.
+
 ## 1. Environment & Tooling
 - **Goal:** Prepare a reproducible MATLAB workspace.
 - **Dependencies:** None.
@@ -29,6 +31,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Convert PDFs into raw text documents.
 - **Depends on:** Repository Setup.
 - **Implementation:** `reg.ingest_pdfs` with fixtures for text and image-only PDFs.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testPDFIngest.m` ensures OCR fallback and basic parsing.
 - **Output:** Table of documents (`doc_id`, `text`).
 
@@ -36,6 +39,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Split long documents into overlapping token chunks.
 - **Depends on:** Data Ingestion Module.
 - **Implementation:** `reg.chunk_text` respecting `chunk_size_tokens` & `chunk_overlap`.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testIngestAndChunk.m` verifies chunk counts and boundaries.
 - **Output:** Table of chunks (`chunk_id`, `doc_id`, `text`).
 
@@ -43,6 +47,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Bootstrap labels using rule-based heuristics.
 - **Depends on:** Text Chunking Module.
 - **Implementation:** `reg.weak_rules` returning label matrix.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testRulesAndModel.m` confirms label coverage and format.
  - **Output:** Sparse label matrix `bootLabelMat`.
 
@@ -50,6 +55,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Embed chunks using BERT (GPU) or FastText fallback.
 - **Depends on:** Text Chunking Module.
 - **Implementation:** `reg.doc_embeddings_bert_gpu` & `reg.precompute_embeddings`.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFeatures.m` checks embedding shapes & backend selection.
 - **Output:** Matrix `embeddingMat` of embeddings per chunk.
 
@@ -59,6 +65,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Implementation:**
   - `reg.train_multilabel` for classifier.
   - `reg.hybrid_search` for cosine + BM25 retrieval.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testRegressionMetricsSimulated.m` & `tests/testHybridSearch.m` validate baseline metrics.
 - **Output:** Baseline model artifacts and retrieval functionality.
 
@@ -66,6 +73,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Improve retrieval with an MLP on frozen embeddings.
 - **Depends on:** Baseline Classifier & Retrieval.
 - **Implementation:** `reg.train_projection_head` with `reg_projection_workflow.m` driver.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testProjectionHeadSimulated.m` ensures Recall@n increases over baseline. `tests/testProjectionAutoloadPipeline.m` verifies auto-use in `reg_pipeline`.
 - **Output:** `projection_head.mat` used automatically by the pipeline.
 
@@ -73,6 +81,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Unfreeze BERT layers and apply contrastive learning.
 - **Depends on:** Projection Head Workflow (optional but recommended) and Embedding Generation Module.
 - **Implementation:** `reg.ft_build_contrastive_dataset`, `reg.ft_train_encoder`, and `reg_finetune_encoder_workflow.m`.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFineTuneSmoke.m` for basic convergence, `tests/testFineTuneResume.m` for checkpoint resume.
 - **Output:** `fine_tuned_bert.mat` encoder weights.
 
@@ -83,6 +92,7 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
   - `reg.eval_retrieval` and `reg.eval_per_label` for metrics.
   - `reg_eval_and_report.m` generates `reg_eval_report.pdf` and trends.
   - Gold mini-pack support via `reg.load_gold` and `reg_eval_gold.m`.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testMetricsExpectedJSON.m`, `tests/testGoldMetrics.m`, `tests/testReportArtifact.m`.
 - **Output:** Metrics CSVs, PDF/HTML reports, gold evaluation results.
 
@@ -90,12 +100,14 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Automate CRR/EBA fetches and track version differences.
 - **Depends on:** Environment & Tooling.
 - **Implementation:** `reg_crr_sync.m`, `reg.crr_diff_versions`, `reg.crr_diff_articles`, and related HTML/PDF report generators.
+  - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFetchers.m` (network-tolerant).
 - **Output:** Date-stamped corpora and diff reports.
 
 ## 12. Continuous Testing Framework
 - **Goal:** Ensure every module is validated locally and in CI.
 - **Depends on:** All previous modules.
+- **Testing Style:** All tests must subclass `matlab.unittest.TestCase` and use fixtures with explicit teardown methods.
 - **Steps:**
   1. Run full suite: `results = runtests("tests","IncludeSubfolders",true,"UseParallel",false);`.
   2. Examine `table(results)` and address failures before proceeding.


### PR DESCRIPTION
## Summary
- mandate each module expose a MATLAB class with a public interface
- remind that implementation bullets should cite module class names and interfaces
- require tests to subclass `matlab.unittest.TestCase` with fixtures and teardown methods

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c49db5424833094aa77dc7be02ac7