### PR TITLE
Add multilabel training and hybrid search pseudocode docs

### DIFF
--- a/docs/pseudocode/hybridSearch.md
+++ b/docs/pseudocode/hybridSearch.md
@@ -1,0 +1,29 @@
+# Hybrid Search Score Fusion Pseudocode
+
+Combines lexical and vector search results into a single ranked list.
+Assumes two retrieval systems: BM25 for term matching and an embedding index
+for semantic similarity. Each returns top `K` documents with scores.
+
+```
+HYBRID_SEARCH(query, K, weightLexical, weightVector):
+    bm25Table ← BM25_SEARCH(query, K)        // docId, bm25Score
+    vectorTable ← VECTOR_SEARCH(query, K)    // docId, vectorScore
+
+    normalize bm25Table.bm25Score to range [0,1]
+    normalize vectorTable.vectorScore to range [0,1]
+
+    mergedTable ← outer join bm25Table and vectorTable on docId
+    replace missing bm25Score or vectorScore with 0
+
+    mergedTable.combinedScore ←
+        weightLexical * bm25Score + weightVector * vectorScore
+
+    sort mergedTable by combinedScore in descending order
+    return mergedTable
+```
+
+**Outputs**
+
+- Results table containing `docId`, individual scores, and `combinedScore`.
+- Final ranking is determined by `combinedScore` in descending order.
+- Ties retain the relative order from the lexical results.

--- a/docs/pseudocode/trainMultilabel.md
+++ b/docs/pseudocode/trainMultilabel.md
@@ -1,0 +1,38 @@
+# Multilabel Classifier Training Pseudocode
+
+This pseudocode outlines how to train a multilabel classifier over chunked text.
+The dataset contains `N` examples and `L` possible labels.
+
+```
+TRAIN_MULTILABEL(trainTable):
+    labelMatrix ← encode labels in trainTable as multi-hot vectors of length L
+    model ← initialize classifier with final sigmoid layer of size L
+
+    repeat for each epoch:
+        for each (text, labelVector) in trainTable:
+            features ← embed(text)
+            logits ← forward(model, features)
+            loss ← binary cross-entropy(sigmoid(logits), labelVector)
+            update model parameters using loss and learning rate
+
+    classifierHandle(text):
+        features ← embed(text)
+        logits ← forward(model, features)
+        probVector ← sigmoid(logits)        // length L
+        return probVector
+
+    return classifierHandle
+```
+
+**Outputs**
+
+- `classifierHandle`: maps text input to a probability vector of length `L`.
+- During evaluation, collect results for a batch of `N` texts:
+
+```
+probMatrix ← classifierHandle(batchText)    // N × L
+labelMatrix ← elementwise comparison (probMatrix > threshold)
+```
+
+- Metrics such as micro/macro F1 or label-wise AUC use the original column
+  ordering of labels.


### PR DESCRIPTION
## Summary
- Document multilabel classifier training with language-agnostic pseudocode and expected probability/label outputs
- Describe hybrid search score fusion using normalized lexical and vector scores with weighted ranking

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c743390d4833083db2f625972eb94