### PR TITLE
docs: clarify function and method naming

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -40,10 +40,13 @@ convention defined in **this** document [Matlab Style Guide](Matlab_Style_Guide.
 ### 1.2 Naming for Functions & Classes
 | Entity | Convention | Example |
 |--------|------------|---------|
-| Functions & Methods | lowerCamelCase | `loadData`, `computeScore` |
+| Standalone Functions | lowerCamelCase | `loadData`, `parseText` |
+| Class Methods | lowerCamelCase | `computeScore`, `updateModel` |
 | Classes | UpperCamelCase | `DocumentParser`, `EmbeddingModel` |
 | Class properties | lowerCamelCase | `maxEpochs`, `learningRate` |
 | Class constants | UPPER_CASE | `DEFAULT_TIMEOUT` |
+
+Class methods must also be recorded in the [identifier registry](identifier_registry.md) per the [process guide](README_NAMING.md).
 
 
 ### 1.3 Constants


### PR DESCRIPTION
## Summary
- separate table entries for standalone functions and class methods, each using lowerCamelCase
- note that class methods must be recorded in the identifier registry per the process guide

## Testing
- `matlab -batch "run_smoke_test"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c60d294f88330845487dd46c5393f