### PR TITLE
Clarify TDD workflow for golden data

### DIFF
--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -48,9 +48,10 @@ Runtime data produced or consumed by the pipeline is organized under `src/data/`
 
 1. **Write a test**
    - Create a skeleton in `tests/` named `testMyFeature.m`.
-   - Ensure appropriate setup, teardown, fixtures and golden data is generted to satisfy the test.
+   - Define setup and teardown fixtures, using generator classes to produce golden data.
+   - Record golden dataset paths in `docs/identifier_registry.md`.
    - Include `%% NAME-REGISTRY:TEST testMyFeature` and call the target stub.
-   - Force the pass with using the appropriate command from the matlab test suite to force a not implemented result.
+   - Force the pass using the appropriate command from the MATLAB test suite to force a not implemented result.
 
 2. **Add a stub module**
    - Under `src/reg/`, create `myFeature.m` with the function signature, a `%% NAME-REGISTRY:FUNCTION myFeature` breadcrumb, and a `TODO` placeholder.
@@ -59,4 +60,4 @@ Runtime data produced or consumed by the pipeline is organized under `src/data/`
    - Add entries for the new function, file, and test in `docs/identifier_registry.md`.
 
 
-Following this scaffold keeps modules, tests, and the identifier registry synchronized.
+Following this scaffold keeps modules, tests, and the identifier registry synchronized. See [docs/TESTING_POLICY.md](TESTING_POLICY.md) for full methodology.


### PR DESCRIPTION
## Summary
- clarify that test skeletons must define fixtures and use generator classes for golden data
- note that golden dataset paths belong in docs/identifier_registry.md
- link to docs/TESTING_POLICY.md for full testing methodology

## Testing
- `matlab -batch "run_smoke_test"` *(command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689e242c3c9c8330898fd655cf35ad10