### PR TITLE
docs: standardize spacing in text chunking step

### DIFF
--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load the ingested documents table `docsTbl`:
    ```matlab
-   load('data/docsTbl.mat','docsTbl')
+   load('data/docsTbl.mat', 'docsTbl');
    ```
 2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab
@@ -19,7 +19,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 3. Save the chunksTbl for later modules:
    ```matlab
-   save('data/chunksTbl.mat','chunksTbl')
+   save('data/chunksTbl.mat', 'chunksTbl');
    ```
 
 ## Function Interface


### PR DESCRIPTION
## Summary
- Ensure load/save examples in text chunking step use spaces after commas and end with semicolons
- Confirm all other comma-separated arguments in the document have proper spacing

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave-cli --eval "disp('octave available')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7e08e2c8330ba8477a4d0247229