### PR TITLE
docs: add naming note to step guides

### DIFF
--- a/docs/step01_environment_tooling.md
+++ b/docs/step01_environment_tooling.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Install **MATLAB R2024a** on your workstation.
 2. During installation, add these toolboxes:
    - Text Analytics

--- a/docs/step02_repository_setup.md
+++ b/docs/step02_repository_setup.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Clone or unzip the project repository.
 2. In MATLAB, navigate to the project root and add all folders to the path:
    ```matlab

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`). Fetcher utilities save downloaded PDFs to `data/raw`.
 2. Before running `reg.ingestPdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
 3. In MATLAB, call the ingestion routine:

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Load the ingested documents table `docsTbl`:
    ```matlab
    load('data/docsTbl.mat','docsTbl')

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Load chunk table:
    ```matlab
    load('data/chunksTbl.mat','chunksTbl')

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Load chunk table:
    ```matlab
    load('data/chunksTbl.mat','chunksTbl')

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Load embeddings and weak labels:
    ```matlab
    load('data/embeddingMat.mat','embeddingMat');

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Load `embeddingMat` and `bootLabelMat` as in Step 7.
 2. Train the projection head:
    ```matlab

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Build the contrastive training dataset:
    ```matlab
    contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunksTbl, bootLabelMat);

--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -8,6 +8,8 @@
 
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Run the evaluation script to compute retrieval metrics and generate a PDF report:
 
    ```matlab

--- a/docs/step11_pipeline_controller.md
+++ b/docs/step11_pipeline_controller.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Implement a `reg.PipelineController` class that instantiates and sequences other controllers (ingest, chunk, weak label, embed, train, evaluate).
 2. Read execution order and parameters from `pipeline.json` and `knobs.json` to determine which stages run.
 3. Use a shared logger (e.g., `reg.getLogger`) so each stage logs with timestamps and module identifiers.

--- a/docs/step12_data_acquisition_diffs.md
+++ b/docs/step12_data_acquisition_diffs.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. Synchronize the Common Rulebook (CRR) or similar sources:
    ```matlab
    reg.crrSync();

--- a/docs/step13_continuous_testing.md
+++ b/docs/step13_continuous_testing.md
@@ -7,6 +7,8 @@
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
 1. In MATLAB, run the full test suite regularly:
    ```matlab
    resultsTbl = runtests('tests','IncludeSubfolders',true,'UseParallel',false);


### PR DESCRIPTION
## Summary
- remind contributors in every build step doc to consult naming conventions and update the identifier registry when adding new terms

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd4ee7fe88330aa52f1e8111ad4aa