### PR TITLE
Add testing policy and cross references

### DIFF
--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -1,0 +1,59 @@
+# Testing Policy
+
+This document defines the project's expectations for automated tests and the supporting
+infrastructure. It complements the master scaffold and naming guides.
+
+## Scope and Test Types
+
+The MATLAB Test framework is the canonical runner.  Test files live under `tests/` and use
+function‑based or class‑based suites following the `testName.m` convention.  Supported
+test categories are:
+
+- **unit** – verify individual functions or class methods.
+- **integration** – exercise interactions across modules.
+- **smoke** – lightweight environment checks used for quick validation.
+- **regression** – compare outputs against golden datasets to guard against
+  unintended changes.
+
+Include tags for the relevant categories in the identifier registry.  Structure tests
+using standard `matlab.unittest` utilities and keep helper functions scoped locally.
+
+## Golden Data
+
+Classes that generate golden datasets must reside in `tests/` and carry the
+`%% NAME-REGISTRY:CLASS` breadcrumb.  Generated artifacts are stored under
+`tests/data/` and tracked with a unique folder per dataset.  Each dataset must be
+referenced in `docs/identifier_registry.md` via the tests table, including the
+path to the stored golden data and its owner.
+
+## Workflow
+
+1. **Write the test first.** Create the skeleton in `tests/` and register it in the
+   identifier registry.
+2. **Implement or update code.** Keep temporary variables close to use and suffix
+   data types per the style guide.
+3. **Run smoke and regression suites.**
+   ```bash
+   matlab -batch "run_smoke_test"
+   matlab -batch "runtests('tests', 'IncludeSubfolders', true)"
+   ```
+4. **Commit changes** only after all tests pass.
+
+## Continuous Integration
+
+CI runs the smoke suite on every push and the full regression suite on pull
+requests.  Failures block merges.  Developers must ensure their branch passes
+locally before pushing.
+
+## Directory Layout
+
+- `tests/` – all test suites.
+- `tests/data/` – golden datasets and fixtures.
+- `docs/identifier_registry.md` – registration of tests and datasets.
+- `docs/TESTING_POLICY.md` – this policy.
+
+## Governance
+
+The policy is owned by the repository maintainers.  Amendments require a pull
+request reviewed by at least one maintainer.  Deviations from this policy must
+be documented in the commit history with rationale.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -210,6 +210,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 |------|---------|-----------|-------|------|
 | startup.m | Initialize project paths and defaults | startup | @todo | |
 | shutdown.m | Remove project paths and restore defaults | shutdown | @todo | |
+| TESTING_POLICY.md | Repository testing policy and workflows | n/a | @todo | documentation |
 
 
 

--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -2,7 +2,8 @@
 
 > Before implementing new modules or tests, review the canonical docs:
 > [Matlab_Style_Guide](Matlab_Style_Guide.md), [README_NAMING](README_NAMING.md),
-> [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md), and [identifier_registry](identifier_registry.md).
+> [TESTING_POLICY](TESTING_POLICY.md), [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md),
+> and [identifier_registry](identifier_registry.md).
 
 This document summarizes the MATLAB package located at `src/reg/`, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
 

--- a/docs/step13_continuous_testing.md
+++ b/docs/step13_continuous_testing.md
@@ -2,12 +2,16 @@
 
 **Goal:** Ensure all modules stay reliable through automated testing.
 
+Refer to [TESTING_POLICY](TESTING_POLICY.md) for repository-wide expectations and
+conventions.
+
 **Depends on:** Completion of prior steps.
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+Consult `README_NAMING.md`, `TESTING_POLICY.md`, and update `docs/identifier_registry.md`
+for any new identifiers introduced in this step.
 
 1. In MATLAB, run the full test suite regularly:
    ```matlab


### PR DESCRIPTION
## Summary
- document project-wide test scopes, workflows, and CI expectations in `docs/TESTING_POLICY.md`
- link testing policy from scaffold and continuous testing guides
- register policy in identifier registry

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `matlab -batch "runtests('tests', 'IncludeSubfolders', true)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e2426c7148330bb074f8646f7c855