### PR TITLE
Add unit tests for startup, shutdown and lint runner

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -82,6 +82,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | config | Load configuration settings and apply overrides | module | none | struct `configStruct` | @todo | reads JSON files |
 | startup | RegClassifier project initialization | module | `project` object | none | @todo | |
 | shutdown | RegClassifier project cleanup | module | project object | none | @todo | |
+| run_mlint | Lint MATLAB files and emit artifacts for CI | module | none | none | @todo | |
 
 
 
@@ -92,6 +93,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | config | none | struct of settings from JSON files | reads configuration files |
 | startup | project object | none | adds repo paths, sets defaults |
 | shutdown | project object | none | removes repo paths, restores defaults |
+| run_mlint | none | none | writes lint artifacts to `lint/` and may error on issues |
 
 
 
@@ -135,6 +137,9 @@ Common test scopes or prefixes include:
 | Name | Purpose | Scope | Owner | Related Functions | Notes |
 |------|---------|-------|-------|-------------------|-------|
 | testConfig | Test configuration override precedence | unit | @todo | config | verifies override precedence |
+| testStartup | Verify startup adds repository to path | unit | @todo | startup | includes smoke and regression tags |
+| testShutdown | Verify shutdown removes repository from path | unit | @todo | shutdown | includes smoke and regression tags |
+| testRunMlint | Ensure run\_mlint produces lint artifacts | unit | @todo | run\_mlint | |
 
 
 ---

--- a/tests/scripts/testRunMlint.m
+++ b/tests/scripts/testRunMlint.m
@@ -1,0 +1,34 @@
+classdef testRunMlint < matlab.unittest.TestCase
+    % NAME-REGISTRY:TEST testRunMlint
+
+    properties
+        repoRoot
+        originalFailOn
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
+            tc.originalFailOn = getenv('MLINT_FAIL_ON');
+            setenv('MLINT_FAIL_ON','none');
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            setenv('MLINT_FAIL_ON', tc.originalFailOn);
+            lintDir = fullfile(tc.repoRoot, "lint");
+            if isfolder(lintDir)
+                rmdir(lintDir, 's');
+            end
+        end
+    end
+
+    methods(Test, TestTags={"Unit","Smoke"})
+        function testRun(tc)
+            run_mlint;
+            txtPath = fullfile(tc.repoRoot, "lint", "mlint.txt");
+            tc.verifyTrue(isfile(txtPath));
+        end
+    end
+end

--- a/tests/testShutdown.m
+++ b/tests/testShutdown.m
@@ -1,0 +1,31 @@
+classdef testShutdown < matlab.unittest.TestCase
+    % NAME-REGISTRY:TEST testShutdown
+
+    properties
+        repoRoot
+        originalPath
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
+            tc.originalPath = path;
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            path(tc.originalPath);
+        end
+    end
+
+    methods(Test, TestTags={"Unit","Regression","Smoke"})
+        function testRemovesRepoFromPath(tc)
+            startup();
+            project.RootFolder = char(tc.repoRoot);
+            shutdown(project);
+            paths = split(string(path), pathsep);
+            tc.verifyFalse(any(paths == tc.repoRoot));
+        end
+    end
+end

--- a/tests/testStartup.m
+++ b/tests/testStartup.m
@@ -1,0 +1,38 @@
+classdef testStartup < matlab.unittest.TestCase
+    % NAME-REGISTRY:TEST testStartup
+
+    properties
+        repoRoot
+        originalPath
+    end
+
+    methods(TestMethodSetup)
+        function storePath(tc)
+            tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
+            tc.originalPath = path;
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function restorePath(tc)
+            path(tc.originalPath);
+        end
+    end
+
+    methods(Test, TestTags={"Unit","Smoke"})
+        function testAddsRepoToPath(tc)
+            startup();
+            paths = split(string(path), pathsep);
+            tc.verifyTrue(any(paths == tc.repoRoot));
+        end
+    end
+
+    methods(Test, TestTags={"Unit","Regression"})
+        function testStartupWithProjectStruct(tc)
+            project.RootFolder = char(tc.repoRoot);
+            startup(project);
+            paths = split(string(path), pathsep);
+            tc.verifyTrue(any(paths == tc.repoRoot));
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add MATLAB unit tests for `startup`, `shutdown` and `run_mlint`
- document new identifiers in registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `pre-commit run --files tests/testStartup.m tests/testShutdown.m tests/scripts/testRunMlint.m docs/identifier_registry.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c6ebb3b6483309c43dab6a17823ac