### PR TITLE
docs: record testing policy

### DIFF
--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -210,6 +210,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 |------|---------|-----------|-------|------|
 | startup.m | Initialize project paths and defaults | startup | @todo | |
 | shutdown.m | Remove project paths and restore defaults | shutdown | @todo | |
+| docs/TESTING_POLICY.md | Central testing rules and golden-data procedures. | n/a | @todo | |
 
 
 
@@ -227,7 +228,7 @@ Record each test with a scope identifying its coverage type:
 
 If a test spans multiple coverage types, list all applicable tags separated by commas in the Scope column.
 
-Regression entries must include the simulated dataset path, expected output, and dataset owner used as the baseline. Future regression tests without these fields will not be accepted.
+Regression entries must include the golden dataset path, expected output, and dataset owner, as specified in [docs/TESTING_POLICY.md](TESTING_POLICY.md). Future regression tests without these fields will not be accepted.
 
 | Name | Purpose | Scope | Owner | Related Functions | Golden Dataset Path | Expected Output | Dataset Owner | Notes |
 |------|---------|-------|-------|-------------------|---------------------|-----------------|---------------|-------|


### PR DESCRIPTION
## Summary
- Register docs/TESTING_POLICY.md in Files/Modules table
- Note in Tests section that regression rows must include golden data path, expected output, and dataset owner per testing policy

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e2439eeb48330b948d1db5dbbfa97