### PR TITLE
docs: clarify package folder naming

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -79,6 +79,7 @@ Class names, class properties, class methods, and interface definitions must als
 - One function per file; file name matches the main function.
 - Filenames must match the main function/class name.
 - Use namespaced folders (e.g., `+utils`, `+internal`) to manage scope.
+- Package folders must be named in **lowerCamelCase** (e.g., `+dataProcessing`).
 - Avoid `global`, `assignin`, or `eval`.
 - Prefer function files over scripts for reusable code.
 


### PR DESCRIPTION
## Summary
- require package folders to use lowerCamelCase (e.g., `+dataProcessing`)

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c83b371888330bdc0224dacc16134