### PR TITLE
Use two-space indentation in ClassArchitecture doc

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -46,440 +46,383 @@
 **Model Layer (+model)**
 
 classdef Document
-    %DOCUMENT Represents a regulatory PDF document.
-    
-    properties
-        docID   % Unique identifier
-        text    % Raw text content
+  %DOCUMENT Represents a regulatory PDF document.
+  properties
+    docID   % Unique identifier
+    text    % Raw text content
+  end
+  methods
+    function obj = Document(docID, text)
+      obj.docID = docID;
+      obj.text = text;
     end
-    
-    methods
-        function obj = Document(docID, text)
-            obj.docID = docID;
-            obj.text = text;
-        end
-        
-        function n = tokenCount(obj)
-            % Return number of tokens in text.
-            n = [];  %#ok<*NASGU>
-        end
-        
-        function md = metadata(obj)
-            % Return additional metadata (source, title, etc.).
-            md = struct();
-        end
+    function n = tokenCount(obj)
+      % Return number of tokens in text.
+      n = [];  %#ok<*NASGU>
     end
+    function md = metadata(obj)
+      % Return additional metadata (source, title, etc.).
+      md = struct();
+    end
+  end
 end
 
 
 classdef Chunk
-    %CHUNK Overlapping text segment from a document.
-    
-    properties
-        chunkID
-        docID
-        text
-        startIndex
-        endIndex
+  %CHUNK Overlapping text segment from a document.
+  properties
+    chunkID
+    docID
+    text
+    startIndex
+    endIndex
+  end
+  methods
+    function obj = Chunk(chunkID, docID, text, startIndex, endIndex)
+      obj.chunkID = chunkID;
+      obj.docID = docID;
+      obj.text = text;
+      obj.startIndex = startIndex;
+      obj.endIndex = endIndex;
     end
-    
-    methods
-        function obj = Chunk(chunkID, docID, text, startIndex, endIndex)
-            obj.chunkID = chunkID;
-            obj.docID = docID;
-            obj.text = text;
-            obj.startIndex = startIndex;
-            obj.endIndex = endIndex;
-        end
-        
-        function len = length(obj)
-            % Return number of tokens in text.
-            len = [];
-        end
-        
-        function tf = overlaps(obj, other)
-            % Determine if two chunks overlap in a document.
-            tf = false;
-        end
+    function len = length(obj)
+      % Return number of tokens in text.
+      len = [];
     end
+    function tf = overlaps(obj, other)
+      % Determine if two chunks overlap in a document.
+      tf = false;
+    end
+  end
 end
 
 
 classdef LabelMatrix
-    %LABELMATRIX Sparse weak labels per chunk and topic.
-    
-    properties
-        chunkIDs
-        topicIDs
-        matrix  % Sparse representation
+  %LABELMATRIX Sparse weak labels per chunk and topic.
+  properties
+    chunkIDs
+    topicIDs
+    matrix  % Sparse representation
+  end
+  methods
+    function obj = LabelMatrix(chunkIDs, topicIDs, matrix)
+      obj.chunkIDs = chunkIDs;
+      obj.topicIDs = topicIDs;
+      obj.matrix = matrix;
     end
-    
-    methods
-        function obj = LabelMatrix(chunkIDs, topicIDs, matrix)
-            obj.chunkIDs = chunkIDs;
-            obj.topicIDs = topicIDs;
-            obj.matrix = matrix;
-        end
-        
-        function addLabel(obj, chunkID, topicID, weight)
-            % Insert or update a label weight.
-        end
-        
-        function labels = getLabelsForChunk(obj, chunkID)
-            % Return topic:weight pairs for a chunk.
-            labels = struct();
-        end
+    function addLabel(obj, chunkID, topicID, weight)
+      % Insert or update a label weight.
     end
+    function labels = getLabelsForChunk(obj, chunkID)
+      % Return topic:weight pairs for a chunk.
+      labels = struct();
+    end
+  end
 end
 
 
 classdef Embedding
-    %EMBEDDING Vector representation of a chunk.
-    
-    properties
-        chunkID
-        vector
-        modelName
+  %EMBEDDING Vector representation of a chunk.
+  properties
+    chunkID
+    vector
+    modelName
+  end
+  methods
+    function obj = Embedding(chunkID, vector, modelName)
+      obj.chunkID = chunkID;
+      obj.vector = vector;
+      obj.modelName = modelName;
     end
-    
-    methods
-        function obj = Embedding(chunkID, vector, modelName)
-            obj.chunkID = chunkID;
-            obj.vector = vector;
-            obj.modelName = modelName;
-        end
-        
-        function sim = cosineSimilarity(obj, other)
-            % Compute cosine similarity with another embedding.
-            sim = 0;
-        end
-        
-        function normalize(obj)
-            % Normalize vector in-place.
-        end
+    function sim = cosineSimilarity(obj, other)
+      % Compute cosine similarity with another embedding.
+      sim = 0;
     end
+    function normalize(obj)
+      % Normalize vector in-place.
+    end
+  end
 end
 
 classdef BaselineModel
-    %BASELINEMODEL Multi-label classifier and hybrid retrieval index.
-    
-    properties
-        labelMatrix
-        embeddings
-        modelWeights
+  %BASELINEMODEL Multi-label classifier and hybrid retrieval index.
+  properties
+    labelMatrix
+    embeddings
+    modelWeights
+  end
+  methods
+    function obj = BaselineModel(labelMatrix, embeddings)
+      obj.labelMatrix = labelMatrix;
+      obj.embeddings = embeddings;
+      obj.modelWeights = [];
     end
-    
-    methods
-        function obj = BaselineModel(labelMatrix, embeddings)
-            obj.labelMatrix = labelMatrix;
-            obj.embeddings = embeddings;
-            obj.modelWeights = [];
-        end
-        
-        function train(obj, epochs, lr)
-            % Train the classifier.
-        end
-        
-        function probs = predict(obj, embedding)
-            % Predict label probabilities for a single embedding.
-            probs = [];
-        end
-        
-        function save(obj, path)
-            % Serialize model to disk.
-        end
+    function train(obj, epochs, lr)
+      % Train the classifier.
     end
+    function probs = predict(obj, embedding)
+      % Predict label probabilities for a single embedding.
+      probs = [];
+    end
+    function save(obj, path)
+      % Serialize model to disk.
+    end
+  end
 end
 
 
 
 classdef ProjectionHead
-    %PROJECTIONHEAD MLP or shallow network for embedding transformation.
-    
-    properties
-        inputDim
-        outputDim
-        parameters
+  %PROJECTIONHEAD MLP or shallow network for embedding transformation.
+  properties
+    inputDim
+    outputDim
+    parameters
+  end
+  methods
+    function obj = ProjectionHead(inputDim, outputDim)
+      obj.inputDim = inputDim;
+      obj.outputDim = outputDim;
+      obj.parameters = struct();
     end
-    
-    methods
-        function obj = ProjectionHead(inputDim, outputDim)
-            obj.inputDim = inputDim;
-            obj.outputDim = outputDim;
-            obj.parameters = struct();
-        end
-        
-        function fit(obj, X, Y, epochs, lr)
-            % Train projection head.
-        end
-        
-        function Xtrans = transform(obj, X)
-            % Apply transformation to embeddings.
-            Xtrans = [];
-        end
+    function fit(obj, X, Y, epochs, lr)
+      % Train projection head.
     end
+    function Xtrans = transform(obj, X)
+      % Apply transformation to embeddings.
+      Xtrans = [];
+    end
+  end
 end
 
 
 classdef Encoder
-    %ENCODER Fine-tuned model for contrastive learning.
-    
-    properties
-        baseModel
-        stateDict
+  %ENCODER Fine-tuned model for contrastive learning.
+  properties
+    baseModel
+    stateDict
+  end
+  methods
+    function obj = Encoder(baseModel)
+      obj.baseModel = baseModel;
+      obj.stateDict = [];
     end
-    
-    methods
-        function obj = Encoder(baseModel)
-            obj.baseModel = baseModel;
-            obj.stateDict = [];
-        end
-        
-        function fineTune(obj, dataset, epochs, lr)
-            % Contrastive fine-tuning procedure.
-        end
-        
-        function emb = encode(obj, text)
-            % Convert text to embedding.
-            emb = [];
-        end
+    function fineTune(obj, dataset, epochs, lr)
+      % Contrastive fine-tuning procedure.
     end
+    function emb = encode(obj, text)
+      % Convert text to embedding.
+      emb = [];
+    end
+  end
 end
 
 
 classdef Metrics
-    %METRICS Encapsulates evaluation results.
-    
-    properties
-        metricName
-        scores  % e.g., containers.Map or struct
+  %METRICS Encapsulates evaluation results.
+  properties
+    metricName
+    scores  % e.g., containers.Map or struct
+  end
+  methods
+    function obj = Metrics(metricName, scores)
+      obj.metricName = metricName;
+      obj.scores = scores;
     end
-    
-    methods
-        function obj = Metrics(metricName, scores)
-            obj.metricName = metricName;
-            obj.scores = scores;
-        end
-        
-        function s = summary(obj)
-            % Return human-readable summary of metrics.
-            s = "";
-        end
+    function s = summary(obj)
+      % Return human-readable summary of metrics.
+      s = "";
     end
+  end
 end
 
 
 classdef CorpusVersion
-    %CORPUSVERSION Versioned corpus handling for diff operations.
-    
-    properties
-        versionID
-        documents  % Array of Document
+  %CORPUSVERSION Versioned corpus handling for diff operations.
+  properties
+    versionID
+    documents  % Array of Document
+  end
+  methods
+    function obj = CorpusVersion(versionID, documents)
+      obj.versionID = versionID;
+      obj.documents = documents;
     end
-    
-    methods
-        function obj = CorpusVersion(versionID, documents)
-            obj.versionID = versionID;
-            obj.documents = documents;
-        end
-        
-        function diffResult = diff(obj, other)
-            % Return differences between versions.
-            diffResult = struct();
-        end
+    function diffResult = diff(obj, other)
+      % Return differences between versions.
+      diffResult = struct();
     end
+  end
 end
 
 
 **View Layer (+view)**
 
 classdef EvalReportView
-    %EVALREPORTVIEW Renders evaluation metrics into report format.
-    
-    methods
-        function renderPDF(~, metrics, path)
-            % Generate PDF report.
-        end
-        
-        function renderHTML(~, metrics, path)
-            % Generate HTML report.
-        end
+  %EVALREPORTVIEW Renders evaluation metrics into report format.
+  methods
+    function renderPDF(~, metrics, path)
+      % Generate PDF report.
     end
+    function renderHTML(~, metrics, path)
+      % Generate HTML report.
+    end
+  end
 end
 
 classdef DiffReportView
-    %DIFFREPORTVIEW Renders document diffs between corpus versions.
-    
-    methods
-        function render(~, diffResult, path, fmt)
-            % Generate diff report in HTML or PDF.
-            if nargin < 4
-                fmt = "html";
-            end
-        end
+  %DIFFREPORTVIEW Renders document diffs between corpus versions.
+  methods
+    function render(~, diffResult, path, fmt)
+      % Generate diff report in HTML or PDF.
+      if nargin < 4
+        fmt = "html";
+      end
     end
+  end
 end
 
 
 classdef MetricsPlotsView
-    %METRICSPLOTSVIEW Creates visual plots for metrics and trends.
-    
-    methods
-        function plotHeatmap(~, metrics, path)
-            % Render heatmap from metric matrix.
-        end
-        
-        function plotTrend(~, metricHistory, path)
-            % Render line chart for metric trends over versions.
-        end
+  %METRICSPLOTSVIEW Creates visual plots for metrics and trends.
+  methods
+    function plotHeatmap(~, metrics, path)
+      % Render heatmap from metric matrix.
     end
+    function plotTrend(~, metricHistory, path)
+      % Render line chart for metric trends over versions.
+    end
+  end
 end
 
 
 **Controller Layer (+controller)**
 
 classdef IngestionController
-    %INGESTIONCONTROLLER Parses PDFs and returns Document objects.
-    
-    methods
-        function documents = run(~, sourcePaths)
-            documents = [];
-        end
+  %INGESTIONCONTROLLER Parses PDFs and returns Document objects.
+  methods
+    function documents = run(~, sourcePaths)
+      documents = [];
     end
+  end
 end
 
 
 classdef ChunkingController
-    %CHUNKINGCONTROLLER Splits documents into overlapping chunks.
-    
-    methods
-        function chunks = run(~, documents, window, overlap)
-            chunks = [];
-        end
+  %CHUNKINGCONTROLLER Splits documents into overlapping chunks.
+  methods
+    function chunks = run(~, documents, window, overlap)
+      chunks = [];
     end
+  end
 end
 
 classdef WeakLabelingController
-    %WEAKLABELINGCONTROLLER Applies heuristic rules to label chunks.
-    
-    methods
-        function labelMatrix = run(~, chunks, labelingRules)
-            labelMatrix = [];
-        end
+  %WEAKLABELINGCONTROLLER Applies heuristic rules to label chunks.
+  methods
+    function labelMatrix = run(~, chunks, labelingRules)
+      labelMatrix = [];
     end
+  end
 end
 
 
 classdef EmbeddingController
-    %EMBEDDINGCONTROLLER Generates embeddings for chunks.
-    
-    methods
-        function embeddings = run(~, chunks, modelName)
-            embeddings = [];
-        end
+  %EMBEDDINGCONTROLLER Generates embeddings for chunks.
+  methods
+    function embeddings = run(~, chunks, modelName)
+      embeddings = [];
     end
+  end
 end
 
 
 classdef BaselineController
-    %BASELINECONTROLLER Trains baseline classifier and serves retrieval.
-    
-    methods
-        function model = train(~, labelMatrix, embeddings)
-            model = [];
-        end
-        
-        function chunks = retrieve(~, queryEmbedding, topK)
-            chunks = [];
-        end
+  %BASELINECONTROLLER Trains baseline classifier and serves retrieval.
+  methods
+    function model = train(~, labelMatrix, embeddings)
+      model = [];
     end
+    function chunks = retrieve(~, queryEmbedding, topK)
+      chunks = [];
+    end
+  end
 end
 
 classdef ProjectionHeadController
-    %PROJECTIONHEADCONTROLLER Manages projection head training and usage.
-    
-    methods
-        function head = fit(~, embeddings, labels)
-            head = [];
-        end
-        
-        function transformed = apply(~, projectionHead, embeddings)
-            transformed = [];
-        end
+  %PROJECTIONHEADCONTROLLER Manages projection head training and usage.
+  methods
+    function head = fit(~, embeddings, labels)
+      head = [];
     end
+    function transformed = apply(~, projectionHead, embeddings)
+      transformed = [];
+    end
+  end
 end
 
 
 classdef FineTuneController
-    %FINETUNECONTROLLER Fine-tunes base models.
-    
-    methods
-        function encoder = run(~, dataset, baseModel)
-            encoder = [];
-        end
+  %FINETUNECONTROLLER Fine-tunes base models.
+  methods
+    function encoder = run(~, dataset, baseModel)
+      encoder = [];
     end
+  end
 end
 
 
 classdef EvaluationController
-    %EVALUATIONCONTROLLER Computes metrics and generates reports.
-    
-    methods
-        function metrics = evaluate(~, model, testEmbeddings, trueLabels)
-            metrics = [];
-        end
-        
-        function generateReports(~, metrics, outDir)
-            % Use view layer to produce reports.
-        end
+  %EVALUATIONCONTROLLER Computes metrics and generates reports.
+  methods
+    function metrics = evaluate(~, model, testEmbeddings, trueLabels)
+      metrics = [];
     end
+    function generateReports(~, metrics, outDir)
+      % Use view layer to produce reports.
+    end
+  end
 end
 
 
 classdef DataAcquisitionController
-    %DATAACQUISITIONCONTROLLER Fetches corpora and runs diffs.
-    
-    methods
-        function corpus = fetch(~, sources)
-            corpus = [];
-        end
-        
-        function diffVersions(~, oldVersion, newVersion, outDir)
-            % Run diff and trigger DiffReportView.
-        end
+  %DATAACQUISITIONCONTROLLER Fetches corpora and runs diffs.
+  methods
+    function corpus = fetch(~, sources)
+      corpus = [];
     end
+    function diffVersions(~, oldVersion, newVersion, outDir)
+      % Run diff and trigger DiffReportView.
+    end
+  end
 end
 
 
 classdef PipelineController
-    %PIPELINECONTROLLER High-level orchestration based on dependency graph.
-    
-    properties
-        controllers % Struct or containers.Map holding controller instances
+  %PIPELINECONTROLLER High-level orchestration based on dependency graph.
+  properties
+    controllers % Struct or containers.Map holding controller instances
+  end
+  methods
+    function obj = PipelineController(controllers)
+      obj.controllers = controllers;
     end
-    
-    methods
-        function obj = PipelineController(controllers)
-            obj.controllers = controllers;
-        end
-        
-        function execute(obj, config)
-            % Execute pipeline steps using obj.controllers.
-        end
+    function execute(obj, config)
+      % Execute pipeline steps using obj.controllers.
     end
+  end
 end
 
 
 classdef TestController
-    %TESTCONTROLLER Executes continuous test suite.
-    
-    methods
-        function results = runTests(~, selectors)
-            if nargin < 2
-                selectors = [];
-            end
-            results = struct();
-        end
+  %TESTCONTROLLER Executes continuous test suite.
+  methods
+    function results = runTests(~, selectors)
+      if nargin < 2
+        selectors = [];
+      end
+      results = struct();
     end
+  end
 end
 


### PR DESCRIPTION
## Summary
- Simplify `ClassArchitecture.md` code examples to use two-space indentation for improved readability.

## Testing
- `python3 -m markdown docs/ClassArchitecture.md` *(fails: No module named markdown)*
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c5a8d585c83308284456c7bdcb631