### PR TITLE
Refine testing policy and reference from naming guide

### DIFF
--- a/docs/README_NAMING.md
+++ b/docs/README_NAMING.md
@@ -6,6 +6,9 @@ This README is a process guide for maintaining naming consistency. The
 all naming rules. All approved classes, class properties, class methods, functions, variables, constants, files/modules, tests, and other identifiers are tracked in the
 `identifier_registry.md`.
 
+For guidance on writing and organizing tests, consult the
+[TESTING_POLICY](TESTING_POLICY.md).
+
 - Pseudocode identifiers used only for algorithm illustration must not be added to [`docs/identifier_registry.md`](identifier_registry.md); keep them within documentation such as `docs/pseudocode/`.
 - New or modified class properties and class methods must be recorded in [`docs/identifier_registry.md`](identifier_registry.md) alongside the corresponding class names.
 - New or modified class interfaces must be added to [`docs/identifier_registry.md`](identifier_registry.md) as well.

--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -1,0 +1,61 @@
+# Testing Policy
+
+This policy sets the expectations for how tests are written, organized, and executed.
+It supplements the [master scaffold](master_scaffold.md) and naming guides and is
+mandatory for all contributors.
+
+## Scope and Test Types
+
+The project uses the MATLAB Test framework (`matlab.unittest`). All test files live
+under `tests/` and follow the `testName.m` convention using either
+function-based tests or `matlab.unittest.TestCase` classes. Supported test
+categories and their conventions are:
+
+- **unit** – verify individual functions or methods with minimal dependencies.
+- **integration** – exercise interactions across multiple modules or layers.
+- **smoke** – lightweight environment checks for rapid feedback.
+- **regression** – compare outputs against golden data to detect behavioral drift.
+
+Tag test suites with these categories in `docs/identifier_registry.md`. Use
+`matlab.unittest` assertions, fixtures, and `TestMethodSetup`/`TestClassSetup`
+constructs to keep tests isolated and deterministic.
+
+## Golden Data
+
+Classes or scripts that generate golden datasets must reside in `tests/` and
+include a `%% NAME-REGISTRY:CLASS` breadcrumb. Generated artifacts are stored
+under `tests/data/<dataset>/` and grouped by dataset name. Every dataset must be
+registered in `docs/identifier_registry.md` with its path and maintainer.
+
+## Workflow
+
+1. **Write the test first.** Create the skeleton in `tests/`, include
+   `%% NAME-REGISTRY:TEST`, and record the new identifier in
+   `docs/identifier_registry.md`.
+2. **Implement or update code.** Follow the style guide and keep temporary
+   variables near their use.
+3. **Generate or refresh golden data** when behavior changes.
+4. **Run the suites locally:**
+   ```bash
+   matlab -batch "run_smoke_test"
+   matlab -batch "runtests('tests', 'IncludeSubfolders', true)"
+   ```
+5. **Commit changes only after all tests pass.**
+
+## Continuous Integration
+
+CI executes the smoke suite on every push and the full regression suite on pull
+requests. Failing jobs block merges; ensure local success before pushing.
+
+## Directory Layout
+
+- `tests/` – all test suites.
+- `tests/data/` – golden datasets and fixtures.
+- `docs/identifier_registry.md` – registration of tests and datasets.
+- `docs/TESTING_POLICY.md` – this policy.
+
+## Governance
+
+The policy is owned by the repository maintainers. Updates require a pull
+request reviewed by at least one maintainer. Deviations must be justified in the
+commit history.

--- a/docs/identifier_registry.md
+++ b/docs/identifier_registry.md
@@ -210,6 +210,7 @@ Keep the illustrative examples below in sync with the current naming conventions
 |------|---------|-----------|-------|------|
 | startup.m | Initialize project paths and defaults | startup | @todo | |
 | shutdown.m | Remove project paths and restore defaults | shutdown | @todo | |
+| TESTING_POLICY.md | Policy on test scopes, golden data, and CI expectations | n/a | @todo | documentation |
 
 
 

--- a/docs/master_scaffold.md
+++ b/docs/master_scaffold.md
@@ -2,7 +2,8 @@
 
 > Before implementing new modules or tests, review the canonical docs:
 > [Matlab_Style_Guide](Matlab_Style_Guide.md), [README_NAMING](README_NAMING.md),
-> [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md), and [identifier_registry](identifier_registry.md).
+> [TESTING_POLICY](TESTING_POLICY.md), [SYSTEM_BUILD_PLAN](SYSTEM_BUILD_PLAN.md),
+> and [identifier_registry](identifier_registry.md).
 
 This document summarizes the MATLAB package located at `src/reg/`, the stub modules required for each step of the pipeline, and the matching test skeletons. Use it as the starting point for test-driven development.
 

--- a/docs/step13_continuous_testing.md
+++ b/docs/step13_continuous_testing.md
@@ -2,12 +2,16 @@
 
 **Goal:** Ensure all modules stay reliable through automated testing.
 
+Refer to [TESTING_POLICY](TESTING_POLICY.md) for repository-wide expectations and
+conventions.
+
 **Depends on:** Completion of prior steps.
 
 ## Instructions
 Refer to [Master Scaffold](master_scaffold.md) for stub modules and test skeletons before beginning this step.
 
-Consult `README_NAMING.md` and update `docs/identifier_registry.md` for any new identifiers introduced in this step.
+Consult `README_NAMING.md`, `TESTING_POLICY.md`, and update `docs/identifier_registry.md`
+for any new identifiers introduced in this step.
 
 1. In MATLAB, run the full test suite regularly:
    ```matlab


### PR DESCRIPTION
## Summary
- expand testing policy with MATLAB Test conventions, golden data workflow, and CI expectations
- link testing policy from naming guide and update registry entry

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `matlab -batch "runtests('tests', 'IncludeSubfolders', true)"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e2426c7148330bb074f8646f7c855