### PR TITLE
Switch documentation examples to token-based counting

### DIFF
--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -66,12 +66,14 @@ classdef Document
 
         function n = tokenCount(obj)
             %TOKENCOUNT Return number of tokens in text.
+            %   Tokens are whitespace-separated words.
             %   n = tokenCount(obj)
             %   obj (Document): Instance.
             %   n (double): Number of tokens.
             %
             %   Side effects: none.
-            n = numel(obj.text);
+            tokens = strsplit(obj.text);
+            n = numel(tokens);
         end
 
         function metadataStruct = metadata(obj)
@@ -120,12 +122,14 @@ classdef Chunk
 
         function n = tokenCount(obj)
             %TOKENCOUNT Return number of tokens in text.
+            %   Tokens are whitespace-separated words.
             %   n = tokenCount(obj)
             %   obj (Chunk): Instance.
             %   n (double): Number of tokens.
             %
             %   Side effects: none.
-            n = numel(obj.text);
+            tokens = strsplit(obj.text);
+            n = numel(tokens);
         end
 
         function tf = overlaps(obj, other)


### PR DESCRIPTION
## Summary
- Use whitespace tokenization in `Document` and `Chunk` `tokenCount` examples
- Clarify that counts are based on word tokens

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ddc1ed940833085346d2297e75fac