### PR TITLE
docs: clarify naming for classes and packages

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -51,7 +51,7 @@ Note: identifiers appearing only in pseudocode examples are for algorithm illust
 | Class properties | lowerCamelCase | `maxEpochs`, `learningRate` |
 | Class constants | UPPER_CASE | `DEFAULT_TIMEOUT` |
 
-Function, script, and class identifiers must also be recorded in the [identifier registry](identifier_registry.md) per the [process guide](README_NAMING.md#function-and-script-names).
+Function, script, and class identifiers must also be recorded in the [identifier registry](identifier_registry.md) per the [process guide](README_NAMING.md#function-script-and-class-names).
 
 
 ### 1.3 Constants

--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -11,10 +11,16 @@ all naming rules. All approved classes, class properties, class methods, functio
 - New or modified class interfaces must be added to [`docs/identifier_registry.md`](identifier_registry.md) as well.
 
 
-## Function and Script Names
+## Function, Script, and Class Names
 
 Use lowerCamelCase for all function and script names (e.g., `ingestPdfs`, `trainMultilabel`). See the
 [Scripts](Matlab_Style_Guide.md#scripts) subsection of the style guide for detailed guidance.
+
+- Classes use UpperCamelCase ([Matlab Style Guide §1.2](Matlab_Style_Guide.md#12-naming-for-functions--classes)).
+- Interface classes use UpperCamelCase prefixed with `I` ([Matlab Style Guide §1.2](Matlab_Style_Guide.md#12-naming-for-functions--classes)).
+- Test classes use lowerCamelCase prefixed with `test` ([Matlab Style Guide §1.2](Matlab_Style_Guide.md#12-naming-for-functions--classes)).
+- Package folder names use lowerCamelCase ([Matlab Style Guide §2.1](Matlab_Style_Guide.md#21-files-and-functions)).
+- Class properties use lowerCamelCase and class constants use UPPER_CASE ([Matlab Style Guide §1.2](Matlab_Style_Guide.md#12-naming-for-functions--classes)).
 
 - Development scripts (e.g., `startup.m`, `run_mlint.m`) reside in the repository root or `scripts/` and are not tested.
 - Scripts that contribute to runtime behavior must live in `+helpers/` and have corresponding tests in `tests/`.


### PR DESCRIPTION
## Summary
- detail naming rules for classes, interfaces, tests, packages, and class members
- rename naming README section to include classes
- keep style guide cross-reference aligned with new heading

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c8b7d520c8330a88c10e7a2d6d90a