### PR TITLE
Clarify data acquisition diffStruct contract

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -34,7 +34,7 @@
 | `+controller/projectionHeadControllerClass.m` | Instantiates `model.projectionHeadClass` and delegates calls without duplicate training logic |
 | `+controller/fineTuneControllerClass.m`       | Builds contrastive datasets and produces `model.encoderClass` models |
 | `+controller/evaluationControllerClass.m`     | Computes metrics and invokes `view.evalReportViewClass` and gold pack evaluation |
-| `+controller/dataAcquisitionControllerClass.m`| Fetches regulatory corpora and triggers diff analyses with `view.diffReportViewClass` |
+| `+controller/dataAcquisitionControllerClass.m`| Fetches regulatory corpora, computes version diffs, and returns `diffStruct` for callers to pass to `view.diffReportViewClass` |
 | `+controller/pipelineControllerClass.m`       | Orchestrates end‑to‑end execution based on module dependencies |
 | `+controller/testControllerClass.m`           | Executes continuous test suite to maintain reliability |
 
@@ -770,9 +770,14 @@ classdef dataAcquisitionControllerClass
             %   diffStruct = diffVersions(obj, oldVersionId, newVersionId)
             %   oldVersionId (string): Baseline version.
             %   newVersionId (string): New version.
-            %   diffStruct (struct): Differences between versions.
+            %   diffStruct (struct): Differences between versions with fields:
+            %       addedDocVec (documentClass Vec): Documents only in newVersionId.
+            %       removedDocVec (documentClass Vec): Documents only in oldVersionId.
+            %       changedDocVec (documentClass Vec): Documents present in both but modified.
+            %   Callers should handle diffStruct (e.g., pass to diffReportViewClass).
             %
             %   Side effects: accesses external resources.
+            diffStruct = struct();
         end
     end
 end


### PR DESCRIPTION
## Summary
- document that dataAcquisitionControllerClass.diffVersions returns a structured diff with added, removed, and changed documents
- note that callers must handle the returned diffStruct, typically passing it to diffReportViewClass

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd65a22d08330a266142ca4a6cffa