### PR TITLE
docs: clarify test file and method conventions

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -50,6 +50,8 @@ Short-lived helpers such as `tmp` or `idx` should remain within a few lines of u
 Place tests in the `tests/` folder and name each file `testName.m`. Test files should mirror the source structure, and each `testName.m` defines a corresponding `classdef testName` in lowerCamelCase with a `test` prefix. Each class and public method must have:
 
 - At least one unit test verifying its core behavior.
+- Every test file subclasses `matlab.unittest.TestCase` and defines `methods (TestClassSetup)` / `methods (TestClassTeardown)` or uses `addTeardown` ([Testing](Matlab_Style_Guide.md#3-testing)).
+- Each test method is named in lowerCamelCase starting with a verb and declares `TestTags` such as `Unit`, `Smoke`, `Integration`, or `Regression` ([Testing](Matlab_Style_Guide.md#3-testing)).
 - Maintain separate `Smoke` and `Regression` suites; use `matlab -batch "run_smoke_test"` to run the `Smoke` suite quickly.
 - Integration tests are optional and added when cross-module behavior warrants them.
 


### PR DESCRIPTION
## Summary
- document requirement to subclass `matlab.unittest.TestCase` and provide setup/teardown in test files
- note that test methods use lowerCamelCase verbs and declare tags like `Unit`, `Smoke`, `Integration`, or `Regression`

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689c93e833c88330ae43588f920963d5