### PR TITLE
docs: fix save syntax and spacing in data ingestion guide

### DIFF
--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -18,7 +18,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 4. The function extracts text from each PDF into `docsTbl`. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
 5. Save `docsTbl` for later steps:
    ```matlab
-   save('data/docsTbl.mat','docsTbl')
+   save('data/docsTbl.mat', 'docsTbl');
    ```
 
 ## Function Interface


### PR DESCRIPTION
## Summary
- fix `save` command in data ingestion step to include space after comma and semicolon
- enforce consistent comma spacing across the doc

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7ded5bc8330abbb81931c78ba6c