### PR TITLE
Add property validation to test classes

### DIFF
--- a/tests/scripts/testRunMlint.m
+++ b/tests/scripts/testRunMlint.m
@@ -2,15 +2,17 @@ classdef testRunMlint < matlab.unittest.TestCase
     % NAME-REGISTRY:TEST testRunMlint
 
     properties
-        repoRoot
-        originalFailOn
+        repoRoot (1,1) string
+        originalFailOn (1,1) string
     end
 
     methods(TestMethodSetup)
         function setup(tc)
             tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
-            tc.originalFailOn = getenv('MLINT_FAIL_ON');
+            tc.originalFailOn = string(getenv('MLINT_FAIL_ON'));
             setenv('MLINT_FAIL_ON','none');
+            mustBeFolder(tc.repoRoot);
+            mustBeTextScalar(tc.originalFailOn);
         end
     end
 

--- a/tests/testShutdown.m
+++ b/tests/testShutdown.m
@@ -3,14 +3,16 @@ classdef testShutdown < matlab.unittest.TestCase
     % NAME-REGISTRY:TEST testShutdown
 
     properties
-        repoRoot
-        originalPath
+        repoRoot (1,1) string
+        originalPath (1,1) string
     end
 
     methods(TestMethodSetup)
         function setup(tc)
             tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
-            tc.originalPath = path;
+            tc.originalPath = string(path);
+            mustBeFolder(tc.repoRoot);
+            mustBeNonempty(tc.originalPath);
         end
     end
 

--- a/tests/testStartup.m
+++ b/tests/testStartup.m
@@ -2,14 +2,16 @@ classdef testStartup < matlab.unittest.TestCase
     % NAME-REGISTRY:TEST testStartup
 
     properties
-        repoRoot
-        originalPath
+        repoRoot (1,1) string
+        originalPath (1,1) string
     end
 
     methods(TestMethodSetup)
         function storePath(tc)
             tc.repoRoot = string(fileparts(fileparts(mfilename('fullpath'))));
-            tc.originalPath = path;
+            tc.originalPath = string(path);
+            mustBeFolder(tc.repoRoot);
+            mustBeNonempty(tc.originalPath);
         end
     end
 


### PR DESCRIPTION
## Summary
- enforce string scalar validation for repository path and environment fields in tests
- add nonempty and folder checks during test setup

## Testing
- `matlab -batch "runtests"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689c80c833888330af5678ac33ad218b