### PR TITLE
Refactor baseline model responsibilities

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -51,25 +51,25 @@ Keep the illustrative examples below in sync with the current naming conventions
 | Chunk | Overlapping text segment from a document | module | @todo | [ClassArchitecture.md#L90-L142](ClassArchitecture.md#L90-L142) | |
 | LabelMatrix | Sparse weak labels aligned to chunks and topics | module | @todo | [ClassArchitecture.md#L145-L192](ClassArchitecture.md#L145-L192) | |
 | Embedding | Vector representation of a chunk | module | @todo | [ClassArchitecture.md#L195-L239](ClassArchitecture.md#L195-L239) | |
-| BaselineModel | Multi-label classifier and retrieval artifacts | module | @todo | [ClassArchitecture.md#L241-L295](ClassArchitecture.md#L241-L295) | |
-| ProjectionHead | MLP transforming embeddings for retrieval | module | @todo | [ClassArchitecture.md#L299-L346](ClassArchitecture.md#L299-L346) | |
-| Encoder | Fine-tuned model for contrastive learning | module | @todo | [ClassArchitecture.md#L349-L392](ClassArchitecture.md#L349-L392) | |
-| Metrics | Evaluation results and per-label performance | module | @todo | [ClassArchitecture.md#L395-L427](ClassArchitecture.md#L395-L427) | |
-| CorpusVersion | Versioned corpora for diff operations | module | @todo | [ClassArchitecture.md#L430-L463](ClassArchitecture.md#L430-L463) | |
-| EvalReportView | Generates reports summarizing metrics | module | @todo | [ClassArchitecture.md#L468-L491](ClassArchitecture.md#L468-L491) | |
-| DiffReportView | Presents diffs between regulatory versions | module | @todo | [ClassArchitecture.md#L493-L511](ClassArchitecture.md#L493-L511) | |
-| MetricsPlotsView | Visualizes metrics and trend plots | module | @todo | [ClassArchitecture.md#L514-L537](ClassArchitecture.md#L514-L537) | |
-| IngestionController | Parses PDFs and produces Document models | module | @todo | [ClassArchitecture.md#L542-L557](ClassArchitecture.md#L542-L557) | |
-| ChunkingController | Splits documents into overlapping chunks | module | @todo | [ClassArchitecture.md#L560-L577](ClassArchitecture.md#L560-L577) | |
-| WeakLabelingController | Applies heuristic rules to label chunks | module | @todo | [ClassArchitecture.md#L579-L595](ClassArchitecture.md#L579-L595) | |
-| EmbeddingController | Generates embeddings for chunks | module | @todo | [ClassArchitecture.md#L598-L614](ClassArchitecture.md#L598-L614) | |
-| BaselineController | Trains baseline classifier and serves retrieval | module | @todo | [ClassArchitecture.md#L617-L644](ClassArchitecture.md#L617-L644) | |
-| ProjectionHeadController | Manages projection head training and usage | module | @todo | [ClassArchitecture.md#L646-L673](ClassArchitecture.md#L646-L673) | |
-| FineTuneController | Fine-tunes base models | module | @todo | [ClassArchitecture.md#L676-L692](ClassArchitecture.md#L676-L692) | |
-| EvaluationController | Computes metrics and generates reports | module | @todo | [ClassArchitecture.md#L695-L721](ClassArchitecture.md#L695-L721) | |
-| DataAcquisitionController | Fetches corpora and triggers diff analyses | module | @todo | [ClassArchitecture.md#L724-L749](ClassArchitecture.md#L724-L749) | |
-| PipelineController | Orchestrates end-to-end pipeline | module | @todo | [ClassArchitecture.md#L752-L780](ClassArchitecture.md#L752-L780) | |
-| TestController | Executes continuous test suite | module | @todo | [ClassArchitecture.md#L783-L800](ClassArchitecture.md#L783-L800) | |
+| BaselineModel | Multi-label classifier and retrieval artifacts | module | @todo | [ClassArchitecture.md#L241-L307](ClassArchitecture.md#L241-L307) | |
+| ProjectionHead | MLP transforming embeddings for retrieval | module | @todo | [ClassArchitecture.md#L311-L358](ClassArchitecture.md#L311-L358) | |
+| Encoder | Fine-tuned model for contrastive learning | module | @todo | [ClassArchitecture.md#L361-L404](ClassArchitecture.md#L361-L404) | |
+| Metrics | Evaluation results and per-label performance | module | @todo | [ClassArchitecture.md#L407-L439](ClassArchitecture.md#L407-L439) | |
+| CorpusVersion | Versioned corpora for diff operations | module | @todo | [ClassArchitecture.md#L442-L475](ClassArchitecture.md#L442-L475) | |
+| EvalReportView | Generates reports summarizing metrics | module | @todo | [ClassArchitecture.md#L480-L503](ClassArchitecture.md#L480-L503) | |
+| DiffReportView | Presents diffs between regulatory versions | module | @todo | [ClassArchitecture.md#L505-L523](ClassArchitecture.md#L505-L523) | |
+| MetricsPlotsView | Visualizes metrics and trend plots | module | @todo | [ClassArchitecture.md#L526-L549](ClassArchitecture.md#L526-L549) | |
+| IngestionController | Parses PDFs and produces Document models | module | @todo | [ClassArchitecture.md#L554-L569](ClassArchitecture.md#L554-L569) | |
+| ChunkingController | Splits documents into overlapping chunks | module | @todo | [ClassArchitecture.md#L572-L589](ClassArchitecture.md#L572-L589) | |
+| WeakLabelingController | Applies heuristic rules to label chunks | module | @todo | [ClassArchitecture.md#L591-L607](ClassArchitecture.md#L591-L607) | |
+| EmbeddingController | Generates embeddings for chunks | module | @todo | [ClassArchitecture.md#L610-L626](ClassArchitecture.md#L610-L626) | |
+| BaselineController | Constructs baselineModelClass and delegates operations | module | @todo | [ClassArchitecture.md#L629-L660](ClassArchitecture.md#L629-L660) | |
+| ProjectionHeadController | Manages projection head training and usage | module | @todo | [ClassArchitecture.md#L662-L689](ClassArchitecture.md#L662-L689) | |
+| FineTuneController | Fine-tunes base models | module | @todo | [ClassArchitecture.md#L692-L708](ClassArchitecture.md#L692-L708) | |
+| EvaluationController | Computes metrics and generates reports | module | @todo | [ClassArchitecture.md#L711-L737](ClassArchitecture.md#L711-L737) | |
+| DataAcquisitionController | Fetches corpora and triggers diff analyses | module | @todo | [ClassArchitecture.md#L740-L765](ClassArchitecture.md#L740-L765) | |
+| PipelineController | Orchestrates end-to-end pipeline | module | @todo | [ClassArchitecture.md#L768-L796](ClassArchitecture.md#L768-L796) | |
+| TestController | Executes continuous test suite | module | @todo | [ClassArchitecture.md#L799-L817](ClassArchitecture.md#L799-L817) | |
 
 
 
@@ -93,9 +93,9 @@ Keep the illustrative examples below in sync with the current naming conventions
 | [Embedding](ClassArchitecture.md#L195-L239) | [chunkId](ClassArchitecture.md#L200) | double | Chunk identifier |
 | [Embedding](ClassArchitecture.md#L195-L239) | [embeddingVec](ClassArchitecture.md#L201) | double Vec | Embedding vector |
 | [Embedding](ClassArchitecture.md#L195-L239) | [modelName](ClassArchitecture.md#L202) | string | Source model name |
-| [BaselineModel](ClassArchitecture.md#L241-L295) | [labelMat](ClassArchitecture.md#L246) | double Mat | Label matrix |
-| [BaselineModel](ClassArchitecture.md#L241-L295) | [embeddingMat](ClassArchitecture.md#L247) | double Mat | Embedding matrix |
-| [BaselineModel](ClassArchitecture.md#L241-L295) | [weightMat](ClassArchitecture.md#L248) | double Mat | Learned classifier weights |
+| [BaselineModel](ClassArchitecture.md#L241-L307) | [labelMat](ClassArchitecture.md#L246) | double Mat | Label matrix |
+| [BaselineModel](ClassArchitecture.md#L241-L307) | [embeddingMat](ClassArchitecture.md#L247) | double Mat | Embedding matrix |
+| [BaselineModel](ClassArchitecture.md#L241-L307) | [weightMat](ClassArchitecture.md#L248) | double Mat | Learned classifier weights |
 | [ProjectionHead](ClassArchitecture.md#L299-L346) | [inputDim](ClassArchitecture.md#L304) | double | Input dimension |
 | [ProjectionHead](ClassArchitecture.md#L299-L346) | [outputDim](ClassArchitecture.md#L305) | double | Output dimension |
 | [ProjectionHead](ClassArchitecture.md#L299-L346) | [paramStruct](ClassArchitecture.md#L306) | struct | Model parameters |
@@ -121,42 +121,43 @@ Keep the illustrative examples below in sync with the current naming conventions
 | [getLabelsForChunk](ClassArchitecture.md#L181-L190) | [LabelMatrix](ClassArchitecture.md#L145-L192) | Return topic-weight pairs for a chunk | |
 | [cosineSimilarity](ClassArchitecture.md#L220-L228) | [Embedding](ClassArchitecture.md#L195-L239) | Compute cosine similarity with another embedding | |
 | [normalize](ClassArchitecture.md#L231-L237) | [Embedding](ClassArchitecture.md#L195-L239) | Normalize vector in-place | |
-| [train](ClassArchitecture.md#L265-L272) | [BaselineModel](ClassArchitecture.md#L241-L295) | Train the classifier | |
-| [predict](ClassArchitecture.md#L275-L283) | [BaselineModel](ClassArchitecture.md#L241-L295) | Predict label probabilities | |
-| [save](ClassArchitecture.md#L286-L293) | [BaselineModel](ClassArchitecture.md#L241-L295) | Serialize model to disk | |
-| [fit](ClassArchitecture.md#L323-L332) | [ProjectionHead](ClassArchitecture.md#L299-L346) | Train projection head | |
-| [transform](ClassArchitecture.md#L335-L344) | [ProjectionHead](ClassArchitecture.md#L299-L346) | Apply transformation to embeddings | |
-| [fineTune](ClassArchitecture.md#L370-L379) | [Encoder](ClassArchitecture.md#L349-L392) | Contrastive fine-tuning procedure | |
-| [encode](ClassArchitecture.md#L381-L389) | [Encoder](ClassArchitecture.md#L349-L392) | Convert text to embedding | |
-| [summary](ClassArchitecture.md#L417-L425) | [Metrics](ClassArchitecture.md#L395-L427) | Return human-readable summary of metrics | |
-| [diff](ClassArchitecture.md#L452-L460) | [CorpusVersion](ClassArchitecture.md#L430-L463) | Return differences between versions | |
-| [renderPDF](ClassArchitecture.md#L473-L480) | [EvalReportView](ClassArchitecture.md#L468-L491) | Generate PDF report | |
-| [renderHTML](ClassArchitecture.md#L482-L489) | [EvalReportView](ClassArchitecture.md#L468-L491) | Generate HTML report | |
-| [render](ClassArchitecture.md#L498-L509) | [DiffReportView](ClassArchitecture.md#L493-L511) | Generate diff report in HTML or PDF | |
-| [plotHeatmap](ClassArchitecture.md#L519-L526) | [MetricsPlotsView](ClassArchitecture.md#L514-L537) | Render heatmap from metric matrix | |
-| [plotTrend](ClassArchitecture.md#L528-L535) | [MetricsPlotsView](ClassArchitecture.md#L514-L537) | Render line chart for metric trends | |
-| [run](ClassArchitecture.md#L547-L555) | [IngestionController](ClassArchitecture.md#L542-L557) | Parse PDFs to documents | |
-| [run](ClassArchitecture.md#L565-L575) | [ChunkingController](ClassArchitecture.md#L560-L577) | Split documents into chunks | |
-| [run](ClassArchitecture.md#L584-L593) | [WeakLabelingController](ClassArchitecture.md#L579-L595) | Apply weak labeling rules | |
-| [run](ClassArchitecture.md#L603-L612) | [EmbeddingController](ClassArchitecture.md#L598-L614) | Generate embeddings | |
-| [train](ClassArchitecture.md#L622-L631) | [BaselineController](ClassArchitecture.md#L617-L644) | Fit baseline classifier | |
-| [retrieve](ClassArchitecture.md#L633-L642) | [BaselineController](ClassArchitecture.md#L617-L644) | Retrieve top chunks for query embedding | |
-| [fit](ClassArchitecture.md#L651-L660) | [ProjectionHeadController](ClassArchitecture.md#L646-L673) | Train projection head | |
-| [apply](ClassArchitecture.md#L662-L671) | [ProjectionHeadController](ClassArchitecture.md#L646-L673) | Apply projection head to embeddings | |
-| [run](ClassArchitecture.md#L681-L689) | [FineTuneController](ClassArchitecture.md#L676-L692) | Fine-tune encoder | |
-| [evaluate](ClassArchitecture.md#L700-L709) | [EvaluationController](ClassArchitecture.md#L695-L721) | Compute metrics for model | |
-| [generateReports](ClassArchitecture.md#L712-L719) | [EvaluationController](ClassArchitecture.md#L695-L721) | Produce evaluation reports | |
-| [fetch](ClassArchitecture.md#L729-L737) | [DataAcquisitionController](ClassArchitecture.md#L724-L749) | Retrieve corpora from sources | |
-| [diffVersions](ClassArchitecture.md#L739-L747) | [DataAcquisitionController](ClassArchitecture.md#L724-L749) | Run diff and trigger report generation | |
-| [execute](ClassArchitecture.md#L771-L778) | [PipelineController](ClassArchitecture.md#L752-L780) | Execute pipeline steps | |
-| [runTests](ClassArchitecture.md#L788-L798) | [TestController](ClassArchitecture.md#L783-L800) | Execute selected tests | |
+| [train](ClassArchitecture.md#L265-L272) | [BaselineModel](ClassArchitecture.md#L241-L307) | Train the classifier | |
+| [predict](ClassArchitecture.md#L275-L283) | [BaselineModel](ClassArchitecture.md#L241-L307) | Predict label probabilities | |
+| [retrieve](ClassArchitecture.md#L286-L296) | [BaselineModel](ClassArchitecture.md#L241-L307) | Retrieve top chunks for query embedding | |
+| [save](ClassArchitecture.md#L298-L305) | [BaselineModel](ClassArchitecture.md#L241-L307) | Serialize model to disk | |
+| [fit](ClassArchitecture.md#L335-L345) | [ProjectionHead](ClassArchitecture.md#L311-L358) | Train projection head | |
+| [transform](ClassArchitecture.md#L347-L356) | [ProjectionHead](ClassArchitecture.md#L311-L358) | Apply transformation to embeddings | |
+| [fineTune](ClassArchitecture.md#L382-L391) | [Encoder](ClassArchitecture.md#L361-L404) | Contrastive fine-tuning procedure | |
+| [encode](ClassArchitecture.md#L393-L402) | [Encoder](ClassArchitecture.md#L361-L404) | Convert text to embedding | |
+| [summary](ClassArchitecture.md#L429-L437) | [Metrics](ClassArchitecture.md#L407-L439) | Return human-readable summary of metrics | |
+| [diff](ClassArchitecture.md#L464-L473) | [CorpusVersion](ClassArchitecture.md#L442-L475) | Return differences between versions | |
+| [renderPDF](ClassArchitecture.md#L485-L492) | [EvalReportView](ClassArchitecture.md#L480-L503) | Generate PDF report | |
+| [renderHTML](ClassArchitecture.md#L494-L501) | [EvalReportView](ClassArchitecture.md#L480-L503) | Generate HTML report | |
+| [render](ClassArchitecture.md#L510-L521) | [DiffReportView](ClassArchitecture.md#L505-L523) | Generate diff report in HTML or PDF | |
+| [plotHeatmap](ClassArchitecture.md#L531-L538) | [MetricsPlotsView](ClassArchitecture.md#L526-L549) | Render heatmap from metric matrix | |
+| [plotTrend](ClassArchitecture.md#L540-L547) | [MetricsPlotsView](ClassArchitecture.md#L526-L549) | Render line chart for metric trends | |
+| [run](ClassArchitecture.md#L559-L566) | [IngestionController](ClassArchitecture.md#L554-L569) | Parse PDFs to documents | |
+| [run](ClassArchitecture.md#L577-L586) | [ChunkingController](ClassArchitecture.md#L572-L589) | Split documents into chunks | |
+| [run](ClassArchitecture.md#L596-L604) | [WeakLabelingController](ClassArchitecture.md#L591-L607) | Apply weak labeling rules | |
+| [run](ClassArchitecture.md#L615-L623) | [EmbeddingController](ClassArchitecture.md#L610-L626) | Generate embeddings | |
+| [train](ClassArchitecture.md#L634-L646) | [BaselineController](ClassArchitecture.md#L629-L660) | Fit baseline classifier | delegates to model |
+| [retrieve](ClassArchitecture.md#L648-L657) | [BaselineController](ClassArchitecture.md#L629-L660) | Retrieve top chunks using model | |
+| [fit](ClassArchitecture.md#L667-L676) | [ProjectionHeadController](ClassArchitecture.md#L662-L689) | Train projection head | |
+| [apply](ClassArchitecture.md#L678-L687) | [ProjectionHeadController](ClassArchitecture.md#L662-L689) | Apply projection head to embeddings | |
+| [run](ClassArchitecture.md#L697-L705) | [FineTuneController](ClassArchitecture.md#L692-L708) | Fine-tune encoder | |
+| [evaluate](ClassArchitecture.md#L716-L725) | [EvaluationController](ClassArchitecture.md#L711-L737) | Compute metrics for model | |
+| [generateReports](ClassArchitecture.md#L728-L735) | [EvaluationController](ClassArchitecture.md#L711-L737) | Produce evaluation reports | |
+| [fetch](ClassArchitecture.md#L745-L752) | [DataAcquisitionController](ClassArchitecture.md#L740-L765) | Retrieve corpora from sources | |
+| [diffVersions](ClassArchitecture.md#L755-L763) | [DataAcquisitionController](ClassArchitecture.md#L740-L765) | Run diff and trigger report generation | |
+| [execute](ClassArchitecture.md#L787-L794) | [PipelineController](ClassArchitecture.md#L768-L796) | Execute pipeline steps | |
+| [runTests](ClassArchitecture.md#L804-L815) | [TestController](ClassArchitecture.md#L799-L817) | Execute selected tests | |
 
 > **Note:** List every new or renamed class method here and follow `lowerCamelCase` naming.
 
 ## Class Interfaces
 | Interface | Purpose | Methods | Implementing Classes | Notes |
 |-----------|---------|---------|----------------------|-------|
-| IClassifier | Standardize classifier APIs | train, predict | baselineModelClass | example interface |
+| IClassifier | Standardize classifier APIs | train, predict | [baselineModelClass](ClassArchitecture.md#L241-L307) | example interface |
 
 
 


### PR DESCRIPTION
## Summary
- Move training and retrieval logic into `baselineModelClass` with new `retrieve` method
- Simplify `baselineControllerClass` to instantiate model and delegate training and retrieval
- Update identifier registry and architecture docs to reflect new responsibilities

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cbe19efc483309aaac64161bb66e6