### PR TITLE
docs: reference canonical guides in scaffold

### DIFF
--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -1,5 +1,9 @@
 # Master Scaffold
 
+> Before implementing new modules or tests, review the canonical docs:
+> [Matlab_Style_Guide](Matlab_Style_Guide.md), [README_NAMING](README_NAMING.md),
+> [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md), and [identifier_registry](identifier_registry.md).
+
 This document summarizes the MATLAB `+reg` package, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
 
 ## Package Structure


### PR DESCRIPTION
## Summary
- Direct contributors to key canonical docs from the master scaffold for guidance before adding modules or tests

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cbd46a4b88330a3ec859682749978