### PR TITLE
docs: rename loadGold parameter to goldPath

### DIFF
--- a/docs/pseudocode/evaluation.md
+++ b/docs/pseudocode/evaluation.md
@@ -18,7 +18,8 @@
 ## Gold Loading
 Load a curated gold mini-pack when available:
 ```matlab
-goldTbl = reg.loadGold(pathStr);
+goldPath = 'path/to/gold';
+goldTbl = reg.loadGold(goldPath);
 ```
 `goldTbl` schema:
 - `docId` (string): document identifier.

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -15,7 +15,8 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
    ```
 2. Optional: evaluate against a gold mini-pack if available:
    ```matlab
-   goldTbl = reg.loadGold('path/to/gold');
+   goldPath = 'path/to/gold';
+   goldTbl = reg.loadGold(goldPath);
    reg.evalPerLabel(predYMat, goldTbl.y);
    ```
 3. Inspect generated artifacts in the `reports` or `output` folder.
@@ -33,12 +34,13 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 ### reg.loadGold
 - **Parameters:**
-  - `pathStr` (string): location of gold annotations.
+  - `goldPath` (string): location of gold annotations.
 - **Returns:** table `goldTbl` of annotations.
 - **Side Effects:** reads curated annotation packs if available.
 - **Usage Example:**
   ```matlab
-  goldTbl = reg.loadGold('path/to/gold');
+  goldPath = 'path/to/gold';
+  goldTbl = reg.loadGold(goldPath);
   ```
 
 
@@ -53,7 +55,7 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
   reg.evalPerLabel(predYMat, goldTbl.y);
   ```
 
-See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references. – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
+See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for metric schema references.
 
 
 


### PR DESCRIPTION
## Summary
- rename `reg.loadGold` argument to `goldPath` and update usage examples
- fix duplicate "Identifier Registry – Data Contracts" sentence in evaluation docs
- standardize parameter names to lowerCamelCase across examples

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd31d65a8833091005d8ce68c61f7