### PR TITLE
docs: rename length method to tokenCount

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -61,7 +61,7 @@ classdef Document
         
         function n = tokenCount(obj)
             % Return number of tokens in text.
-            n = [];  %#ok<*NASGU>
+            n = numel(obj.text);
         end
         
         function md = metadata(obj)
@@ -92,9 +92,9 @@ classdef Chunk
             obj.endIndex = endIndex;
         end
         
-        function len = length(obj)
+        function n = tokenCount(obj)
             % Return number of tokens in text.
-            len = [];
+            n = numel(obj.text);
         end
         
         function tf = overlaps(obj, other)

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -53,7 +53,9 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 
 ## Class Methods
-
+| Name | Class | Purpose | Notes |
+|------|-------|---------|-------|
+| tokenCount | Document, Chunk | Return number of tokens in text | Renamed from `length` |
 
 ### Class Interfaces
 


### PR DESCRIPTION
## Summary
- rename `length` method to `tokenCount` in class architecture overview
- replace placeholder token count logic with `numel`
- record `tokenCount` in identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c5a4acbb8833096c0fa07dd003d9e