### PR TITLE
docs: clarify golden dataset responsibilities

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -154,7 +154,7 @@ Class names, class properties, class methods, and interface definitions must als
 - Maintain separate suites tagged with `Smoke` and `Regression`:
   - `run_smoke_test` executes a fast subset validating environment and key workflows.
   - The regression suite uses known good simulated data with expected results to detect unintended changes and runs alongside unit and integration tests.
-  - Module owners must curate and maintain the golden datasets used in regression tests. These datasets must be version-controlled and documented in `identifier_registry.md`.
+  - Module owners must design modules that generate reproducible golden datasets and expected outputs. These artifacts must be stored under version control and documented in `identifier_registry.md`. When requirements change, module owners are responsible for regenerating and updating the golden data accordingly.
 - Regression tests should rely on curated simulated datasets rather than reproductions of specific bugs.
 - Every test file must subclass `matlab.unittest.TestCase` and include `methods (TestClassSetup)` and `methods (TestClassTeardown)` blocks, or explicitly register cleanups using `addTeardown`.
 - Include:

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -44,7 +44,7 @@ Place tests in the `tests/` folder and name each file `testName.m`. Each class a
 - Integration tests exercising cross-module interactions.
 - Regression tests comparing outputs against known good simulated data to detect unintended changes.
 
-Module owners must curate and maintain golden datasets used in regression tests. These datasets must be version-controlled and documented in `identifier_registry.md`.
+Module owners must design modules that generate reproducible golden datasets and expected outputs. These artifacts must be stored under version control and documented in `identifier_registry.md`. When requirements change, module owners are responsible for regenerating and updating the golden data accordingly.
 
 Refer to [Testing](Matlab_Style_Guide.md#3-testing) for the complete testing conventions.
 


### PR DESCRIPTION
## Summary
- Clarify that module owners must design modules producing reproducible golden datasets and expected outputs
- Require storing golden datasets and outputs under version control
- Note that module owners must update golden data when requirements change

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c7eb1c6c883309559d2403d2c03b2