### PR TITLE
docs: add spacing after commas in step guides

### DIFF
--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -18,7 +18,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 4. The function extracts text from each PDF into `docsTbl`. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
 5. Save `docsTbl` for later steps:
    ```matlab
-   save('data/docsTbl.mat','docsTbl')
+   save('data/docsTbl.mat', 'docsTbl')
    ```
 
 ## Function Interface

--- a/docs/step12_data_acquisition_diffs.md
+++ b/docs/step12_data_acquisition_diffs.md
@@ -15,7 +15,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 2. Generate diffStruct reports between document versions:
    ```matlab
-   diffStruct = reg.crrDiffVersions('versionA','versionB');
+   diffStruct = reg.crrDiffVersions('versionA', 'versionB');
    reg.crrDiffReport();
    ```
 3. Review HTML or PDF diffStruct outputs for changes.
@@ -39,7 +39,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** none.
 - **Usage Example:**
    ```matlab
-   diffStruct = reg.crrDiffVersions('v1','v2');
+   diffStruct = reg.crrDiffVersions('v1', 'v2');
    ```
 
 ### reg.crrDiffReport

--- a/docs/step13_continuous_testing.md
+++ b/docs/step13_continuous_testing.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. In MATLAB, run the full test suite regularly:
    ```matlab
-   resultsTbl = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
+   resultsTbl = runtests('tests', 'IncludeSubfolders', true, 'UseParallel', false);
    table(resultsTbl)
    ```
 2. Investigate any failures before committing changes.
@@ -27,7 +27,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** executes all MATLAB tests in the project.
 - **Usage Example:**
   ```matlab
-  resultsTbl = runtests('tests','IncludeSubfolders',true,'UseParallel',false);
+  resultsTbl = runtests('tests', 'IncludeSubfolders', true, 'UseParallel', false);
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for any test-related artifacts.


### PR DESCRIPTION
## Summary
- standardize comma spacing in step03, step12, and step13 documentation examples

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cd9e858108330becfd0675dd456b9