### PR TITLE
Rename setdiff helper and update diff versions

### DIFF
--- a/+controller/DataAcquisitionController.m
+++ b/+controller/DataAcquisitionController.m
@@ -1,0 +1,19 @@
+classdef DataAcquisitionController
+%DATAACQUISITIONCONTROLLER Fetch corpora and compute differences
+    methods
+        function diffStruct = diffVersions(~, oldCorpusVec, newCorpusVec)
+        %DIFFVERSIONS Compute added and removed documents between corpora
+        %   diffStruct = DIFFVERSIONS(oldCorpusVec, newCorpusVec) returns a
+        %   struct with fields addedDocs and removedDocs.
+
+            arguments
+                oldCorpusVec (1,:) struct
+                newCorpusVec (1,:) struct
+            end
+
+            diffStruct = struct();
+            diffStruct.addedDocs = helpers.docSetdiff(newCorpusVec, oldCorpusVec);
+            diffStruct.removedDocs = helpers.docSetdiff(oldCorpusVec, newCorpusVec);
+        end
+    end
+end

--- a/+helpers/docSetdiff.m
+++ b/+helpers/docSetdiff.m
@@ -1,0 +1,13 @@
+function diffDocsVec = docSetdiff(corpusAVec, corpusBVec)
+%DOCSETDIFF Return documents in corpusAVec missing from corpusBVec by docId
+%   diffDocsVec = DOCSETDIFF(corpusAVec, corpusBVec) returns the elements of
+%   corpusAVec whose docId field does not appear in corpusBVec.
+
+    arguments
+        corpusAVec (1,:) struct
+        corpusBVec (1,:) struct
+    end
+
+    [~, idxVec] = builtin('setdiff', {corpusAVec.docId}, {corpusBVec.docId});
+    diffDocsVec = corpusAVec(idxVec);
+end

--- a/docs/ClassArchitecture.md
+++ b/docs/ClassArchitecture.md
@@ -43,7 +43,7 @@
 | Function Path                  | Purpose                                                              |
 | ------------------------------ | -------------------------------------------------------------------- |
 | `+helpers/loadCorpus.m`        | Load `model.Document` vectors for a corpus version identifier        |
-| `+helpers/setdiff.m`          | Return documents in first corpus missing from the second by `docId` |
+| `+helpers/docSetdiff.m`       | Return documents in first corpus missing from the second by `docId` |
 | `+helpers/detectChanges.m`     | Detect documents with identical `docId` but modified `text` content  |
 
 ## Class Definitions
@@ -794,16 +794,16 @@ function documentVec = loadCorpus(versionId)
     end
 end
 
-% +helpers/setdiff.m
-function diffDocsVec = setdiff(corpusAVec, corpusBVec)
-    %SETDIFF Documents in corpusAVec but not corpusBVec by `docId`.
-    %   diffDocsVec = setdiff(corpusAVec, corpusBVec)
+% +helpers/docSetdiff.m
+function diffDocsVec = docSetdiff(corpusAVec, corpusBVec)
+    %DOCSETDIFF Documents in corpusAVec but not corpusBVec by `docId`.
+    %   diffDocsVec = docSetdiff(corpusAVec, corpusBVec)
     %   corpusAVec (model.Document Vec): Candidate corpus.
     %   corpusBVec (model.Document Vec): Corpus to subtract.
     %   diffDocsVec (model.Document Vec): Unique documents.
     %
     %   Side effects: none.
-    [~, idxVec] = setdiff({corpusAVec.docId}, {corpusBVec.docId});
+    [~, idxVec] = builtin('setdiff', {corpusAVec.docId}, {corpusBVec.docId});
     diffDocsVec = corpusAVec(idxVec);
 end
 
@@ -858,8 +858,8 @@ classdef DataAcquisitionController
             %   Side effects: accesses external resources.
             oldCorpus = helpers.loadCorpus(oldVersionId);
             newCorpus = helpers.loadCorpus(newVersionId);
-            diffStruct.addedDocs = helpers.setdiff(newCorpus, oldCorpus);
-            diffStruct.removedDocs = helpers.setdiff(oldCorpus, newCorpus);
+            diffStruct.addedDocs = helpers.docSetdiff(newCorpus, oldCorpus);
+            diffStruct.removedDocs = helpers.docSetdiff(oldCorpus, newCorpus);
             diffStruct.changedDocs = helpers.detectChanges(oldCorpus, newCorpus);
         end
     end

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -181,6 +181,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 | startup | project object | none | adds repo paths, sets defaults |
 | shutdown | project object | none | removes repo paths, restores defaults |
 | run_mlint | none | none | writes lint artifacts to `lint/` and may error on issues |
+| docSetdiff | corpusAVec, corpusBVec | diffDocsVec | uses builtin `setdiff` to compare corpora |
 
 
 

--- a/tests/testDataAcquisitionController.m
+++ b/tests/testDataAcquisitionController.m
@@ -1,0 +1,13 @@
+function tests = testDataAcquisitionController
+%TESTDATAACQUISITIONCONTROLLER Tests for DataAcquisitionController
+    tests = functiontests(localfunctions);
+end
+
+function testDiffVersionsComputesAddedAndRemoved(testCase)
+    controllerObj = controller.DataAcquisitionController();
+    oldCorpusVec = struct('docId', {'A', 'B'});
+    newCorpusVec = struct('docId', {'B', 'C'});
+    diffStruct = controllerObj.diffVersions(oldCorpusVec, newCorpusVec);
+    verifyEqual(testCase, {diffStruct.addedDocs.docId}, {'C'});
+    verifyEqual(testCase, {diffStruct.removedDocs.docId}, {'A'});
+end

--- a/tests/testDocSetdiff.m
+++ b/tests/testDocSetdiff.m
@@ -1,0 +1,11 @@
+function tests = testDocSetdiff
+%TESTDOCSETDIFF Unit tests for helpers.docSetdiff
+    tests = functiontests(localfunctions);
+end
+
+function testReturnsDocumentsMissingFromSecondCorpus(testCase)
+    corpusAVec = struct('docId', {'A', 'B', 'C'});
+    corpusBVec = struct('docId', {'B'});
+    diffDocsVec = helpers.docSetdiff(corpusAVec, corpusBVec);
+    verifyEqual(testCase, {diffDocsVec.docId}, {'A', 'C'});
+end


### PR DESCRIPTION
## Summary
- rename custom setdiff helper to docSetdiff and delegate to builtin('setdiff')
- use helpers.docSetdiff in DataAcquisitionController.diffVersions
- document docSetdiff in architecture and identifier registry

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689dff563230833093968013573e07c3