### PR TITLE
docs: add interface naming guidance for interfaces

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -43,10 +43,11 @@ convention defined in **this** document [Matlab Style Guide](Matlab_Style_Guide.
 | Standalone Functions | lowerCamelCase | `loadData`, `parseText` |
 | Class Methods | lowerCamelCase | `computeScore`, `updateModel` |
 | Classes | UpperCamelCase | `DocumentParser`, `EmbeddingModel` |
+| Interface Classes | UpperCamelCase prefixed with `I` | `ILogFormatter`, `IDataSource` |
 | Class properties | lowerCamelCase | `maxEpochs`, `learningRate` |
 | Class constants | UPPER_CASE | `DEFAULT_TIMEOUT` |
 
-Class methods must also be recorded in the [identifier registry](identifier_registry.md) per the [process guide](README_NAMING.md).
+Class names, class properties, class methods, and interface definitions must also be recorded in the [identifier registry](identifier_registry.md) per the [process guide](README_NAMING.md).
 
 
 ### 1.3 Constants


### PR DESCRIPTION
## Summary
- document naming convention for interface classes
- note that classes, properties, methods, and interfaces must be recorded in the identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c6582d0288330bdbabade46981eea