### PR TITLE
Clarify text chunking goal and parameters

### DIFF
--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -1,6 +1,6 @@
 # Step 4: Text Chunking
 
-**Goal:** Split long documents into overlapping token chunksTbl.
+**Goal:** Split long documents into overlapping token chunks.
 
 **Depends on:** [Step 3: Data Ingestion](step03_data_ingestion.md).
 
@@ -26,7 +26,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 - **Parameters:**
   - `docsTbl` (table): from Step 3 with `docId` and `text` fields.
   - `'chunkSizeTokens'` (double): tokens per chunk.
-    - `'chunkOverlap'` (double): overlap between chunksTbl.
+  - `'chunkOverlap'` (double): overlap between chunks.
 - **Returns:** table `chunksTbl` with columns `chunkId` (double), `docId` (string), and `text` (string).
 - **Side Effects:** none; pure transformation of input table.
 - **Usage Example:**


### PR DESCRIPTION
## Summary
- Refine text chunking step goal and parameter descriptions
- Ensure `chunksTbl` is only referenced for the output table

## Testing
- `matlab -batch "runtests('tests/testIngestAndChunk.m')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd2d9a4a48330bf36517be12100f4