### PR TITLE
docs: load chunk table from chunksTbl.mat

### DIFF
--- a/docs/pseudocode/embeddingGeneration.md
+++ b/docs/pseudocode/embeddingGeneration.md
@@ -2,9 +2,9 @@
 
 This sketch outlines how to compute and persist document embeddings. The routine prefers a GPU backend but falls back to the CPU when necessary.
 
-## 1. Load Chunks
+## 1. Load chunk table
 ```matlab
-chunksTbl = load('data/chunks.mat').chunks;
+chunksTbl = load('data/chunksTbl.mat').chunksTbl;
 numChunks = height(chunksTbl);
 ```
 

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -7,14 +7,14 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-1. Load chunk data:
+1. Load chunk table:
    ```matlab
-   load('data/chunks.mat','chunks')
+   load('data/chunksTbl.mat','chunksTbl')
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
 
-   weakLabelMat = reg.weakRules(chunks.text, configStruct.labels);
+   weakLabelMat = reg.weakRules(chunksTbl.text, configStruct.labels);
    bootLabelMat = weakLabelMat >= configStruct.minRuleConf; % optional threshold
 
    ```
@@ -50,13 +50,13 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schemas of `weakLabelMat` and `bootLabelMat`.
 
 
-> **Note:** `reg.weakRules` requires `chunks.text` and the label list `configStruct.labels`
+> **Note:** `reg.weakRules` requires `chunksTbl.text` and the label list `configStruct.labels`
 > from [`config.m`](../config.m). The confidence cutoff `configStruct.minRuleConf` is
 > optional and can be tuned in `config.m` or overridden via `knobs.json`.
 
 ## Verification
 - `weakLabelMat` contains confidence scores per label.
-- `bootLabelMat` is a sparse matrix with rows matching `chunks` and columns representing topics.
+- `bootLabelMat` is a sparse matrix with rows matching `chunksTbl` and columns representing topics.
 - Run the labeling test:
   ```matlab
   runtests('tests/testRulesAndModel.m')

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -7,13 +7,13 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-1. Load chunk data:
+1. Load chunk table:
    ```matlab
-   load('data/chunks.mat','chunks')
+   load('data/chunksTbl.mat','chunksTbl')
    ```
 2. Generate embeddings with the GPU-enabled BERT encoder:
    ```matlab
-   embeddingMat = reg.docEmbeddingsBertGpu(chunks);
+   embeddingMat = reg.docEmbeddingsBertGpu(chunksTbl);
    ```
    If a GPU is unavailable, the function automatically falls back to a CPU-friendly model.
 3. Cache embeddings for reuse:
@@ -25,12 +25,12 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### reg.docEmbeddingsBertGpu
 - **Parameters:**
-  - `chunks` (table): as defined in Step 4.
+  - `chunksTbl` (table): as defined in Step 4.
 - **Returns:** double matrix `embeddingMat` of size `[numChunks x 768]` by default.
 - **Side Effects:** loads BERT weights and uses GPU when available.
 - **Usage Example:**
   ```matlab
-  embeddingMat = reg.docEmbeddingsBertGpu(chunks);
+  embeddingMat = reg.docEmbeddingsBertGpu(chunksTbl);
   ```
 
 ### reg.precomputeEmbeddings


### PR DESCRIPTION
## Summary
- Update weak labeling and embedding docs to load `chunksTbl.mat` instead of `chunks.mat`
- Rename variable references to `chunksTbl` and adjust descriptions
- Align embedding pseudocode with `chunksTbl` table

## Testing
- ⚠️ `matlab -batch "runtests"` *(command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689cd2f2e01c83308330b1b5192df0a4