### PR TITLE
refactor: clarify baseline controller training variable

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -643,8 +643,9 @@ classdef baselineControllerClass
             %   model (baselineModelClass): Trained model.
             %
             %   Side effects: none.
-            model = model.baselineModelClass(labelMatrixObj, embeddingVec);
-            model.train(numEpochs, learningRate);
+            baselineModel = model.baselineModelClass(labelMatrixObj, embeddingVec);
+            baselineModel.train(numEpochs, learningRate);
+            model = baselineModel;
         end
 
         function chunkVec = retrieve(~, model, queryEmbeddingVec, topK)


### PR DESCRIPTION
## Summary
- rename local variable in `baselineControllerClass.train` to `baselineModel`
- ensure trained model is returned to caller

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd392931483308afc4878c5311c4d