### PR TITLE
docs: require version-controlled golden datasets for regression tests

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -152,6 +152,7 @@ Class names, class properties, class methods, and interface definitions must als
 - Maintain separate suites tagged with `Smoke` and `Regression`:
   - `run_smoke_test` executes a fast subset validating environment and key workflows.
   - The regression suite uses known good simulated data with expected results to detect unintended changes and runs alongside unit and integration tests.
+  - Module owners must curate and maintain the golden datasets used in regression tests. These datasets must be version-controlled and documented in `identifier_registry.md`.
 - Regression tests should rely on curated simulated datasets rather than reproductions of specific bugs.
 - Every test file must subclass `matlab.unittest.TestCase` and include `methods (TestClassSetup)` and `methods (TestClassTeardown)` blocks, or explicitly register cleanups using `addTeardown`.
 - Include:

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -43,6 +43,8 @@ Place tests in the `tests/` folder and name each file `testName.m`. Each class a
 - Integration tests exercising cross-module interactions.
 - Regression tests comparing outputs against known good simulated data to detect unintended changes.
 
+Module owners must curate and maintain golden datasets used in regression tests. These datasets must be version-controlled and documented in `identifier_registry.md`.
+
 Refer to [Testing](Matlab_Style_Guide.md#3-testing) for the complete testing conventions.
 
 ## Workflow


### PR DESCRIPTION
## Summary
- specify that module owners must curate and maintain golden datasets for regression suites
- require these datasets to be version-controlled and listed in `identifier_registry.md`

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c74a84b7c833092ee2c4026d09fca