### PR TITLE
Document exclusion of pseudocode identifiers

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -12,8 +12,10 @@ in the project** is the [identifier registry](identifier_registry.md).
 The [identifier registry](identifier_registry.md) is the definitve source 
 for the collection of all identifiers, **not** how to name the indentifiers.
 Identifiers defined here must be registered in the [identifier registry](identifier_registry.md)
-via [process guide](README_NAMING.md) and **must** follow the naming 
+via [process guide](README_NAMING.md) and **must** follow the naming
 convention defined in **this** document [Matlab Style Guide](Matlab_Style_Guide.md).
+
+Note: identifiers appearing only in pseudocode examples are for algorithm illustration and must remain within documentation; they are **not** to be registered in the [identifier registry](identifier_registry.md).
 
 ---
 

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -6,6 +6,7 @@ This README is a process guide for maintaining naming consistency. The
 all naming rules. All approved classes, class properties, class methods, functions, variables, constants, files/modules, tests, and other identifiers are tracked in the
 `identifier_registry.md`.
 
+- Pseudocode identifiers used only for algorithm illustration must not be added to [`docs/identifier_registry.md`](identifier_registry.md); keep them within documentation such as `docs/pseudocode/`.
 - New or modified class properties and class methods must be recorded in [`docs/identifier_registry.md`](identifier_registry.md) alongside the corresponding class names.
 - New or modified class interfaces must be added to [`docs/identifier_registry.md`](identifier_registry.md) as well.
 

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -7,6 +7,8 @@ definitive source for the collection of
 all identifiers, **not** how to name the identifiers.
 Update it via PR and keep it in sync with code.
 
+Pseudocode identifiers used solely for algorithm illustration are excluded from this registry and should remain within documentation such as `docs/pseudocode/`.
+
 Refer to [Matlab Style Guide](Matlab_Style_Guide.md) for naming rules and [README_NAMING](README_NAMING.md) for process guidelines.
 
 


### PR DESCRIPTION
## Summary
- clarify that pseudocode identifiers are illustrative only and must not be registered
- instruct contributors to avoid adding pseudocode names to identifier registry
- mention registry explicitly excludes pseudocode entries

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c781c25a48330a85afbfb5dabb841