### PR TITLE
docs: track class members in naming workflow

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -3,9 +3,10 @@
 
 This README is a process guide for maintaining naming consistency. The
 [Matlab Style Guide](Matlab_Style_Guide.md) is the normative reference for
-all naming rules. All approved classes, functions, variables, constants,
-files/modules, tests, and other identifiers are tracked in the
+all naming rules. All approved classes, class properties, class methods, functions, variables, constants, files/modules, tests, and other identifiers are tracked in the
 `identifier_registry.md`.
+
+New or modified class properties and class methods must be recorded in [`docs/identifier_registry.md`](identifier_registry.md) alongside the corresponding class names.
 
 
 ## Function and Script Names
@@ -41,8 +42,7 @@ Place tests in the `tests/` folder and name each file `testName.m`. Refer to [Te
 
 1. Review the [Matlab Style Guide](Matlab_Style_Guide.md) for the latest
    naming guidance.
-2. Before coding, search for existing classes, functions, variables,
-   constants, files/modules, tests, and other identifiers that may be
+2. Before coding, search for existing classes, class properties, class methods, functions, variables, constants, files/modules, tests, and other identifiers that may be
    affected by your task:
    - Review `identifier_registry.md`.
    - Search the repository with `rg <identifier>` or MATLAB's *Find Files*
@@ -52,8 +52,8 @@ Place tests in the `tests/` folder and name each file `testName.m`. Refer to [Te
 5. Add or update tests: any new module or function must include a corresponding test file in `tests/`, and existing tests must be updated when module behavior changes.
 6. When introducing new identifiers in your code, **always** crosscheck this
    name isnt in use and **always** update the `identifier_registry.md` with
-   new classes, functions, variables, constants, files/modules, tests, and
-   other identifiers through a PR with your new code.
+   new classes, class properties, class methods, functions, variables, constants,
+   files/modules, tests, and other identifiers through a PR with your new code.
 7. Verify that any new or modified identifier has a corresponding entry in
    [`docs/identifier_registry.md`](identifier_registry.md).
 8. Run the full test suite locally:
@@ -81,7 +81,7 @@ violations are found.
 ## How to propose a new identifier
 
 
-1. Propose new classes, functions, variables, constants, files/modules, tests, or other identifiers in
+1. Propose new classes, class properties, class methods, functions, variables, constants, files/modules, tests, or other identifiers in
  `identifier_registry.md` with a PR. **always** ensure you are **not** causing drift by introducing new 
   identifiers and not recording them, or by not using existing identifiers consistently.
 2. Update code and commit, with any new identifiers and the updated `identifier_registry.md`  

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -1,8 +1,7 @@
 # Identifier Registry
 
 
-This is the **single source of truth** for classes, functions, variables,
-constants, files/modules, tests, and other identifiers that are defined
+This is the **single source of truth** for classes, class properties, class methods, functions, variables, constants, files/modules, tests, and other identifiers that are defined
 in the project. The [identifier registry](identifier_registry.md) is the
 definitive source for the collection of
 all identifiers, **not** how to name the identifiers.
@@ -33,7 +32,7 @@ Scopes:
 
 To document a new identifier:
 
-1. Locate the appropriate table (Classes, Functions, Variables, etc.).
+1. Locate the appropriate table (Classes, Class Properties, Class Methods, Functions, Variables, etc.).
 2. Add a row filling in every column for that section.
 3. Reference related files or tests when relevant.
 4. Ensure the name follows the conventions above.


### PR DESCRIPTION
## Summary
- clarify that naming workflow tracks class properties and methods in addition to classes
- update README_NAMING workflow steps and proposal instructions for class members
- note that class properties and methods belong in `docs/identifier_registry.md` alongside class names

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c60b735d88330914b963e73dde827