### PR TITLE
docs: use src data path for runtime artifacts

### DIFF
--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -37,7 +37,7 @@ Orchestration and flow control code is located in `src/reg/controller/`.
 
 ## Runtime Data Layout
 
-Runtime data produced or consumed by the pipeline is organized as follows:
+Runtime data produced or consumed by the pipeline is organized under `src/data/` as follows:
 
 - `src/data/datastore/db/`
 - `src/data/processing/raw/`

--- a/docs/step03_data_ingestion.md
+++ b/docs/step03_data_ingestion.md
@@ -9,16 +9,16 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
 
-1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `data/pdfs`). Fetcher utilities save downloaded PDFs to `data/raw`.
-2. Before running `reg.ingestPdfs`, either copy PDFs into `data/pdfs` or update `pipeline.json` to read from `data/raw`.
+1. Place source PDFs in a folder referenced by `pipeline.json` (e.g., `src/data/input/pdfs`). Fetcher utilities save downloaded PDFs to `src/data/processing/raw`.
+2. Before running `reg.ingestPdfs`, either copy PDFs into `src/data/input/pdfs` or update `pipeline.json` to read from `src/data/processing/raw`.
 3. In MATLAB, call the ingestion routine:
    ```matlab
-   docsTbl = reg.ingestPdfs('data/pdfs');
+   docsTbl = reg.ingestPdfs('src/data/input/pdfs');
    ```
 4. The function extracts text from each PDF into `docsTbl`. Image-only pages fall back to OCR if the Report Generator toolbox is installed.
 5. Save `docsTbl` for later steps:
    ```matlab
-   save('data/docsTbl.mat', 'docsTbl')
+   save('src/data/docsTbl.mat', 'docsTbl')
    ```
 
 ## Function Interface
@@ -30,7 +30,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 - **Side Effects:** reads PDFs from disk and uses OCR for image-only pages.
 - **Usage Example:**
   ```matlab
-  docsTbl = reg.ingestPdfs("data/pdfs_mock");
+  docsTbl = reg.ingestPdfs("src/data/input/pdfs_mock");
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for schema.

--- a/docs/step04_text_chunking.md
+++ b/docs/step04_text_chunking.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load the ingested documents table `docsTbl`:
    ```matlab
-   load('data/docsTbl.mat', 'docsTbl');
+   load('src/data/docsTbl.mat', 'docsTbl');
    ```
 2. Chunk each document with the helper function (default `chunkSizeTokens=300`, `chunkOverlap=80`):
    ```matlab
@@ -19,7 +19,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 3. Save the chunksTbl for later modules:
    ```matlab
-   save('data/chunksTbl.mat', 'chunksTbl');
+   save('src/data/chunksTbl.mat', 'chunksTbl');
    ```
 
 ## Function Interface

--- a/docs/step05_weak_labeling.md
+++ b/docs/step05_weak_labeling.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load chunk table:
    ```matlab
-   load('data/chunksTbl.mat', 'chunksTbl');
+   load('src/data/chunksTbl.mat', 'chunksTbl');
    ```
 2. Generate weak labels with rule-based functions:
    ```matlab
@@ -22,7 +22,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    ```
 3. Store the thresholded label matrix for future training:
    ```matlab
-   save('data/bootLabelMat.mat', 'bootLabelMat');
+   save('src/data/bootLabelMat.mat', 'bootLabelMat');
    ```
 
 ## Function Interface

--- a/docs/step06_embedding_generation.md
+++ b/docs/step06_embedding_generation.md
@@ -11,7 +11,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load chunk table:
    ```matlab
-   load('data/chunksTbl.mat', 'chunksTbl');
+   load('src/data/chunksTbl.mat', 'chunksTbl');
    ```
 2. Generate embeddings with the GPU-enabled BERT encoder:
    ```matlab
@@ -20,7 +20,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
    If a GPU is unavailable, the function automatically falls back to a CPU-friendly model.
 3. Cache embeddings for reuse:
    ```matlab
-   reg.precomputeEmbeddings(embeddingMat, 'data/embeddingMat.mat');
+   reg.precomputeEmbeddings(embeddingMat, 'src/data/embeddingMat.mat');
    ```
 
 ## Function Interface

--- a/docs/step07_baseline_classifier.md
+++ b/docs/step07_baseline_classifier.md
@@ -11,8 +11,8 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load embeddings and weak labels:
    ```matlab
-   load('data/embeddingMat.mat', 'embeddingMat');
-   load('data/bootLabelMat.mat', 'bootLabelMat');
+   load('src/data/embeddingMat.mat', 'embeddingMat');
+   load('src/data/bootLabelMat.mat', 'bootLabelMat');
    ```
 2. Train the baseline classifier:
    ```matlab

--- a/docs/step08_projection_head.md
+++ b/docs/step08_projection_head.md
@@ -11,8 +11,8 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Load `embeddingMat` and `bootLabelMat` as in Step 7:
    ```matlab
-   load('data/embeddingMat.mat', 'embeddingMat');
-   load('data/bootLabelMat.mat', 'bootLabelMat');
+   load('src/data/embeddingMat.mat', 'embeddingMat');
+   load('src/data/bootLabelMat.mat', 'bootLabelMat');
    ```
 2. Train the projection head:
    ```matlab

--- a/docs/step09_encoder_finetuning.md
+++ b/docs/step09_encoder_finetuning.md
@@ -11,10 +11,10 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 1. Build the contrastive training dataset:
    ```matlab
-   load('data/chunksTbl.mat', 'chunksTbl');
-   load('data/bootLabelMat.mat', 'bootLabelMat');
+   load('src/data/chunksTbl.mat', 'chunksTbl');
+   load('src/data/bootLabelMat.mat', 'bootLabelMat');
    contrastiveDatasetTbl = reg.ftBuildContrastiveDataset(chunksTbl, bootLabelMat);
-   save('data/contrastiveDatasetTbl.mat', 'contrastiveDatasetTbl');
+   save('src/data/contrastiveDatasetTbl.mat', 'contrastiveDatasetTbl');
    ```
 2. Fine-tune the encoder starting from the pretrained weights:
    ```matlab

--- a/docs/step12_data_acquisition_diffs.md
+++ b/docs/step12_data_acquisition_diffs.md
@@ -25,7 +25,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 ### reg.crrSync
 - **Parameters:** none.
 - **Returns:** none.
-- **Side Effects:** downloads the latest corpus to `data/raw`.
+- **Side Effects:** downloads the latest corpus to `src/data/processing/raw`.
 - **Usage Example:**
   ```matlab
   reg.crrSync();
@@ -55,7 +55,7 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
 
 
 ## Verification
-- Date-stamped corpora appear in the `data` directory.
+- Date-stamped corpora appear in the `src/data/processing/raw` directory.
 - Run fetcher tests:
   ```matlab
   runtests('tests/testFetchers.m')


### PR DESCRIPTION
## Summary
- clarify in master scaffold that runtime data lives under `src/data/`
- point step instructions to `src/data` for ingesting, chunking, labeling, embeddings, and corpus sync

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cde5d3b7c8330a3c03f716241d8a3