### PR TITLE
docs: expand identifier registry for classes

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -50,16 +50,20 @@ Keep the illustrative examples below in sync with the current naming conventions
 
 
 
+> **Note:** List every new or renamed class property here and follow `lowerCamelCase` naming.
+
 ## Class Properties
 
 | Class | Property | Type | Description |
 |-------|----------|------|-------------|
+| [BaselineModel](ClassArchitecture.md#L164-L194) | [weightMat](ClassArchitecture.md#L171) | double matrix | Learned classifier weights |
 
-
+> **Note:** List every new or renamed class method here and follow `lowerCamelCase` naming.
 
 ## Class Methods
 | Name | Class | Purpose | Notes |
 |------|-------|---------|-------|
+| [train](ClassArchitecture.md#L181-L183) | [BaselineModel](ClassArchitecture.md#L164-L194) | Fit classifier weights to embeddings and labels | |
 | tokenCount | Document, Chunk | Return number of tokens in text | Renamed from `length` |
 
 ## Class Interfaces


### PR DESCRIPTION
## Summary
- advise contributors to document new/renamed class properties and methods
- register `weightMat` property for `BaselineModel` and link to its definition
- record `train` method for `BaselineModel` with link to architecture doc

## Testing
- `matlab -batch "runtests"` *(command failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c60eaea308330959ddd0638dd897c