### PR TITLE
Document CI test commands and dataset policy

### DIFF
--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -92,10 +92,11 @@ Fixtures include:
    run regEvalAndReport
    ```
 6. **Run Tests**
-   ```matlab
-   results = runtests("tests","IncludeSubfolders",true);
-   table(results)
+   ```bash
+   matlab -batch "run_smoke_test"
+   matlab -batch "runtests('tests','IncludeSubfolders',true)"
    ```
+   CI must provision golden datasets via fixtures, and failures against them halt the pipeline. See [TESTING_POLICY](TESTING_POLICY.md) for dataset refresh procedures.
 
 ## 4. What We’ve Been Optimising
 - **GPU batch sizes & sequence lengths** for the 16 GB 4060 Ti
@@ -109,9 +110,9 @@ Fixtures include:
 - **Full MATLAB project folder** (zip)
 - **Any recent console errors**
 - **Any failed test outputs** from:
-  ```matlab
-  results = runtests("tests","IncludeSubfolders",true);
-  table(results)
+  ```bash
+  matlab -batch "run_smoke_test"
+  matlab -batch "runtests('tests','IncludeSubfolders',true)"
   ```
 
 ## 6. How a New ChatGPT Session Can Help

--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -1,0 +1,11 @@
+# Testing Policy
+
+Continuous integration relies on golden datasets supplied via fixtures. These datasets serve as regression baselines.
+
+## Dataset Refresh Procedures
+1. Generate updated golden datasets.
+2. Update repository fixtures to reference the new data.
+3. Run `matlab -batch "runtests('tests','IncludeSubfolders',true)"` to validate.
+4. Commit the refreshed datasets and fixtures.
+
+Failures against golden datasets halt the CI pipeline until resolved.

--- a/docs/step13_continuous_testing.md
+++ b/docs/step13_continuous_testing.md
@@ -9,13 +9,14 @@ Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeleto
 
 Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
 
-1. In MATLAB, run the full test suite regularly:
-   ```matlab
-   resultsTbl = runtests('tests', 'IncludeSubfolders', true, 'UseParallel', false);
-   table(resultsTbl)
+1. From MATLAB's project root, run tests via batch mode:
+   ```bash
+   matlab -batch "run_smoke_test"                                  # smoke suite
+   matlab -batch "runtests('tests','IncludeSubfolders',true)"       # full regression
    ```
 2. Investigate any failures before committing changes.
-3. Optional: configure continuous integration (e.g., GitHub Actions) to run the same command on each push.
+3. CI must provision golden datasets via fixtures, and failures against them halt the pipeline. See [TESTING_POLICY](TESTING_POLICY.md) for dataset refresh procedures.
+4. Optional: configure continuous integration (e.g., GitHub Actions) to run the same commands on each push.
 
 ## Function Interface
 ### runtests
@@ -26,8 +27,8 @@ Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new 
   - **Returns:** table `resultsTbl` with fields `Name`, `Passed`, `Failed`, `Incomplete`, and `Duration`.
 - **Side Effects:** executes all MATLAB tests in the project.
 - **Usage Example:**
-  ```matlab
-  resultsTbl = runtests('tests', 'IncludeSubfolders', true, 'UseParallel', false);
+  ```bash
+  matlab -batch "runtests('tests','IncludeSubfolders',true)"
   ```
 
 See [Identifier Registry – Data Contracts](identifier_registry.md#data-contracts) for any test-related artifacts.


### PR DESCRIPTION
## Summary
- Document MATLAB smoke and full regression test commands in project context and continuous testing guide
- Add guidance that CI provisions golden datasets via fixtures and failures halt the pipeline
- Introduce `docs/TESTING_POLICY.md` outlining dataset refresh procedures

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `matlab -batch "runtests('tests','IncludeSubfolders',true)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e2431d9488330a2f5f68824fe775b