### PR TITLE
Add fine-tuning controller workflow and triplet models

### DIFF
--- a/+reg/+model/Pair.m
+++ b/+reg/+model/Pair.m
@@ -1,0 +1,19 @@
+classdef Pair
+    %PAIR Represents a pair of indices and label for contrastive learning.
+    properties
+        A
+        B
+        Label
+    end
+    methods
+        function obj = Pair(a, b, label)
+            if nargin > 0
+                obj.A = a;
+                obj.B = b;
+                if nargin > 2
+                    obj.Label = label;
+                end
+            end
+        end
+    end
+end

--- a/+reg/+model/Triplet.m
+++ b/+reg/+model/Triplet.m
@@ -1,0 +1,17 @@
+classdef Triplet
+    %TRIPLET Represents an anchor, positive, negative indices for contrastive learning.
+    properties
+        Anchor
+        Positive
+        Negative
+    end
+    methods
+        function obj = Triplet(anchor, positive, negative)
+            if nargin > 0
+                obj.Anchor = anchor;
+                obj.Positive = positive;
+                obj.Negative = negative;
+            end
+        end
+    end
+end

--- a/reg_finetune_pipeline.m
+++ b/reg_finetune_pipeline.m
@@ -1,0 +1,14 @@
+%REG_FINETUNE_PIPELINE Example entry point for encoder fine-tuning using MVC.
+%   Instantiates FineTuneController with stub models and kicks off run().
+function reg_finetune_pipeline()
+    pdfModel = reg.model.PDFIngestModel();
+    chunkModel = reg.model.TextChunkModel();
+    weakModel = reg.model.WeakLabelModel();
+    dataModel = reg.model.FineTuneDataModel();
+    encoderModel = reg.model.EncoderFineTuneModel();
+    evalModel = reg.model.EvaluationModel();
+    view = reg.view.MetricsView();
+    controller = reg.controller.FineTuneController(pdfModel, chunkModel, weakModel, ...
+        dataModel, encoderModel, evalModel, view);
+    controller.run();
+end

--- a/tests/TestFineTuneController.m
+++ b/tests/TestFineTuneController.m
@@ -1,0 +1,43 @@
+classdef TestFineTuneController < matlab.unittest.TestCase
+    %TESTFINETUNECONTROLLER Ensure FineTuneController methods propagate stubs.
+
+    properties
+        Controller
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            pdfModel = reg.model.PDFIngestModel();
+            chunkModel = reg.model.TextChunkModel();
+            weakModel = reg.model.WeakLabelModel();
+            dataModel = reg.model.FineTuneDataModel();
+            encoderModel = reg.model.EncoderFineTuneModel();
+            evalModel = reg.model.EvaluationModel();
+            view = reg.view.MetricsView();
+            tc.Controller = reg.controller.FineTuneController(pdfModel, chunkModel, weakModel, dataModel, encoderModel, evalModel, view);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+        end
+    end
+
+    methods(Test)
+        function buildTripletsPropagates(tc)
+            tc.verifyError(@() tc.Controller.buildTriplets(), 'reg:model:NotImplemented');
+        end
+        function trainEncoderPropagates(tc)
+            tc.verifyError(@() tc.Controller.trainEncoder([]), 'reg:model:NotImplemented');
+        end
+        function saveModelRoundTrip(tc)
+            net = struct('W', 1);
+            tmp = [tempname '.mat'];
+            tc.Controller.saveModel(net, tmp);
+            S = load(tmp, 'net');
+            tc.verifyEqual(S.net, net);
+            delete(tmp);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add simple `Triplet` and `Pair` value models for contrastive samples
- implement `FineTuneController` with `buildTriplets`, `trainEncoder`, `evaluate`, and `saveModel`
- wire a `reg_finetune_pipeline` entry and unit tests for controller stubs and model saving

## Testing
- `matlab -batch "runtests('tests/TestFineTuneController.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e3c680f288330a7d4fbf4d432d727