### PR TITLE
docs: use regEvalReport.pdf and clarify verification columns

### DIFF
--- a/docs/step10_evaluation_reporting.md
+++ b/docs/step10_evaluation_reporting.md
@@ -27,7 +27,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 ### reg.evalRetrieval
 - **Parameters:** `resultsTbl` table, `goldTbl` table.
-- **Returns:** metrics tables and generates `reg_eval_report.pdf`.
+- **Returns:** metrics tables and generates `regEvalReport.pdf`.
 - **Side Effects:** reads model artifacts and writes report files to disk.
 - **Usage Example:**
   ```matlab
@@ -62,10 +62,10 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
 
 
 ## Verification
-- Report files such as `reg_eval_report.pdf` and metric CSVs are created.
+- Report files such as `regEvalReport.pdf` and metric CSVs are created.
 - Retrieval results table includes expected columns:
   ```matlab
-  assert(all(ismember({'docId','score'}, resultsTbl.Properties.VariableNames)));
+  assert(all(ismember({'docId', 'score'}, resultsTbl.Properties.VariableNames)));
   ```
 - Run evaluation tests:
   ```matlab


### PR DESCRIPTION
## Summary
- reference regEvalReport.pdf instead of reg_eval_report.pdf
- include space after comma in verification column list
- confirm consistent spacing in comma-separated items

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7e89ae48330b4a6ba2e6c69ee80