### PR TITLE
Align build plan steps and add MVC scaffolding docs

### DIFF
--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -20,7 +20,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 2. Repository Setup
 - **Goal:** Acquire the project and confirm configuration wiring.
-- **Depends on:** Environment & Tooling.
+- **Depends on:** [Step 1: Environment & Tooling](step01_environment_tooling.md).
 - **Steps:**
   1. Clone/unzip repo; add to MATLAB path with `addpath(genpath(pwd)); savepath`.
   2. Adjust `pipeline.json` (I/O, DB) and `knobs.json` (chunking, batch sizes, learning rates). Optional `params.json` for fine-tune overrides.
@@ -29,7 +29,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 3. MVC Scaffolding & Persistence
 - **Goal:** Establish the base MVC structure and storage layer.
-- **Depends on:** Repository Setup.
+- **Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
 - **Steps:**
   1. Create `+model`, `+view`, and `+controller` directories.
   2. Implement base classes (e.g., `model.Document`, `controller.IngestionController`).
@@ -38,7 +38,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 4. Data Ingestion Module
 - **Goal:** Convert PDFs into raw text documents.
-- **Depends on:** Repository Setup and MVC Scaffolding & Persistence.
+- **Depends on:** [Step 2: Repository Setup](step02_repository_setup.md) and [Step 3: MVC Scaffolding & Persistence](step03_mvc_scaffolding.md).
 - **Implementation:** `reg.ingestPdfs` with fixtures for text and image-only PDFs.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testPDFIngest.m` ensures OCR fallback and basic parsing.
@@ -46,7 +46,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 5. Text Chunking Module
 - **Goal:** Split long documents into overlapping token chunks.
-- **Depends on:** Data Ingestion Module.
+- **Depends on:** [Step 4: Data Ingestion Module](step04_data_ingestion.md).
 - **Implementation:** `reg.chunkText` respecting `chunkSizeTokens` & `chunkOverlap`.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testIngestAndChunk.m` verifies chunk counts and boundaries.
@@ -54,15 +54,15 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 6. Weak Labeling Module
 - **Goal:** Bootstrap labels using rule-based heuristics.
-- **Depends on:** Text Chunking Module.
+- **Depends on:** [Step 5: Text Chunking Module](step05_text_chunking.md).
 - **Implementation:** `reg.weakRules` returning label matrix.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testRulesAndModel.m` confirms label coverage and format.
- - **Output:** Sparse label matrix `bootLabelMat`.
+- **Output:** Sparse label matrix `bootLabelMat`.
 
 ## 7. Embedding Generation Module
 - **Goal:** Embed chunks using BERT (GPU) or FastText fallback.
-- **Depends on:** Text Chunking Module.
+- **Depends on:** [Step 6: Weak Labeling Module](step06_weak_labeling.md).
 - **Implementation:** `reg.docEmbeddingsBertGpu` & `reg.precomputeEmbeddings`.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFeatures.m` checks embedding shapes & backend selection.
@@ -70,7 +70,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 8. Baseline Classifier & Retrieval
 - **Goal:** Train a multi-label classifier and enable hybrid search.
-- **Depends on:** Weak Labeling Module and Embedding Generation Module.
+- **Depends on:** [Step 6: Weak Labeling Module](step06_weak_labeling.md) and [Step 7: Embedding Generation Module](step07_embedding_generation.md).
 - **Implementation:**
   - `reg.trainMultilabel` for classifier.
   - `reg.hybridSearch` for cosine + BM25 retrieval.
@@ -80,7 +80,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 9. Projection Head Workflow
 - **Goal:** Improve retrieval with an MLP on frozen embeddings.
-- **Depends on:** Baseline Classifier & Retrieval.
+- **Depends on:** [Step 8: Baseline Classifier & Retrieval](step08_baseline_classifier.md).
 - **Implementation:** `reg.trainProjectionHead` with `regProjectionWorkflow.m` driver.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testProjectionHeadSimulated.m` ensures Recall@n increases over baseline. `tests/testProjectionAutoloadPipeline.m` verifies auto-use in `reg_pipeline`.
@@ -88,7 +88,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 10. Encoder Fine-Tuning Workflow
 - **Goal:** Unfreeze BERT layers and apply contrastive learning.
-- **Depends on:** Projection Head Workflow (optional but recommended) and Embedding Generation Module.
+- **Depends on:** [Step 9: Projection Head Workflow](step09_projection_head.md) and [Step 7: Embedding Generation Module](step07_embedding_generation.md).
 - **Implementation:** `reg.ftBuildContrastiveDataset`, `reg.ftTrainEncoder`, and `regFineTuneEncoderWorkflow.m`.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFineTuneSmoke.m` for basic convergence, `tests/testFineTuneResume.m` for checkpoint resume.
@@ -96,7 +96,7 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 
 ## 11. Evaluation & Reporting
 - **Goal:** Quantify performance and produce human-readable reports.
-- **Depends on:** Baseline/Projection/Fine-Tuned models.
+- **Depends on:** [Step 8](step08_baseline_classifier.md), [Step 9](step09_projection_head.md), and [Step 10](step10_encoder_finetuning.md).
 - **Implementation:**
   - `reg.evalRetrieval` and `reg.evalPerLabel` for metrics.
   - `controller.EvaluationController` drives evaluation and report generation:
@@ -110,9 +110,9 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 - **Output:** Metrics CSVs, `regEvalReport.pdf`/`.html`, diff report artifacts, visualization images, and gold evaluation results.
 
 
-## 11. Pipeline Controller
+## 12. Pipeline Controller
 - **Goal:** Coordinate module execution through a central controller.
-- **Depends on:** Evaluation & Reporting.
+- **Depends on:** [Step 11: Evaluation & Reporting](step11_evaluation_reporting.md).
 - **Implementation:**
   - Implement `reg.PipelineController` to sequence ingestion, chunking, labeling, embedding, training, and evaluation controllers.
   - Use configuration files (`pipeline.json`, `knobs.json`) to drive stage selection and parameters.
@@ -122,15 +122,15 @@ Every module must expose a MATLAB class with a clearly defined public interface 
 - **Testing:** `tests/testPipelineController.m` validates end-to-end coordination with mocked dependencies and failure handling.
 - **Output:** Reproducible pipeline runs with centralized logs and robust error reporting.
 
-## 12. Data Acquisition & Diff Utilities (Optional)
+## 13. Data Acquisition & Diff Utilities (Optional)
 - **Goal:** Automate CRR/EBA fetches and track version differences.
-- **Depends on:** Environment & Tooling.
+- **Depends on:** [Step 1: Environment & Tooling](step01_environment_tooling.md).
 - **Implementation:** `regCrrSync.m`, `reg.crrDiffVersions`, `reg.crrDiffArticles`, and related HTML/PDF report generators.
   - Reference the module's class name and any interfaces it implements.
 - **Testing:** `tests/testFetchers.m` (network-tolerant).
 - **Output:** Date-stamped corpora and diff reports.
 
-## 13. Continuous Testing Framework
+## 14. Continuous Testing Framework
 - **Goal:** Ensure every module is validated locally and in CI.
 - **Depends on:** All previous modules.
 - **Testing Style:** All tests must subclass `matlab.unittest.TestCase` and use fixtures with explicit teardown methods.
@@ -156,16 +156,17 @@ Environment → Repo Setup → MVC Scaffolding → Ingest → Chunk → Weak Lab
 ## Suggested Module Build Order
 1. Environment & Tooling
 2. Repository Setup
-3. Data Ingestion
-4. Text Chunking
-5. Weak Labeling
-6. Embedding Generation
-7. Baseline Classifier & Retrieval
-8. Projection Head Workflow
-9. Encoder Fine-Tuning Workflow
-10. Evaluation & Reporting
-11. Pipeline Controller
-12. Data Acquisition & Diff Utilities (optional)
-13. Continuous Testing Framework
+3. MVC Scaffolding & Persistence
+4. Data Ingestion
+5. Text Chunking
+6. Weak Labeling
+7. Embedding Generation
+8. Baseline Classifier & Retrieval
+9. Projection Head Workflow
+10. Encoder Fine-Tuning Workflow
+11. Evaluation & Reporting
+12. Pipeline Controller
+13. Data Acquisition & Diff Utilities (optional)
+14. Continuous Testing Framework
 
 Following this order builds the system incrementally while keeping each component as independent as possible and providing explicit checkpoints for testing and quality control.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -274,7 +274,7 @@ Regression entries must include the simulated dataset path, expected output, and
 
 | Producer → Consumer | Payload Schema | Format | Validation | Notes |
 |--------------------|----------------|--------|-----------|-------|
-| ingest → chunking | Document | MAT-file (`docsTbl.mat`) | non-empty `text` | see [Step 3](step03_data_ingestion.md) |
+| ingest → chunking | Document | MAT-file (`docsTbl.mat`) | non-empty `text` | see [Step 4](step04_data_ingestion.md) |
 
 
 ---

--- a/docs/step02_repository_setup.md
+++ b/docs/step02_repository_setup.md
@@ -50,4 +50,4 @@ Data structures referenced in later modules are detailed in [Identifier Registry
 - MATLAB can locate project functions such as `regPipeline`.
 
 ## Next Steps
-Continue to [Step 3: Data Ingestion](step03_data_ingestion.md).
+Continue to [Step 3: MVC Scaffolding & Persistence](step03_mvc_scaffolding.md).

--- a/docs/step03_mvc_scaffolding.md
+++ b/docs/step03_mvc_scaffolding.md
@@ -1,0 +1,16 @@
+# Step 3: MVC Scaffolding & Persistence
+
+**Goal:** Establish the base MVC structure and storage layer.
+
+**Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
+
+## Instructions
+Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
+
+Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+
+1. Create `+model`, `+view`, and `+controller` directories to organize core classes.
+2. Implement base classes such as `model.Document` and `controller.IngestionController`.
+3. Establish a persistence layer (repositories or DAOs) for storing model state.
+
+Continue to [Step 4: Data Ingestion](step04_data_ingestion.md).

--- a/docs/step04_data_ingestion.md
+++ b/docs/step04_data_ingestion.md
@@ -1,8 +1,8 @@
-# Step 3: Data Ingestion
+# Step 4: Data Ingestion
 
 **Goal:** Convert PDF documents into a `docsTbl` table of raw text records.
 
-**Depends on:** [Step 2: Repository Setup](step02_repository_setup.md).
+**Depends on:** [Step 2: Repository Setup](step02_repository_setup.md) and [Step 3: MVC Scaffolding & Persistence](step03_mvc_scaffolding.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -45,4 +45,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   The test should pass, confirming OCR fallback and basic parsing.
 
 ## Next Steps
-Continue to [Step 4: Text Chunking](step04_text_chunking.md).
+Continue to [Step 5: Text Chunking](step05_text_chunking.md).

--- a/docs/step05_text_chunking.md
+++ b/docs/step05_text_chunking.md
@@ -1,8 +1,8 @@
-# Step 4: Text Chunking
+# Step 5: Text Chunking
 
 **Goal:** Split long documents into overlapping token chunks.
 
-**Depends on:** [Step 3: Data Ingestion](step03_data_ingestion.md).
+**Depends on:** [Step 4: Data Ingestion](step04_data_ingestion.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -26,7 +26,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 ### reg.chunkText
 - **Parameters:**
-  - `docsTbl` (table): from Step 3 with `docId` and `text` fields.
+  - `docsTbl` (table): from Step 4 with `docId` and `text` fields.
   - `'chunkSizeTokens'` (double): tokens per chunk.
   - `'chunkOverlap'` (double): overlap between chunks.
 - **Returns:** table `chunksTbl` with columns `chunkId` (double), `docId` (string), and `text` (string).
@@ -48,4 +48,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   The test confirms expected chunk counts and boundaries.
 
 ## Next Steps
-Continue to [Step 5: Weak Labeling](step05_weak_labeling.md).
+Continue to [Step 6: Weak Labeling](step06_weak_labeling.md).

--- a/docs/step06_weak_labeling.md
+++ b/docs/step06_weak_labeling.md
@@ -1,8 +1,8 @@
-# Step 5: Weak Labeling
+# Step 6: Weak Labeling
 
 **Goal:** Generate `weakLabelMat` and `bootLabelMat` for each text chunk using heuristic rules.
 
-**Depends on:** [Step 4: Text Chunking](step04_text_chunking.md).
+**Depends on:** [Step 5: Text Chunking](step05_text_chunking.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -66,4 +66,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   The test verifies label coverage and format.
 
 ## Next Steps
-Continue to [Step 6: Embedding Generation](step06_embedding_generation.md).
+Continue to [Step 7: Embedding Generation](step07_embedding_generation.md).

--- a/docs/step07_embedding_generation.md
+++ b/docs/step07_embedding_generation.md
@@ -1,8 +1,8 @@
-# Step 6: Embedding Generation
+# Step 7: Embedding Generation
 
 **Goal:** Create vector representations for each text chunk using BERT or a fallback model.
 
-**Depends on:** [Step 5: Weak Labeling](step05_weak_labeling.md).
+**Depends on:** [Step 6: Weak Labeling](step06_weak_labeling.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -27,7 +27,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 ### reg.docEmbeddingsBertGpu
 - **Parameters:**
-  - `chunksTbl` (table): as defined in Step 4.
+  - `chunksTbl` (table): as defined in Step 5.
 - **Returns:** double matrix `embeddingMat` of size `[numChunks x 768]` by default.
 - **Side Effects:** loads BERT weights and uses GPU when available.
 - **Usage Example:**
@@ -58,4 +58,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   The test confirms embedding shapes and backend selection.
 
 ## Next Steps
-Continue to [Step 7: Baseline Classifier & Retrieval](step07_baseline_classifier.md).
+Continue to [Step 8: Baseline Classifier & Retrieval](step08_baseline_classifier.md).

--- a/docs/step08_baseline_classifier.md
+++ b/docs/step08_baseline_classifier.md
@@ -1,8 +1,8 @@
-# Step 7: Baseline Classifier & Retrieval
+# Step 8: Baseline Classifier & Retrieval
 
 **Goal:** Train a multi-label classifier and enable hybrid search.
 
-**Depends on:** [Step 6: Embedding Generation](step06_embedding_generation.md) and [Step 5: Weak Labeling](step05_weak_labeling.md).
+**Depends on:** [Step 7: Embedding Generation](step07_embedding_generation.md) and [Step 6: Weak Labeling](step06_weak_labeling.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -28,8 +28,8 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 ### reg.trainMultilabel
 - **Parameters:**
-  - `embeddingMat` (double matrix): embeddings from Step 6.
-  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
+  - `embeddingMat` (double matrix): embeddings from Step 7.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 6.
 - **Returns:** struct `baselineModelStruct` with fields `weights` and `bias` (see [BaselineModelStruct](identifier_registry.md#baselinemodelstruct)).
 - **Side Effects:** none.
 - **Usage Example:**
@@ -69,4 +69,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   ```
 
 ## Next Steps
-Continue to [Step 8: Projection Head Workflow](step08_projection_head.md).
+Continue to [Step 9: Projection Head Workflow](step09_projection_head.md).

--- a/docs/step09_projection_head.md
+++ b/docs/step09_projection_head.md
@@ -1,15 +1,15 @@
-# Step 8: Projection Head Workflow
+# Step 9: Projection Head Workflow
 
 **Goal:** Improve retrieval by training a small MLP (projection head) on frozen embeddings.
 
-**Depends on:** [Step 7: Baseline Classifier & Retrieval](step07_baseline_classifier.md).
+**Depends on:** [Step 8: Baseline Classifier & Retrieval](step08_baseline_classifier.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
 Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
 
-1. Load `embeddingMat` and `bootLabelMat` as in Step 7:
+1. Load `embeddingMat` and `bootLabelMat` as in Step 8:
    ```matlab
    load('data/embeddingMat.mat', 'embeddingMat');
    load('data/bootLabelMat.mat', 'bootLabelMat');
@@ -26,9 +26,9 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 ### reg.trainProjectionHead
 - **Parameters:**
 
-  - `embeddingMat` (double matrix): embeddings from Step 6.
+  - `embeddingMat` (double matrix): embeddings from Step 7.
 
-  - `bootLabelMat` (sparse logical matrix): weak labels from Step 5.
+  - `bootLabelMat` (sparse logical matrix): weak labels from Step 6.
 - **Returns:** struct `projectionHeadStruct` with fields `weights` and `bias` used for retrieval enhancement (see [ProjectionHeadStruct](identifier_registry.md#projectionheadstruct)).
 - **Side Effects:** none.
 - **Usage Example:**
@@ -53,4 +53,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   Tests verify improved Recall@n and automatic loading by `regPipeline`.
 
 ## Next Steps
-Continue to [Step 9: Encoder Fine-Tuning Workflow](step09_encoder_finetuning.md).
+Continue to [Step 10: Encoder Fine-Tuning Workflow](step10_encoder_finetuning.md).

--- a/docs/step10_encoder_finetuning.md
+++ b/docs/step10_encoder_finetuning.md
@@ -1,8 +1,8 @@
-# Step 9: Encoder Fine-Tuning Workflow
+# Step 10: Encoder Fine-Tuning Workflow
 
 **Goal:** Unfreeze BERT layers and apply contrastive learning for better representations.
 
-**Depends on:** [Step 8: Projection Head Workflow](step08_projection_head.md) and [Step 6: Embedding Generation](step06_embedding_generation.md).
+**Depends on:** [Step 9: Projection Head Workflow](step09_projection_head.md) and [Step 7: Embedding Generation](step07_embedding_generation.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -27,7 +27,7 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
 
 ### reg.ftBuildContrastiveDataset
 - **Parameters:**
-  - `chunksTbl` (table): see Step 4.
+  - `chunksTbl` (table): see Step 5.
   - `bootLabelMat` (sparse logical `[numChunks x numClasses]`): bootstrapped labels.
 - **Returns:** table `contrastiveDatasetTbl` with columns `anchorIdx`, `posIdx`, and `negIdx` (see [ContrastiveDataset](identifier_registry.md#contrastivedataset)).
 - **Side Effects:** none.
@@ -64,4 +64,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   Tests check basic convergence and checkpoint resume.
 
 ## Next Steps
-Continue to [Step 10: Evaluation & Reporting](step10_evaluation_reporting.md).
+Continue to [Step 11: Evaluation & Reporting](step11_evaluation_reporting.md).

--- a/docs/step11_evaluation_reporting.md
+++ b/docs/step11_evaluation_reporting.md
@@ -1,8 +1,8 @@
-# Step 10: Evaluation & Reporting
+# Step 11: Evaluation & Reporting
 
 **Goal:** Measure system performance and produce human-readable reports.
 
-**Depends on:** Model artifacts from [Step 7](step07_baseline_classifier.md), [Step 8](step08_projection_head.md), or [Step 9](step09_encoder_finetuning.md).
+**Depends on:** Model artifacts from [Step 8](step08_baseline_classifier.md), [Step 9](step09_projection_head.md), or [Step 10](step10_encoder_finetuning.md).
 
 ## Instructions
 
@@ -76,4 +76,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   Tests confirm metrics and report generation.
 
 ## Next Steps
-Continue to [Step 11: Pipeline Controller](step11_pipeline_controller.md). If data utilities are required, proceed to [Step 12: Data Acquisition & Diff Utilities](step12_data_acquisition_diffs.md); otherwise skip to [Step 13: Continuous Testing Framework](step13_continuous_testing.md).
+Continue to [Step 12: Pipeline Controller](step12_pipeline_controller.md). If data utilities are required, proceed to [Step 13: Data Acquisition & Diff Utilities](step13_data_acquisition_diffs.md); otherwise skip to [Step 14: Continuous Testing Framework](step14_continuous_testing.md).

--- a/docs/step12_pipeline_controller.md
+++ b/docs/step12_pipeline_controller.md
@@ -1,8 +1,8 @@
-# Step 11: Pipeline Controller
+# Step 12: Pipeline Controller
 
 **Goal:** Coordinate module controllers via configuration-driven stages.
 
-**Depends on:** [Step 10: Evaluation & Reporting](step10_evaluation_reporting.md).
+**Depends on:** [Step 11: Evaluation & Reporting](step11_evaluation_reporting.md).
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
@@ -30,4 +30,4 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
   Tests validate configuration-driven execution and error handling.
 
 ## Next Steps
-Continue to [Step 12: Data Acquisition & Diff Utilities](step12_data_acquisition_diffs.md) or proceed to [Step 13: Continuous Testing Framework](step13_continuous_testing.md).
+Continue to [Step 13: Data Acquisition & Diff Utilities](step13_data_acquisition_diffs.md) or proceed to [Step 14: Continuous Testing Framework](step14_continuous_testing.md).

--- a/docs/step13_data_acquisition_diffs.md
+++ b/docs/step13_data_acquisition_diffs.md
@@ -1,4 +1,4 @@
-# Step 12: Data Acquisition & Diff Utilities (Optional)
+# Step 13: Data Acquisition & Diff Utilities (Optional)
 
 **Goal:** Fetch regulatory documents and track changes between versions.
 
@@ -63,4 +63,4 @@ See [Identifier Registry – Data Contracts](identifier_registry.md#data-contrac
   Tests handle network availability gracefully.
 
 ## Next Steps
-Proceed to [Step 13: Continuous Testing Framework](step13_continuous_testing.md).
+Proceed to [Step 14: Continuous Testing Framework](step14_continuous_testing.md).

--- a/docs/step14_continuous_testing.md
+++ b/docs/step14_continuous_testing.md
@@ -1,4 +1,4 @@
-# Step 13: Continuous Testing Framework
+# Step 14: Continuous Testing Framework
 
 **Goal:** Ensure all modules stay reliable through automated testing.
 


### PR DESCRIPTION
## Summary
- Fix SYSTEM_BUILD_PLAN so each stage has a unique number and Pipeline Controller follows Evaluation & Reporting
- Insert MVC Scaffolding & Persistence as step 3 and renumber all subsequent step guides
- Link build-plan dependencies to the correct step guides

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cde30ff648330873484fe26051eb0