### PR TITLE
docs: clarify crr diff interface

### DIFF
--- a/docs/step12_data_acquisition_diffs.md
+++ b/docs/step12_data_acquisition_diffs.md
@@ -15,7 +15,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 2. Generate diffStruct reports between document versions:
    ```matlab
-   diffStruct = reg.crrDiffVersions('versionA','versionB');
+   diffStruct = reg.crrDiffVersions('versionA', 'versionB');
    reg.crrDiffReport();
    ```
 3. Review HTML or PDF diffStruct outputs for changes.
@@ -28,18 +28,18 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** downloads the latest corpus to `data/raw`.
 - **Usage Example:**
   ```matlab
-  reg.crrSync()
+  reg.crrSync();
   ```
 
 ### reg.crrDiffVersions
 - **Parameters:**
-  - `vA` (string): version identifier A.
-  - `vB` (string): version identifier B.
+  - `versionA` (string): version identifier A.
+  - `versionB` (string): version identifier B.
 - **Returns:** `diffStruct` (struct) describing added, removed, and changed documents.
 - **Side Effects:** none.
 - **Usage Example:**
    ```matlab
-   diffStruct = reg.crrDiffVersions('v1','v2');
+   diffStruct = reg.crrDiffVersions('versionA', 'versionB');
    ```
 
 ### reg.crrDiffReport
@@ -48,7 +48,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** renders HTML/PDF summaries to disk.
 - **Usage Example:**
   ```matlab
-  reg.crrDiffReport()
+  reg.crrDiffReport();
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for corpus schema references.


### PR DESCRIPTION
## Summary
- clarify `reg.crrDiffVersions` by renaming parameters to `versionA` and `versionB`
- demonstrate correct spacing and semicolon usage for `reg.crrSync` and `reg.crrDiffReport`

## Testing
- `matlab -batch "runtests"` *(failed: command not found: matlab)*
- `sudo apt-get update` *(failed: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_689cd7ea34e083308a02221ce6538b20