### PR TITLE
docs: link testing policy

### DIFF
--- a/docs/Matlab_Style_Guide.md
+++ b/docs/Matlab_Style_Guide.md
@@ -212,6 +212,8 @@ end
 - Maintain reproducibility with `rng(seed)`.
 - Any temporary or placeholder test must call `fatalAssertFail` (or similar) so it fails as incomplete.
 
+Refer to [TESTING_POLICY.md](TESTING_POLICY.md) for workflow and golden-data governance.
+
 #### 3.1 Test Method Naming
 
 - Name test methods in **lowerCamelCase**.


### PR DESCRIPTION
## Summary
- reference TESTING_POLICY.md for workflow and golden-data governance in MATLAB style guide testing section

## Testing
- `matlab -batch "run_smoke_test"` (command not found)
- `pre-commit run --files docs/Matlab_Style_Guide.md` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_689e24350b08833080925389c3c7f7f4