### PR TITLE
docs: fix comma spacing in embedding guide

### DIFF
--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load chunk table:
    ```matlab
-   load('data/chunksTbl.mat','chunksTbl')
+   load('data/chunksTbl.mat', 'chunksTbl');
    ```
 2. Generate embeddings with the GPU-enabled BERT encoder:
    ```matlab
@@ -20,7 +20,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    If a GPU is unavailable, the function automatically falls back to a CPU-friendly model.
 3. Cache embeddings for reuse:
    ```matlab
-   reg.precomputeEmbeddings(embeddingMat,'data/embeddingMat.mat');
+   reg.precomputeEmbeddings(embeddingMat, 'data/embeddingMat.mat');
    ```
 
 ## Function Interface


### PR DESCRIPTION
## Summary
- clarify `load` usage with space after comma and terminating semicolon
- normalize comma spacing in `reg.precomputeEmbeddings` example

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7e345908330966c1b41963e94e2