### PR TITLE
Rename classifier interface entry to IClassifier

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -70,7 +70,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 ## Class Interfaces
 | Interface | Purpose | Methods | Implementing Classes | Notes |
 |-----------|---------|---------|----------------------|-------|
-| ClassifierInterface | Standardize classifier APIs | train, predict | BaselineModel | example interface |
+| IClassifier | Standardize classifier APIs | train, predict | BaselineModel | example interface |
 
 
 


### PR DESCRIPTION
## Summary
- Rename `ClassifierInterface` to `IClassifier` in identifier registry

## Testing
- `pre-commit run --files docs/identifier_registry.md` *(fails: command not found)*
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c6bc2b7ec8330b6cc37c63588ada1