### PR TITLE
docs: namespace class architecture references

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -1,51 +1,47 @@
-**Model Layer**
+**Model Layer (+model)**
 
+| Class Path                | Purpose & Key Data                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `+model/Document.m`       | Represents raw PDF text with identifiers (`doc_id`, `text`)\\:codex-file-citation                   |
+| `+model/Chunk.m`          | Overlapping token segments of documents (`chunk_id`, `doc_id`, `text`)\\:codex-file-citation        |
+| `+model/LabelMatrix.m`    | Sparse weak labels (`Yboot`) aligned to chunks and topics\\:codex-file-citation                     |
+| `+model/Embedding.m`      | Vector representation of each chunk (`X`) produced by BERT or fallback models\\:codex-file-citation |
+| `+model/BaselineModel.m`  | Multi‑label classifier and hybrid retrieval artifacts\\:codex-file-citation                         |
+| `+model/ProjectionHead.m` | MLP fine-tuning frozen embeddings to enhance retrieval\\:codex-file-citation                        |
+| `+model/Encoder.m`        | Fine‑tuned BERT weights for contrastive learning workflows\\:codex-file-citation                    |
+| `+model/Metrics.m`        | Evaluation results and per‑label performance data\\:codex-file-citation                             |
+| `+model/CorpusVersion.m`  | Versioned corpora for diff operations and reports\\:codex-file-citation                             |
 
-| Class            | Purpose & Key Data                                                                                 |
-| ---------------- | -------------------------------------------------------------------------------------------------- |
-| `Document`       | Represents raw PDF text with identifiers (`doc_id`, `text`)\:codex-file-citation                   |
-| `Chunk`          | Overlapping token segments of documents (`chunk_id`, `doc_id`, `text`)\:codex-file-citation        |
-| `LabelMatrix`    | Sparse weak labels (`Yboot`) aligned to chunks and topics\:codex-file-citation                     |
-| `Embedding`      | Vector representation of each chunk (`X`) produced by BERT or fallback models\:codex-file-citation |
-| `BaselineModel`  | Multi‑label classifier and hybrid retrieval artifacts\:codex-file-citation                         |
-| `ProjectionHead` | MLP fine-tuning frozen embeddings to enhance retrieval\:codex-file-citation                        |
-| `Encoder`        | Fine‑tuned BERT weights for contrastive learning workflows\:codex-file-citation                    |
-| `Metrics`        | Evaluation results and per‑label performance data\:codex-file-citation                             |
-| `CorpusVersion`  | Versioned corpora for diff operations and reports\:codex-file-citation                             |
+**View Layer (+view)**
 
+| Class Path                 | Purpose                                                                        |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| `+view/EvalReportView.m`   | Generates PDF/HTML reports summarizing metrics and trends\\:codex-file-citation |
+| `+view/DiffReportView.m`   | Presents HTML or PDF diffs between regulatory versions\\:codex-file-citation    |
+| `+view/MetricsPlotsView.m` | Visualizes metrics/heatmaps (e.g., coretrieval, trend plots).                  |
 
-**View Layer**
+**Controller Layer (+controller)**
 
-| Class              | Purpose                                                                        |
-| ------------------ | ------------------------------------------------------------------------------ |
-| `EvalReportView`   | Generates PDF/HTML reports summarizing metrics and trends\:codex-file-citation |
-| `DiffReportView`   | Presents HTML or PDF diffs between regulatory versions\:codex-file-citation    |
-| `MetricsPlotsView` | Visualizes metrics/heatmaps (e.g., coretrieval, trend plots).                  |
-
-
-**Controller Layer**
-
-| Class                       | Coordinates                                                                                                    |
-| --------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `IngestionController`       | Runs `reg.ingest_pdfs` to populate `Document` models\:codex-file-citation                                      |
-| `ChunkingController`        | Splits documents into `Chunk` models via `reg.chunk_text`:codex-file-citation                                  |
-| `WeakLabelingController`    | Applies heuristic rules to create `LabelMatrix` models\:codex-file-citation                                    |
-| `EmbeddingController`       | Generates and caches `Embedding` models (`reg.doc_embeddings_bert_gpu`)\:codex-file-citation                   |
-| `BaselineController`        | Trains `BaselineModel` and serves retrieval (`reg.train_multilabel`, `reg.hybrid_search`)\:codex-file-citation |
-| `ProjectionHeadController`  | Fits `ProjectionHead` and integrates it into the pipeline\:codex-file-citation                                 |
-| `FineTuneController`        | Builds contrastive datasets and produces `Encoder` models\:codex-file-citation                                 |
-| `EvaluationController`      | Computes metrics and invokes `EvalReportView` and gold pack evaluation\:codex-file-citation                    |
-| `DataAcquisitionController` | Fetches regulatory corpora and triggers diff analyses with `DiffReportView`:codex-file-citation                |
-| `PipelineController`        | Orchestrates end‑to‑end execution based on module dependencies\:codex-file-citation                            |
-| `TestController`            | Executes continuous test suite to maintain reliability\:codex-file-citation                                    |
-
-
+| Class Path                               | Purpose                                                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `+controller/IngestionController.m`      | Runs `reg.ingest_pdfs` to populate `model.Document` models\\:codex-file-citation                               |
+| `+controller/ChunkingController.m`       | Splits documents into `model.Chunk` models via `reg.chunk_text`\\:codex-file-citation                          |
+| `+controller/WeakLabelingController.m`   | Applies heuristic rules to create `model.LabelMatrix` models\\:codex-file-citation                             |
+| `+controller/EmbeddingController.m`      | Generates and caches `model.Embedding` models (`reg.doc_embeddings_bert_gpu`)\\:codex-file-citation            |
+| `+controller/BaselineController.m`       | Trains `model.BaselineModel` and serves retrieval (`reg.train_multilabel`, `reg.hybrid_search`)\\:codex-file-citation |
+| `+controller/ProjectionHeadController.m` | Fits `model.ProjectionHead` and integrates it into the pipeline\\:codex-file-citation                          |
+| `+controller/FineTuneController.m`       | Builds contrastive datasets and produces `model.Encoder` models\\:codex-file-citation                          |
+| `+controller/EvaluationController.m`     | Computes metrics and invokes `view.EvalReportView` and gold pack evaluation\\:codex-file-citation              |
+| `+controller/DataAcquisitionController.m`| Fetches regulatory corpora and triggers diff analyses with `view.DiffReportView`\\:codex-file-citation         |
+| `+controller/PipelineController.m`       | Orchestrates end‑to‑end execution based on module dependencies\\:codex-file-citation                           |
+| `+controller/TestController.m`           | Executes continuous test suite to maintain reliability\\:codex-file-citation                                   |
 
 ## Class Definitions
 
 **Model Layer (+model)**
 
-classdef Document
+% +model/Document.m
+classdef model.Document
     %DOCUMENT Represents a regulatory PDF document.
     
     properties
@@ -72,7 +68,8 @@ classdef Document
 end
 
 
-classdef Chunk
+% +model/Chunk.m
+classdef model.Chunk
     %CHUNK Overlapping text segment from a document.
     
     properties
@@ -105,7 +102,8 @@ classdef Chunk
 end
 
 
-classdef LabelMatrix
+% +model/LabelMatrix.m
+classdef model.LabelMatrix
     %LABELMATRIX Sparse weak labels per chunk and topic.
     
     properties
@@ -133,7 +131,8 @@ classdef LabelMatrix
 end
 
 
-classdef Embedding
+% +model/Embedding.m
+classdef model.Embedding
     %EMBEDDING Vector representation of a chunk.
     
     properties
@@ -160,7 +159,8 @@ classdef Embedding
     end
 end
 
-classdef BaselineModel
+% +model/BaselineModel.m
+classdef model.BaselineModel
     %BASELINEMODEL Multi-label classifier and hybrid retrieval index.
     
     properties
@@ -193,7 +193,8 @@ end
 
 
 
-classdef ProjectionHead
+% +model/ProjectionHead.m
+classdef model.ProjectionHead
     %PROJECTIONHEAD MLP or shallow network for embedding transformation.
     
     properties
@@ -221,7 +222,8 @@ classdef ProjectionHead
 end
 
 
-classdef Encoder
+% +model/Encoder.m
+classdef model.Encoder
     %ENCODER Fine-tuned model for contrastive learning.
     
     properties
@@ -247,7 +249,8 @@ classdef Encoder
 end
 
 
-classdef Metrics
+% +model/Metrics.m
+classdef model.Metrics
     %METRICS Encapsulates evaluation results.
     
     properties
@@ -269,7 +272,8 @@ classdef Metrics
 end
 
 
-classdef CorpusVersion
+% +model/CorpusVersion.m
+classdef model.CorpusVersion
     %CORPUSVERSION Versioned corpus handling for diff operations.
     
     properties
@@ -293,7 +297,8 @@ end
 
 **View Layer (+view)**
 
-classdef EvalReportView
+% +view/EvalReportView.m
+classdef view.EvalReportView
     %EVALREPORTVIEW Renders evaluation metrics into report format.
     
     methods
@@ -307,7 +312,8 @@ classdef EvalReportView
     end
 end
 
-classdef DiffReportView
+% +view/DiffReportView.m
+classdef view.DiffReportView
     %DIFFREPORTVIEW Renders document diffs between corpus versions.
     
     methods
@@ -321,7 +327,8 @@ classdef DiffReportView
 end
 
 
-classdef MetricsPlotsView
+% +view/MetricsPlotsView.m
+classdef view.MetricsPlotsView
     %METRICSPLOTSVIEW Creates visual plots for metrics and trends.
     
     methods
@@ -338,7 +345,8 @@ end
 
 **Controller Layer (+controller)**
 
-classdef IngestionController
+% +controller/IngestionController.m
+classdef controller.IngestionController
     %INGESTIONCONTROLLER Parses PDFs and returns Document objects.
     
     methods
@@ -349,7 +357,8 @@ classdef IngestionController
 end
 
 
-classdef ChunkingController
+% +controller/ChunkingController.m
+classdef controller.ChunkingController
     %CHUNKINGCONTROLLER Splits documents into overlapping chunks.
     
     methods
@@ -359,7 +368,8 @@ classdef ChunkingController
     end
 end
 
-classdef WeakLabelingController
+% +controller/WeakLabelingController.m
+classdef controller.WeakLabelingController
     %WEAKLABELINGCONTROLLER Applies heuristic rules to label chunks.
     
     methods
@@ -370,7 +380,8 @@ classdef WeakLabelingController
 end
 
 
-classdef EmbeddingController
+% +controller/EmbeddingController.m
+classdef controller.EmbeddingController
     %EMBEDDINGCONTROLLER Generates embeddings for chunks.
     
     methods
@@ -381,7 +392,8 @@ classdef EmbeddingController
 end
 
 
-classdef BaselineController
+% +controller/BaselineController.m
+classdef controller.BaselineController
     %BASELINECONTROLLER Trains baseline classifier and serves retrieval.
     
     methods
@@ -395,7 +407,8 @@ classdef BaselineController
     end
 end
 
-classdef ProjectionHeadController
+% +controller/ProjectionHeadController.m
+classdef controller.ProjectionHeadController
     %PROJECTIONHEADCONTROLLER Manages projection head training and usage.
     
     methods
@@ -410,7 +423,8 @@ classdef ProjectionHeadController
 end
 
 
-classdef FineTuneController
+% +controller/FineTuneController.m
+classdef controller.FineTuneController
     %FINETUNECONTROLLER Fine-tunes base models.
     
     methods
@@ -421,7 +435,8 @@ classdef FineTuneController
 end
 
 
-classdef EvaluationController
+% +controller/EvaluationController.m
+classdef controller.EvaluationController
     %EVALUATIONCONTROLLER Computes metrics and generates reports.
     
     methods
@@ -436,7 +451,8 @@ classdef EvaluationController
 end
 
 
-classdef DataAcquisitionController
+% +controller/DataAcquisitionController.m
+classdef controller.DataAcquisitionController
     %DATAACQUISITIONCONTROLLER Fetches corpora and runs diffs.
     
     methods
@@ -451,7 +467,8 @@ classdef DataAcquisitionController
 end
 
 
-classdef PipelineController
+% +controller/PipelineController.m
+classdef controller.PipelineController
     %PIPELINECONTROLLER High-level orchestration based on dependency graph.
     
     properties
@@ -470,7 +487,8 @@ classdef PipelineController
 end
 
 
-classdef TestController
+% +controller/TestController.m
+classdef controller.TestController
     %TESTCONTROLLER Executes continuous test suite.
     
     methods


### PR DESCRIPTION
## Summary
- document package-qualified class file paths in ClassArchitecture
- show namespaced classdefs for model, view, and controller components

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c5a50af04833087fbb162de526a14