### PR TITLE
docs: enforce regression test metadata

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -137,7 +137,7 @@ Record each test with a scope identifying its coverage type:
 - `integration` – cross-module interactions
 - `regression` – verifies outputs against known good simulated data to guard against unintended changes
 
-For regression entries, specify the simulated dataset path, expected output, and dataset owner used as the baseline.
+Regression entries must include the simulated dataset path, expected output, and dataset owner used as the baseline. Future regression tests without these fields will not be accepted.
 
 | Name | Purpose | Scope | Owner | Related Functions | Golden Dataset Path | Expected Output | Dataset Owner | Notes |
 |------|---------|-------|-------|-------------------|---------------------|-----------------|---------------|-------|


### PR DESCRIPTION
## Summary
- require golden dataset path, expected output, and dataset owner for regression tests in identifier registry

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c7eb199d083308017c4c7289bfbce