### PR TITLE
Add startup and shutdown tests and update registry

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -135,6 +135,8 @@ Common test scopes or prefixes include:
 | Name | Purpose | Scope | Owner | Related Functions | Notes |
 |------|---------|-------|-------|-------------------|-------|
 | testConfig | Test configuration override precedence | unit | @todo | config | verifies override precedence |
+| testShutdown | Test project cleanup removes repo root from path | unit | @todo | shutdown | |
+| testStartup | Test project initialization adds repo root to path | unit | @todo | startup | |
 
 
 ---

--- a/tests/testShutdown.m
+++ b/tests/testShutdown.m
@@ -1,0 +1,19 @@
+function tests = testShutdown
+% NAME-REGISTRY:TEST testShutdown
+% Test project cleanup removes repo root from path.
+
+tests = functiontests(localfunctions);
+end
+
+function testRemovesRepoRootFromPath(~)
+    repoRoot = fileparts(fileparts(mfilename('fullpath')));
+    originalPath = path;
+    cleanupObj = onCleanup(@() path(originalPath));
+    project = struct('RootFolder', repoRoot);
+
+    startup(project);
+    assert(contains(path, repoRoot), 'Startup failed to add repo root to path');
+
+    shutdown(project);
+    assert(~contains(path, repoRoot), 'Shutdown did not remove repo root from path');
+end

--- a/tests/testStartup.m
+++ b/tests/testStartup.m
@@ -1,0 +1,17 @@
+function tests = testStartup
+% NAME-REGISTRY:TEST testStartup
+% Test project initialization adds repo root to path.
+
+tests = functiontests(localfunctions);
+end
+
+function testAddsRepoRootToPath(~)
+    repoRoot = fileparts(fileparts(mfilename('fullpath')));
+    originalPath = path;
+    cleanupObj = onCleanup(@() path(originalPath));
+    project = struct('RootFolder', repoRoot);
+
+    startup(project);
+
+    assert(contains(path, repoRoot), 'Startup did not add repo root to path');
+end


### PR DESCRIPTION
## Summary
- add unit tests for startup and shutdown path management
- register testStartup and testShutdown in identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c6ee1a5cc833083aeca7155f03d0c