### PR TITLE
docs: update scaffold for reg layout

### DIFF
--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -4,23 +4,43 @@
 > [Matlab_Style_Guide](Matlab_Style_Guide.md), [README_NAMING](README_NAMING.md),
 > [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md), and [identifier_registry](identifier_registry.md).
 
-This document summarizes the MATLAB package located at `src/+reg/`, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
+This document summarizes the MATLAB package located at `src/reg/`, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
 
 ## Package Structure
 
-Each module is a class file (`classdef`) stored under `src/+reg/`. Every stub includes a `%% NAME-REGISTRY:FUNCTION` breadcrumb and a `TODO` placeholder. The table below lists the modules in build order and their paired tests.
+Each module is a class file (`classdef`) stored under `src/reg/`. Every stub includes a `%% NAME-REGISTRY:FUNCTION` breadcrumb and a `TODO` placeholder. The table below lists the modules in build order and their paired tests.
 
 | Step | Module | Stub `.m` file | Test skeleton(s) |
 |------|--------|----------------|------------------|
-| 3 | Data ingestion | `src/+reg/ingestPdfs.m` | `tests/testPDFIngest.m`, `tests/testIngestAndChunk.m` |
-| 4 | Text chunking | `src/+reg/chunkText.m` | `tests/testIngestAndChunk.m` |
-| 5 | Weak labeling | `src/+reg/weakRules.m` | `tests/testRulesAndModel.m` |
-| 6 | Embedding generation | `src/+reg/docEmbeddingsBertGpu.m`, `src/+reg/precomputeEmbeddings.m` | `tests/testFeatures.m` |
-| 7 | Baseline classifier & retrieval | `src/+reg/trainMultilabel.m`, `src/+reg/hybridSearch.m` | `tests/testRegressionMetricsSimulated.m`, `tests/testHybridSearch.m` |
-| 8 | Projection head | `src/+reg/trainProjectionHead.m` | `tests/testProjectionHeadSimulated.m`, `tests/testProjectionAutoloadPipeline.m` |
-| 9 | Encoder fine-tuning | `src/+reg/ftBuildContrastiveDataset.m`, `src/+reg/ftTrainEncoder.m` | `tests/testFineTuneSmoke.m`, `tests/testFineTuneResume.m` |
-| 10 | Evaluation & reporting | `src/+reg/evalRetrieval.m`, `src/+reg/evalPerLabel.m`, `src/+reg/loadGold.m` | `tests/testMetricsExpectedJSON.m`, `tests/testGoldMetrics.m`, `tests/testReportArtifact.m` |
-| 11 | Data acquisition & diff utilities | `src/+reg/crrDiffVersions.m`, `src/+reg/crrDiffArticles.m` | `tests/testFetchers.m` |
+| 3 | Data ingestion | `src/reg/ingestPdfs.m` | `tests/testPDFIngest.m`, `tests/testIngestAndChunk.m` |
+| 4 | Text chunking | `src/reg/chunkText.m` | `tests/testIngestAndChunk.m` |
+| 5 | Weak labeling | `src/reg/weakRules.m` | `tests/testRulesAndModel.m` |
+| 6 | Embedding generation | `src/reg/docEmbeddingsBertGpu.m`, `src/reg/precomputeEmbeddings.m` | `tests/testFeatures.m` |
+| 7 | Baseline classifier & retrieval | `src/reg/trainMultilabel.m`, `src/reg/hybridSearch.m` | `tests/testRegressionMetricsSimulated.m`, `tests/testHybridSearch.m` |
+| 8 | Projection head | `src/reg/trainProjectionHead.m` | `tests/testProjectionHeadSimulated.m`, `tests/testProjectionAutoloadPipeline.m` |
+| 9 | Encoder fine-tuning | `src/reg/ftBuildContrastiveDataset.m`, `src/reg/ftTrainEncoder.m` | `tests/testFineTuneSmoke.m`, `tests/testFineTuneResume.m` |
+| 10 | Evaluation & reporting | `src/reg/evalRetrieval.m`, `src/reg/evalPerLabel.m`, `src/reg/loadGold.m` | `tests/testMetricsExpectedJSON.m`, `tests/testGoldMetrics.m`, `tests/testReportArtifact.m` |
+| 11 | Data acquisition & diff utilities | `src/reg/crrDiffVersions.m`, `src/reg/crrDiffArticles.m` | `tests/testFetchers.m` |
+
+### MVC Components
+
+#### Model
+Code implementing domain logic resides in `src/reg/model/`.
+
+#### View
+Presentation utilities live in `src/reg/view/`.
+
+#### Controller
+Orchestration and flow control code is located in `src/reg/controller/`.
+
+## Runtime Data Layout
+
+Runtime data produced or consumed by the pipeline is organized as follows:
+
+- `src/data/datastore/db/`
+- `src/data/processing/raw/`
+- `src/data/input/pdfs/`
+- `src/data/output/reports/`
 
 ## TDD Workflow
 
@@ -31,7 +51,7 @@ Each module is a class file (`classdef`) stored under `src/+reg/`. Every stub in
    - Force the pass with using the appropriate command from the matlab test suite to force a not implemented result.
 
 2. **Add a stub module**
-   - Under `src/+reg/`, create `myFeature.m` with the function signature, a `%% NAME-REGISTRY:FUNCTION myFeature` breadcrumb, and a `TODO` placeholder.
+   - Under `src/reg/`, create `myFeature.m` with the function signature, a `%% NAME-REGISTRY:FUNCTION myFeature` breadcrumb, and a `TODO` placeholder.
 
 3. **Update the identifier registry**
    - Add entries for the new function, file, and test in `docs/identifier_registry.md`.


### PR DESCRIPTION
## Summary
- replace legacy `src/+reg/` path references with `src/reg/`
- document MVC components and runtime data layout

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cc6a9aa308330a9a2af3a11399df5