### PR TITLE
Add diff report and sync controllers with tests

### DIFF
--- a/+reg/+controller/DiffReportController.m
+++ b/+reg/+controller/DiffReportController.m
@@ -1,0 +1,46 @@
+classdef DiffReportController < reg.mvc.BaseController
+    %DIFFREPORTCONTROLLER Generate CRR diff reports in PDF and HTML.
+    %   Wraps reg_crr_diff_report and reg_crr_diff_report_html and exposes
+    %   a simple controller interface for producing diff reports between
+    %   two document versions.
+
+    properties
+        PdfGenerator
+        HtmlGenerator
+    end
+
+    methods
+        function obj = DiffReportController(view, pdfFunc, htmlFunc)
+            %DIFFREPORTCONTROLLER Construct controller with generators and view.
+            if nargin < 1 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            if nargin < 2 || isempty(pdfFunc)
+                pdfFunc = @reg_crr_diff_report;
+            end
+            if nargin < 3 || isempty(htmlFunc)
+                htmlFunc = @reg_crr_diff_report_html;
+            end
+            obj@reg.mvc.BaseController([], view);
+            obj.PdfGenerator = pdfFunc;
+            obj.HtmlGenerator = htmlFunc;
+        end
+
+        function report = run(obj, dirA, dirB, outDir)
+            %RUN Produce diff reports for two directories.
+            %   report = RUN(obj, dirA, dirB, outDir) compares the two input
+            %   directories and writes PDF and HTML reports to outDir.
+            if nargin < 4 || isempty(outDir)
+                outDir = fullfile('runs', 'crr_diff_report');
+            end
+            if ~exist(outDir, 'dir')
+                mkdir(outDir);
+            end
+            obj.PdfGenerator(dirA, dirB, 'OutDir', outDir);
+            obj.HtmlGenerator(dirA, dirB, 'OutDir', outDir);
+            report = struct('pdf', fullfile(outDir, 'crr_diff_report.pdf'), ...
+                             'html', fullfile(outDir, 'crr_diff_report.html'));
+            obj.View.display(report);
+        end
+    end
+end

--- a/+reg/+controller/SyncController.m
+++ b/+reg/+controller/SyncController.m
@@ -1,0 +1,34 @@
+classdef SyncController < reg.mvc.BaseController
+    %SYNCCONTROLLER Wrapper for CRR synchronization tasks.
+    %   Provides an interface for invoking reg_crr_sync and forwarding the
+    %   results to a view.
+
+    properties
+        SyncFunction
+    end
+
+    methods
+        function obj = SyncController(view, syncFunc)
+            %SYNCCONTROLLER Construct controller with optional function and view.
+            if nargin < 1 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            if nargin < 2 || isempty(syncFunc)
+                syncFunc = @reg_crr_sync;
+            end
+            obj@reg.mvc.BaseController([], view);
+            obj.SyncFunction = syncFunc;
+        end
+
+        function out = run(obj, date)
+            %RUN Execute synchronization for a given date.
+            %   out = RUN(obj, date) calls the underlying sync function and
+            %   passes the resulting struct to the view.
+            if nargin < 2 || isempty(date)
+                date = datestr(now, 'yyyymmdd');
+            end
+            out = obj.SyncFunction('Date', date);
+            obj.View.display(out);
+        end
+    end
+end

--- a/tests/TestDiffReportController.m
+++ b/tests/TestDiffReportController.m
@@ -1,0 +1,40 @@
+classdef TestDiffReportController < RegTestCase
+    %TESTDIFFREPORTCONTROLLER Ensure diff report controller produces files.
+    methods(Test)
+        function runCreatesReports(tc)
+            outDir = tempname;
+            view = reg.view.ReportView();
+            ctrl = reg.controller.DiffReportController(view, @pdfStub, @htmlStub);
+            result = ctrl.run('dirA', 'dirB', outDir);
+            tc.verifyTrue(isfile(result.pdf));
+            tc.verifyTrue(isfile(result.html));
+            tc.verifyEqual(view.DisplayedData, result);
+        end
+    end
+end
+
+function pdfStub(~, ~, varargin)
+    p = inputParser;
+    addParameter(p, 'OutDir', tempdir);
+    parse(p, varargin{:});
+    outDir = p.Results.OutDir;
+    if ~exist(outDir, 'dir')
+        mkdir(outDir);
+    end
+    fid = fopen(fullfile(outDir, 'crr_diff_report.pdf'), 'w');
+    fwrite(fid, 'PDF');
+    fclose(fid);
+end
+
+function htmlStub(~, ~, varargin)
+    p = inputParser;
+    addParameter(p, 'OutDir', tempdir);
+    parse(p, varargin{:});
+    outDir = p.Results.OutDir;
+    if ~exist(outDir, 'dir')
+        mkdir(outDir);
+    end
+    fid = fopen(fullfile(outDir, 'crr_diff_report.html'), 'w');
+    fwrite(fid, '<html></html>');
+    fclose(fid);
+end

--- a/tests/TestSyncController.m
+++ b/tests/TestSyncController.m
@@ -1,0 +1,32 @@
+classdef TestSyncController < RegTestCase
+    %TESTSYNCCONTROLLER Verify SyncController interface and outputs.
+    methods(Test)
+        function runProducesFiles(tc)
+            view = reg.view.ReportView();
+            ctrl = reg.controller.SyncController(view, @syncStub);
+            result = ctrl.run('20250101');
+            tc.verifyTrue(isfile(result.pdf));
+            tc.verifyTrue(isfolder(result.eba_dir));
+            tc.verifyTrue(isfile(result.eba_index));
+            tc.verifyEqual(view.DisplayedData, result);
+        end
+    end
+end
+
+function out = syncStub(varargin)
+    p = inputParser;
+    addParameter(p, 'Date', '');
+    parse(p, varargin{:});
+    tmp = tempname;
+    mkdir(tmp);
+    pdfPath = fullfile(tmp, ['crr_' p.Results.Date '.pdf']);
+    fid = fopen(pdfPath, 'w');
+    fwrite(fid, 'PDF');
+    fclose(fid);
+    ebaDir = fullfile(tmp, 'eba');
+    mkdir(ebaDir);
+    idx = fullfile(ebaDir, 'index.csv');
+    fid = fopen(idx, 'w');
+    fclose(fid);
+    out = struct('pdf', pdfPath, 'eba_dir', ebaDir, 'eba_index', idx);
+end


### PR DESCRIPTION
## Summary
- add `DiffReportController` to generate CRR diff reports in PDF and HTML
- add `SyncController` to wrap CRR sync tasks
- test controllers with stubbed generators to verify file outputs

## Testing
- `matlab -batch "addpath('tests'); addpath('tests/fixtures'); results=runtests({'tests/TestDiffReportController.m','tests/TestSyncController.m'}); disp(results); exit(any([results.Failed]));"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_689e3c6aa30c8330ad57dd36ca1a10b8