### PR TITLE
docs: fix spacing in weak labeling instructions

### DIFF
--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load chunk table:
    ```matlab
-   load('data/chunksTbl.mat','chunksTbl')
+   load('data/chunksTbl.mat', 'chunksTbl');
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
@@ -22,7 +22,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 3. Store the thresholded label matrix for future training:
    ```matlab
-   save('data/bootLabelMat.mat','bootLabelMat')
+   save('data/bootLabelMat.mat', 'bootLabelMat');
    ```
 
 ## Function Interface
@@ -35,7 +35,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** none.
 - **Usage Example:**
   ```matlab
-  weakLabelMat = reg.weakRules(["example"], ["topicA","topicB"]);
+  weakLabelMat = reg.weakRules(["example"], ["topicA", "topicB"]);
   ```
 
 ### Thresholding


### PR DESCRIPTION
## Summary
- clarify MATLAB load/save snippets with spaces after commas and terminating semicolons
- ensure example label list includes spaces after commas for readability

## Testing
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7e0b92c8330b35b59c422d5775c