### PR TITLE
docs: clarify script placement

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -13,7 +13,11 @@ all naming rules. All approved classes, class properties, class methods, functio
 
 ## Function and Script Names
 
-Use lowerCamelCase for all function and script names (e.g., `ingestPdfs`, `trainMultilabel`).
+Use lowerCamelCase for all function and script names (e.g., `ingestPdfs`, `trainMultilabel`). See the
+[Scripts](Matlab_Style_Guide.md#scripts) subsection of the style guide for detailed guidance.
+
+- Development scripts (e.g., `startup.m`, `run_mlint.m`) reside in the repository root or `scripts/` and are not tested.
+- Scripts that contribute to runtime behavior must live in `+helpers/` and have corresponding tests in `tests/`.
 
 ## Data-Type Suffixes
 


### PR DESCRIPTION
## Summary
- specify where development vs runtime scripts reside
- reference script testing requirements and style guide scripts subsection

## Testing
- `matlab -batch "run_smoke_test"` *(command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689c85ede69c8330957ac2119630b6fd