### PR TITLE
docs: clarify testing guidance

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -55,10 +55,12 @@ See [Matlab Style Guide §1.6](Matlab_Style_Guide.md#16-data-contracts-and-flows
 
 ## Tests
 
+All tests must follow [`docs/TESTING_POLICY.md`](TESTING_POLICY.md) for fixture usage and golden-data handling.
+
 Place tests in the `tests/` folder and name each file `testName.m`. Test files should mirror the source structure, and each `testName.m` defines a corresponding `classdef testName` in lowerCamelCase with a `test` prefix. Each class and public method must have:
 
 - At least one unit test verifying its core behavior.
-- Every test file subclasses `matlab.unittest.TestCase` and defines `methods (TestClassSetup)` / `methods (TestClassTeardown)` or uses `addTeardown` ([Testing](Matlab_Style_Guide.md#3-testing)).
+- Every test file subclasses `matlab.unittest.TestCase` and uses MATLAB Test Toolbox features such as fixtures (`methods (TestClassSetup)`/`addTeardown` or `applyFixture`) and parameterized tests (`TestParameter`).
 - Each test method is named in lowerCamelCase starting with a verb and declares `TestTags` such as `Unit`, `Smoke`, `Integration`, or `Regression` ([Testing](Matlab_Style_Guide.md#3-testing)).
 - Maintain separate `Smoke` and `Regression` suites; use `matlab -batch "run_smoke_test"` to run the `Smoke` suite quickly.
 - Integration tests are optional and added when cross-module behavior warrants them.


### PR DESCRIPTION
## Summary
- note that tests must follow docs/TESTING_POLICY.md for fixtures and golden data
- mention MATLAB Test Toolbox features like fixtures, parameterized tests, and TestTags in testing guidance

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e242deb80833082b0336ed98eda56