### PR TITLE
Clarify MATLAB test class naming

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -45,6 +45,7 @@ Note: identifiers appearing only in pseudocode examples are for algorithm illust
 | Standalone Functions | lowerCamelCase | `loadData`, `parseText` |
 | Class Methods | lowerCamelCase | `computeScore`, `updateModel` |
 | Classes | UpperCamelCase | `DocumentParser`, `EmbeddingModel` |
+| Test Classes | lowerCamelCase prefixed with `test` | `testFeature` |
 | Interface Classes | UpperCamelCase prefixed with `I` | `ILogFormatter`, `IDataSource` |
 | Class properties | lowerCamelCase | `maxEpochs`, `learningRate` |
 | Class constants | UPPER_CASE | `DEFAULT_TIMEOUT` |
@@ -149,7 +150,7 @@ Class names, class properties, class methods, and interface definitions must als
 
 ### 3. Testing
 - Store tests in a `tests/` folder mirroring source structure.
-- Name each test file `testName.m` and ensure the function or class name matches the file.
+- Name each test file `testName.m` and define the class as `classdef testName`, using lowerCamelCase with a `test` prefix.
 - Provide at least one unit test for every public function and class method.
 - Maintain separate suites tagged with `Smoke` and `Regression`:
   - `run_smoke_test` executes a fast subset validating environment and key workflows.


### PR DESCRIPTION
## Summary
- Document exception that test classes use lowerCamelCase with a `test` prefix
- Update testing instructions to reinforce the test class naming pattern

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c8362045883308741a33364ab819a