### PR TITLE
feat: add mvc stub architecture

### DIFF
--- a/+reg/+controller/EvalController.m
+++ b/+reg/+controller/EvalController.m
@@ -1,0 +1,28 @@
+classdef EvalController < reg.mvc.BaseController
+    %EVALCONTROLLER Orchestrates evaluation and reporting workflow.
+    
+    properties
+        EvaluationModel
+        LoggingModel
+        ReportModel
+    end
+    
+    methods
+        function obj = EvalController(evalModel, logModel, reportModel, view)
+            obj@reg.mvc.BaseController(evalModel, view);
+            obj.EvaluationModel = evalModel;
+            obj.LoggingModel = logModel;
+            obj.ReportModel = reportModel;
+        end
+        
+        function run(obj)
+            evalRaw = obj.EvaluationModel.load(); %#ok<NASGU>
+            metrics = obj.EvaluationModel.process([]); %#ok<NASGU>
+            logRaw = obj.LoggingModel.load(); %#ok<NASGU>
+            obj.LoggingModel.process([]);
+            repRaw = obj.ReportModel.load(); %#ok<NASGU>
+            reportData = obj.ReportModel.process([]); %#ok<NASGU>
+            obj.View.display(reportData);
+        end
+    end
+end

--- a/+reg/+controller/FineTuneController.m
+++ b/+reg/+controller/FineTuneController.m
@@ -1,0 +1,40 @@
+classdef FineTuneController < reg.mvc.BaseController
+    %FINETUNECONTROLLER Orchestrates encoder fine-tuning workflow.
+    
+    properties
+        PDFIngestModel
+        TextChunkModel
+        WeakLabelModel
+        FineTuneDataModel
+        EncoderFineTuneModel
+        EvaluationModel
+    end
+    
+    methods
+        function obj = FineTuneController(pdfModel, chunkModel, weakModel, dataModel, encoderModel, evalModel, view)
+            obj@reg.mvc.BaseController(pdfModel, view);
+            obj.PDFIngestModel = pdfModel;
+            obj.TextChunkModel = chunkModel;
+            obj.WeakLabelModel = weakModel;
+            obj.FineTuneDataModel = dataModel;
+            obj.EncoderFineTuneModel = encoderModel;
+            obj.EvaluationModel = evalModel;
+        end
+        
+        function run(obj)
+            files = obj.PDFIngestModel.load(); %#ok<NASGU>
+            docsT = obj.PDFIngestModel.process([]); %#ok<NASGU>
+            chunksRaw = obj.TextChunkModel.load(); %#ok<NASGU>
+            chunksT = obj.TextChunkModel.process([]); %#ok<NASGU>
+            weakRaw = obj.WeakLabelModel.load(); %#ok<NASGU>
+            [Yweak, Yboot] = obj.WeakLabelModel.process([]); %#ok<NASGU>
+            tripletRaw = obj.FineTuneDataModel.load(); %#ok<NASGU>
+            triplets = obj.FineTuneDataModel.process([]); %#ok<NASGU>
+            netRaw = obj.EncoderFineTuneModel.load(); %#ok<NASGU>
+            net = obj.EncoderFineTuneModel.process([]); %#ok<NASGU>
+            evalRaw = obj.EvaluationModel.load(); %#ok<NASGU>
+            metrics = obj.EvaluationModel.process([]); %#ok<NASGU>
+            obj.View.display(metrics);
+        end
+    end
+end

--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -1,0 +1,55 @@
+classdef PipelineController < reg.mvc.BaseController
+    %PIPELINECONTROLLER Orchestrates end-to-end pipeline flow.
+    
+    properties
+        ConfigModel
+        PDFIngestModel
+        TextChunkModel
+        FeatureModel
+        ProjectionHeadModel
+        WeakLabelModel
+        ClassifierModel
+        SearchIndexModel
+        DatabaseModel
+        ReportModel
+    end
+    
+    methods
+        function obj = PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, clsModel, searchModel, dbModel, reportModel, view)
+            obj@reg.mvc.BaseController(cfgModel, view);
+            obj.ConfigModel = cfgModel;
+            obj.PDFIngestModel = pdfModel;
+            obj.TextChunkModel = chunkModel;
+            obj.FeatureModel = featModel;
+            obj.ProjectionHeadModel = projModel;
+            obj.WeakLabelModel = weakModel;
+            obj.ClassifierModel = clsModel;
+            obj.SearchIndexModel = searchModel;
+            obj.DatabaseModel = dbModel;
+            obj.ReportModel = reportModel;
+        end
+        
+        function run(obj)
+            cfgRaw = obj.ConfigModel.load(); %#ok<NASGU>
+            cfg = obj.ConfigModel.process([]); %#ok<NASGU>
+            files = obj.PDFIngestModel.load(); %#ok<NASGU>
+            docsT = obj.PDFIngestModel.process([]); %#ok<NASGU>
+            chunksRaw = obj.TextChunkModel.load(); %#ok<NASGU>
+            chunksT = obj.TextChunkModel.process([]); %#ok<NASGU>
+            featuresRaw = obj.FeatureModel.load(); %#ok<NASGU>
+            [features, embeddings, vocab] = obj.FeatureModel.process([]); %#ok<NASGU>
+            projE = obj.ProjectionHeadModel.process([]); %#ok<NASGU>
+            weakRaw = obj.WeakLabelModel.load(); %#ok<NASGU>
+            [Yweak, Yboot] = obj.WeakLabelModel.process([]); %#ok<NASGU>
+            clsRaw = obj.ClassifierModel.load(); %#ok<NASGU>
+            [models, scores, thresholds, pred] = obj.ClassifierModel.process([]); %#ok<NASGU>
+            searchRaw = obj.SearchIndexModel.load(); %#ok<NASGU>
+            searchIx = obj.SearchIndexModel.process([]); %#ok<NASGU>
+            dbRaw = obj.DatabaseModel.load(); %#ok<NASGU>
+            obj.DatabaseModel.process([]);
+            reportRaw = obj.ReportModel.load(); %#ok<NASGU>
+            reportData = obj.ReportModel.process([]); %#ok<NASGU>
+            obj.View.display(reportData);
+        end
+    end
+end

--- a/+reg/+controller/ProjectionHeadController.m
+++ b/+reg/+controller/ProjectionHeadController.m
@@ -1,0 +1,32 @@
+classdef ProjectionHeadController < reg.mvc.BaseController
+    %PROJECTIONHEADCONTROLLER Orchestrates projection head training workflow.
+    
+    properties
+        FeatureModel
+        FineTuneDataModel
+        ProjectionHeadModel
+        EvaluationModel
+    end
+    
+    methods
+        function obj = ProjectionHeadController(featureModel, dataModel, headModel, evalModel, view)
+            obj@reg.mvc.BaseController(featureModel, view);
+            obj.FeatureModel = featureModel;
+            obj.FineTuneDataModel = dataModel;
+            obj.ProjectionHeadModel = headModel;
+            obj.EvaluationModel = evalModel;
+        end
+        
+        function run(obj)
+            chunks = obj.FeatureModel.load(); %#ok<NASGU>
+            [features, embeddings, vocab] = obj.FeatureModel.process([]); %#ok<NASGU>
+            tripletsRaw = obj.FineTuneDataModel.load(); %#ok<NASGU>
+            triplets = obj.FineTuneDataModel.process([]); %#ok<NASGU>
+            headRaw = obj.ProjectionHeadModel.load(); %#ok<NASGU>
+            projE = obj.ProjectionHeadModel.process([]); %#ok<NASGU>
+            evalRaw = obj.EvaluationModel.load(); %#ok<NASGU>
+            metrics = obj.EvaluationModel.process([]); %#ok<NASGU>
+            obj.View.display(metrics);
+        end
+    end
+end

--- a/+reg/+model/ClassifierModel.m
+++ b/+reg/+model/ClassifierModel.m
@@ -1,0 +1,14 @@
+classdef ClassifierModel < reg.mvc.BaseModel
+    %CLASSIFIERMODEL Stub model training classifiers and predicting labels.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ClassifierModel.load is not implemented.");
+        end
+        function [models, scores, thresholds, pred] = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ClassifierModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/ConfigModel.m
+++ b/+reg/+model/ConfigModel.m
@@ -1,0 +1,14 @@
+classdef ConfigModel < reg.mvc.BaseModel
+    %CONFIGMODEL Stub model retrieving configuration parameters.
+    
+    methods
+        function data = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.load is not implemented.");
+        end
+        function result = process(~, data) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -1,0 +1,14 @@
+classdef DatabaseModel < reg.mvc.BaseModel
+    %DATABASEMODEL Stub model persisting predictions to a database.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "DatabaseModel.load is not implemented.");
+        end
+        function process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "DatabaseModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/EncoderFineTuneModel.m
+++ b/+reg/+model/EncoderFineTuneModel.m
@@ -1,0 +1,14 @@
+classdef EncoderFineTuneModel < reg.mvc.BaseModel
+    %ENCODERFINETUNEMODEL Stub model for encoder fine-tuning.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "EncoderFineTuneModel.load is not implemented.");
+        end
+        function net = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "EncoderFineTuneModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -1,0 +1,14 @@
+classdef EvaluationModel < reg.mvc.BaseModel
+    %EVALUATIONMODEL Stub model computing evaluation metrics.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.load is not implemented.");
+        end
+        function metrics = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -1,0 +1,14 @@
+classdef FeatureModel < reg.mvc.BaseModel
+    %FEATUREMODEL Stub model generating feature representations.
+    
+    methods
+        function chunksT = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "FeatureModel.load is not implemented.");
+        end
+        function [features, embeddings, vocab] = process(~, chunksT) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "FeatureModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/FineTuneDataModel.m
+++ b/+reg/+model/FineTuneDataModel.m
@@ -1,0 +1,14 @@
+classdef FineTuneDataModel < reg.mvc.BaseModel
+    %FINETUNEDATAMODEL Stub model building contrastive triplets.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "FineTuneDataModel.load is not implemented.");
+        end
+        function triplets = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "FineTuneDataModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/GoldPackModel.m
+++ b/+reg/+model/GoldPackModel.m
@@ -1,0 +1,14 @@
+classdef GoldPackModel < reg.mvc.BaseModel
+    %GOLDPACKMODEL Stub model providing labelled gold data.
+    
+    methods
+        function data = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "GoldPackModel.load is not implemented.");
+        end
+        function result = process(~, data) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "GoldPackModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/LoggingModel.m
+++ b/+reg/+model/LoggingModel.m
@@ -1,0 +1,14 @@
+classdef LoggingModel < reg.mvc.BaseModel
+    %LOGGINGMODEL Stub model for persisting metrics.
+    
+    methods
+        function metrics = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "LoggingModel.load is not implemented.");
+        end
+        function process(~, metrics) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "LoggingModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -1,0 +1,14 @@
+classdef PDFIngestModel < reg.mvc.BaseModel
+    %PDFINGESTMODEL Stub model converting PDFs to document table.
+    
+    methods
+        function files = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "PDFIngestModel.load is not implemented.");
+        end
+        function docsT = process(~, files) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "PDFIngestModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/ProjectionHeadModel.m
+++ b/+reg/+model/ProjectionHeadModel.m
@@ -1,0 +1,14 @@
+classdef ProjectionHeadModel < reg.mvc.BaseModel
+    %PROJECTIONHEADMODEL Stub model applying projection head to embeddings.
+    
+    methods
+        function E = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ProjectionHeadModel.load is not implemented.");
+        end
+        function Eproj = process(~, E) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ProjectionHeadModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/ReportModel.m
+++ b/+reg/+model/ReportModel.m
@@ -1,0 +1,14 @@
+classdef ReportModel < reg.mvc.BaseModel
+    %REPORTMODEL Stub model assembling report data.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ReportModel.load is not implemented.");
+        end
+        function reportData = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "ReportModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -1,0 +1,14 @@
+classdef SearchIndexModel < reg.mvc.BaseModel
+    %SEARCHINDEXMODEL Stub model building retrieval index.
+    
+    methods
+        function inputs = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "SearchIndexModel.load is not implemented.");
+        end
+        function searchIx = process(~, inputs) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "SearchIndexModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/TextChunkModel.m
+++ b/+reg/+model/TextChunkModel.m
@@ -1,0 +1,14 @@
+classdef TextChunkModel < reg.mvc.BaseModel
+    %TEXTCHUNKMODEL Stub model splitting documents into chunks.
+    
+    methods
+        function docsT = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "TextChunkModel.load is not implemented.");
+        end
+        function chunksT = process(~, docsT) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "TextChunkModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/WeakLabelModel.m
+++ b/+reg/+model/WeakLabelModel.m
@@ -1,0 +1,14 @@
+classdef WeakLabelModel < reg.mvc.BaseModel
+    %WEAKLABELMODEL Stub model generating weak supervision labels.
+    
+    methods
+        function chunksT = load(~, varargin) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "WeakLabelModel.load is not implemented.");
+        end
+        function [Yweak, Yboot] = process(~, chunksT) %#ok<INUSD>
+            error("reg:model:NotImplemented", ...
+                "WeakLabelModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -1,0 +1,23 @@
+classdef Application < handle
+    %APPLICATION Entry point wiring together Model, View, and Controller.
+    %   Initializes components and triggers execution.
+
+    properties
+        Model
+        View
+        Controller
+    end
+
+    methods
+        function obj = Application(model, view, controller)
+            obj.Model = model;
+            obj.View = view;
+            obj.Controller = controller;
+        end
+
+        function start(obj)
+            %START Kick off the main application flow.
+            obj.Controller.run();
+        end
+    end
+end

--- a/+reg/+mvc/BaseController.m
+++ b/+reg/+mvc/BaseController.m
@@ -1,0 +1,25 @@
+classdef (Abstract) BaseController < handle
+    %BASECONTROLLER Coordinates interaction between Model and View.
+    %   Data flow:
+    %       1. Retrieve data using the Model.
+    %       2. Process data through the Model.
+    %       3. Forward processed data to the View.
+
+    properties (SetAccess = protected)
+        Model
+        View
+    end
+
+    methods
+        function obj = BaseController(model, view)
+            obj.Model = model;
+            obj.View = view;
+        end
+    end
+
+    methods (Abstract)
+        function run(obj)
+            %RUN Execute application flow using Model and View.
+        end
+    end
+end

--- a/+reg/+mvc/BaseModel.m
+++ b/+reg/+mvc/BaseModel.m
@@ -1,0 +1,14 @@
+classdef (Abstract) BaseModel < handle
+    %BASEMODEL Interface for data and core computation layer.
+    %   Responsible for accessing and transforming data.
+
+    methods (Abstract)
+        function data = load(obj, varargin)
+            %LOAD Retrieve input data from a source.
+        end
+
+        function result = process(obj, data)
+            %PROCESS Transform input data into usable results.
+        end
+    end
+end

--- a/+reg/+mvc/BaseView.m
+++ b/+reg/+mvc/BaseView.m
@@ -1,0 +1,10 @@
+classdef (Abstract) BaseView < handle
+    %BASEVIEW Presentation layer interface.
+    %   Consumes results produced by the controller and presents them.
+
+    methods (Abstract)
+        function display(obj, data)
+            %DISPLAY Present results to end users or other systems.
+        end
+    end
+end

--- a/+reg/+mvc/ExampleController.m
+++ b/+reg/+mvc/ExampleController.m
@@ -1,0 +1,14 @@
+classdef ExampleController < reg.mvc.BaseController
+    %EXAMPLECONTROLLER Orchestrates ExampleModel and ExampleView.
+
+    methods
+        function obj = ExampleController(model, view)
+            obj@reg.mvc.BaseController(model, view);
+        end
+        function run(obj)
+            data = obj.Model.load();
+            result = obj.Model.process(data);
+            obj.View.display(result);
+        end
+    end
+end

--- a/+reg/+mvc/ExampleModel.m
+++ b/+reg/+mvc/ExampleModel.m
@@ -1,0 +1,15 @@
+classdef ExampleModel < reg.mvc.BaseModel
+    %EXAMPLEMODEL Stub implementation of BaseModel.
+    %   All methods raise a NotImplemented error.
+
+    methods
+        function data = load(~, varargin) %#ok<INUSD>
+            error("reg:mvc:NotImplemented", ...
+                "ExampleModel.load is not implemented.");
+        end
+        function result = process(~, data) %#ok<INUSD>
+            error("reg:mvc:NotImplemented", ...
+                "ExampleModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+mvc/ExampleView.m
+++ b/+reg/+mvc/ExampleView.m
@@ -1,0 +1,14 @@
+classdef ExampleView < reg.mvc.BaseView
+    %EXAMPLEVIEW Stub view storing displayed data.
+
+    properties
+        DisplayedData
+    end
+
+    methods
+        function display(obj, data)
+            %DISPLAY Store data for verification.
+            obj.DisplayedData = data;
+        end
+    end
+end

--- a/+reg/+view/MetricsView.m
+++ b/+reg/+view/MetricsView.m
@@ -1,0 +1,14 @@
+classdef MetricsView < reg.mvc.BaseView
+    %METRICSVIEW Stub view for presenting metrics.
+    
+    properties
+        DisplayedMetrics
+    end
+    
+    methods
+        function display(obj, data)
+            %DISPLAY Store metrics for verification.
+            obj.DisplayedMetrics = data;
+        end
+    end
+end

--- a/+reg/+view/ReportView.m
+++ b/+reg/+view/ReportView.m
@@ -1,0 +1,14 @@
+classdef ReportView < reg.mvc.BaseView
+    %REPORTVIEW Stub view for rendering reports.
+    
+    properties
+        DisplayedData
+    end
+    
+    methods
+        function display(obj, data)
+            %DISPLAY Store report data for verification.
+            obj.DisplayedData = data;
+        end
+    end
+end

--- a/CLASS_ARCHITECTURE.md
+++ b/CLASS_ARCHITECTURE.md
@@ -1,0 +1,73 @@
+# MVC Clean-Room Class Architecture
+
+This document defines a stubbed class structure for refactoring the
+Regulatory Topic Classifier into a modular Model–View–Controller (MVC)
+application.  All classes are free of business logic and only expose
+interfaces, data flow, and orchestration.
+
+---
+
+## Interfaces
+
+| Interface | Responsibility | Key Methods |
+|-----------|----------------|-------------|
+| `reg.mvc.BaseModel` | Access and transform data | `load(varargin)` → raw input<br>`process(data)` → structured output |
+| `reg.mvc.BaseView` | Present controller output | `display(data)` |
+| `reg.mvc.BaseController` | Coordinate model and view | `run()` |
+| `reg.mvc.Application` | Wire components and start execution | `start()` → `Controller.run()` |
+
+---
+
+## Model Layer
+
+| Class | Purpose |
+|-------|---------|
+| `reg.model.ConfigModel` | Retrieve configuration parameters |
+| `reg.model.PDFIngestModel` | Convert PDFs into a document table |
+| `reg.model.TextChunkModel` | Split documents into token chunks |
+| `reg.model.FeatureModel` | Generate TF‑IDF, topics, and embeddings |
+| `reg.model.ProjectionHeadModel` | Apply optional projection head |
+| `reg.model.WeakLabelModel` | Produce weak and bootstrapped labels |
+| `reg.model.ClassifierModel` | Train models and produce predictions |
+| `reg.model.SearchIndexModel` | Build hybrid retrieval index |
+| `reg.model.DatabaseModel` | Persist chunk predictions and scores |
+| `reg.model.ReportModel` | Assemble data for final reports |
+| `reg.model.FineTuneDataModel` | Build contrastive triplet datasets |
+| `reg.model.EncoderFineTuneModel` | Fine‑tune base encoder |
+| `reg.model.EvaluationModel` | Compute retrieval and classification metrics |
+| `reg.model.LoggingModel` | Save experiment metrics |
+| `reg.model.GoldPackModel` | Provide labelled gold data |
+
+---
+
+## View Layer
+
+| Class | Purpose |
+|-------|---------|
+| `reg.view.ReportView` | Render report artifacts |
+| `reg.view.MetricsView` | Present metrics or progress |
+
+---
+
+## Controller Layer
+
+| Class | Collaborators | Responsibility |
+|-------|---------------|---------------|
+| `reg.controller.PipelineController` | All pipeline models + `ReportView` | Ingest → chunk → features → labels → classifier → index → DB → report |
+| `reg.controller.ProjectionHeadController` | Feature, fine‑tune data, projection head, evaluation models + `MetricsView` | Train and evaluate projection head |
+| `reg.controller.FineTuneController` | PDF ingest, chunk, weak label, fine‑tune data, encoder fine‑tune, evaluation models + `MetricsView` | Build contrastive set and fine‑tune encoder |
+| `reg.controller.EvalController` | Evaluation, logging, report models + `ReportView` | Evaluate embeddings and generate reports |
+
+---
+
+## Data Flow Overview
+
+1. **Pipeline**: PDFs → documents → chunks → features → labels → classifier →
+   search index → database → report.
+2. **Projection Head**: features → triplets → head training → evaluation.
+3. **Fine‑Tune**: ingest → chunks → labels → triplets → encoder training → evaluation.
+4. **Evaluation**: embeddings & labels → metrics → logging → report.
+
+This structure establishes a clean foundation for further development while
+keeping implementation details out of scope.
+

--- a/tests/TestMVCIntegration.m
+++ b/tests/TestMVCIntegration.m
@@ -1,0 +1,31 @@
+classdef TestMVCIntegration < matlab.unittest.TestCase
+    %TESTMVCINTEGRATION Integration tests for MVC coordination.
+
+    properties
+        Model
+        View
+        Controller
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.Model = reg.mvc.ExampleModel();
+            tc.View = reg.mvc.ExampleView();
+            tc.Controller = reg.mvc.ExampleController(tc.Model, tc.View);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+            tc.View = [];
+            tc.Model = [];
+        end
+    end
+
+    methods(Test)
+        function controllerRunPropagatesNotImplemented(tc)
+            tc.verifyError(@() tc.Controller.run(), "reg:mvc:NotImplemented");
+        end
+    end
+end

--- a/tests/TestMVCRegression.m
+++ b/tests/TestMVCRegression.m
@@ -1,0 +1,43 @@
+classdef TestMVCRegression < matlab.unittest.TestCase
+    %TESTMVCREGRESSION Regression tests ensuring interfaces remain stable.
+
+    properties
+        App
+        Controller
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.Controller = SpyController();
+            tc.App = reg.mvc.Application([], [], tc.Controller);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.App = [];
+            tc.Controller = [];
+        end
+    end
+
+    methods(Test)
+        function applicationStartInvokesController(tc)
+            tc.App.start();
+            tc.verifyTrue(tc.Controller.RunCalled);
+        end
+    end
+end
+
+classdef SpyController < reg.mvc.BaseController
+    properties
+        RunCalled = false;
+    end
+    methods
+        function obj = SpyController()
+            obj@reg.mvc.BaseController([], []);
+        end
+        function run(obj)
+            obj.RunCalled = true;
+        end
+    end
+end

--- a/tests/TestMVCSystem.m
+++ b/tests/TestMVCSystem.m
@@ -1,0 +1,28 @@
+classdef TestMVCSystem < matlab.unittest.TestCase
+    %TESTMVCSYSTEM System test exercising end-to-end application wiring.
+
+    properties
+        App
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            model = reg.mvc.ExampleModel();
+            view = reg.mvc.ExampleView();
+            controller = reg.mvc.ExampleController(model, view);
+            tc.App = reg.mvc.Application(model, view, controller);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.App = [];
+        end
+    end
+
+    methods(Test)
+        function startPropagatesNotImplemented(tc)
+            tc.verifyError(@() tc.App.start(), "reg:mvc:NotImplemented");
+        end
+    end
+end

--- a/tests/TestMVCUnit.m
+++ b/tests/TestMVCUnit.m
@@ -1,0 +1,31 @@
+classdef TestMVCUnit < matlab.unittest.TestCase
+    %TESTMVCUNIT Unit tests for MVC stub components.
+
+    properties
+        Model
+        TempFolderFixture
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.TempFolderFixture = tc.applyFixture( ...
+                matlab.unittest.fixtures.TemporaryFolderFixture);
+            tc.Model = reg.mvc.ExampleModel();
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Model = [];
+        end
+    end
+
+    methods(Test)
+        function loadNotImplemented(tc)
+            tc.verifyError(@() tc.Model.load(), "reg:mvc:NotImplemented");
+        end
+        function processNotImplemented(tc)
+            tc.verifyError(@() tc.Model.process([]), "reg:mvc:NotImplemented");
+        end
+    end
+end

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -1,0 +1,34 @@
+classdef TestModelStubs < matlab.unittest.TestCase
+    %TESTMODELSTUBS Ensure stub models raise NotImplemented errors.
+    
+    properties (TestParameter)
+        ModelClass = {
+            'reg.model.ConfigModel',
+            'reg.model.PDFIngestModel',
+            'reg.model.TextChunkModel',
+            'reg.model.FeatureModel',
+            'reg.model.ProjectionHeadModel',
+            'reg.model.WeakLabelModel',
+            'reg.model.ClassifierModel',
+            'reg.model.SearchIndexModel',
+            'reg.model.DatabaseModel',
+            'reg.model.ReportModel',
+            'reg.model.FineTuneDataModel',
+            'reg.model.EncoderFineTuneModel',
+            'reg.model.EvaluationModel',
+            'reg.model.LoggingModel',
+            'reg.model.GoldPackModel'
+        };
+    end
+    
+    methods(Test)
+        function loadNotImplemented(tc, ModelClass)
+            model = feval(ModelClass);
+            tc.verifyError(@() model.load(), 'reg:model:NotImplemented');
+        end
+        function processNotImplemented(tc, ModelClass)
+            model = feval(ModelClass);
+            tc.verifyError(@() model.process([]), 'reg:model:NotImplemented');
+        end
+    end
+end

--- a/tests/TestPipelineController.m
+++ b/tests/TestPipelineController.m
@@ -1,0 +1,36 @@
+classdef TestPipelineController < matlab.unittest.TestCase
+    %TESTPIPELINECONTROLLER Ensure PipelineController propagates NotImplemented.
+    
+    properties
+        Controller
+    end
+    
+    methods(TestMethodSetup)
+        function setup(tc)
+            cfgModel = reg.model.ConfigModel();
+            pdfModel = reg.model.PDFIngestModel();
+            chunkModel = reg.model.TextChunkModel();
+            featModel = reg.model.FeatureModel();
+            projModel = reg.model.ProjectionHeadModel();
+            weakModel = reg.model.WeakLabelModel();
+            clsModel = reg.model.ClassifierModel();
+            searchModel = reg.model.SearchIndexModel();
+            dbModel = reg.model.DatabaseModel();
+            reportModel = reg.model.ReportModel();
+            view = reg.view.ReportView();
+            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, clsModel, searchModel, dbModel, reportModel, view);
+        end
+    end
+    
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+        end
+    end
+    
+    methods(Test)
+        function runPropagatesNotImplemented(tc)
+            tc.verifyError(@() tc.Controller.run(), 'reg:model:NotImplemented');
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- document MVC interfaces and data flow in new `CLASS_ARCHITECTURE.md`
- scaffold models, views, and controllers as clean-room stubs for the pipeline
- add MATLAB unit tests covering model stubs and pipeline controller wiring

## Testing
- `matlab -batch "addpath(pwd); results=runtests('tests'); exit(any([results.Failed]));"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_b_689e2a18afe483308fbb5f80d47c4283