### PR TITLE
Add evaluation controller and pipeline

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -1,0 +1,51 @@
+classdef EvaluationController < handle
+    %EVALUATIONCONTROLLER Provide utilities for evaluation and reporting.
+    %   This controller bundles common evaluation routines used across the
+    %   project such as retrieval metrics, gold-pack evaluation, trend
+    %   plotting and co-retrieval heatmap generation.
+
+    methods
+        function metrics = retrievalMetrics(~, embeddings, posSets, k)
+            %RETRIEVALMETRICS Compute retrieval metrics at K.
+            %   metrics = retrievalMetrics(embeddings, posSets, k) returns a
+            %   struct with RecallAtK, mAP and nDCG computed from the
+            %   provided embeddings and positive sets. K defaults to 10.
+            if nargin < 4, k = 10; end
+            [recallAtK, mAP] = reg.eval_retrieval(embeddings, posSets, k);
+            ndcgAtK = reg.metrics_ndcg(embeddings*embeddings.', posSets, k);
+            metrics = struct('RecallAtK', recallAtK, 'mAP', mAP, 'nDCG', ndcgAtK);
+        end
+
+        function results = evaluateGoldPack(obj, goldDir)
+            %EVALUATEGOLDPACK Run evaluation against a gold mini-pack.
+            %   results = evaluateGoldPack(goldDir) loads the gold
+            %   artefacts, embeds the chunks and computes retrieval metrics
+            %   overall and per label.
+            G = reg.load_gold(goldDir);
+            C = config(); C.labels = G.labels;
+            E = reg.precompute_embeddings(G.chunks.text, C);
+            posSets = cell(height(G.chunks),1);
+            for i = 1:height(G.chunks)
+                labs = G.Y(i,:);
+                pos = find(any(G.Y(:,labs),2)); pos(pos==i) = [];
+                posSets{i} = pos;
+            end
+            overall = obj.retrievalMetrics(E, posSets, 10);
+            per = reg.eval_per_label(E, G.Y, 10);
+            perTbl = table(G.labels(:), per.RecallAtK, ...
+                'VariableNames', {'Label','RecallAt10'});
+            results = struct('overall', overall, 'perLabel', perTbl);
+        end
+
+        function plotTrends(~, csvPath, pngPath)
+            %PLOTTRENDS Generate trend plots from a metrics CSV history.
+            reg.plot_trends(csvPath, pngPath);
+        end
+
+        function plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels)
+            %PLOTCORETRIEVALHEATMAP Create a heatmap of label co-retrieval.
+            [M, order] = reg.label_coretrieval_matrix(embeddings, labelMatrix, 10);
+            reg.plot_coretrieval_heatmap(M(order,order), string(labels(order)), pngPath);
+        end
+    end
+end

--- a/+reg/+controller/EvaluationPipeline.m
+++ b/+reg/+controller/EvaluationPipeline.m
@@ -1,0 +1,45 @@
+classdef EvaluationPipeline < handle
+    %EVALUATIONPIPELINE Orchestrate evaluation steps using EvaluationController.
+
+    properties
+        Controller
+        View
+    end
+
+    methods
+        function obj = EvaluationPipeline(controller, view)
+            obj.Controller = controller;
+            obj.View = view;
+        end
+
+        function run(obj, goldDir, metricsCSV)
+            %RUN Execute evaluation workflow and render report.
+            if nargin < 2, goldDir = 'gold'; end
+
+            % Gold pack evaluation and retrieval metrics
+            goldRes = obj.Controller.evaluateGoldPack(goldDir);
+            metrics = goldRes.overall;
+
+            % Trend plotting if history provided
+            trendsPNG = '';
+            if nargin >= 3 && ~isempty(metricsCSV) && isfile(metricsCSV)
+                trendsPNG = fullfile(tempdir, 'trends.png');
+                obj.Controller.plotTrends(metricsCSV, trendsPNG);
+            end
+
+            % Co-retrieval heatmap using gold embeddings
+            G = reg.load_gold(goldDir);
+            C = config(); C.labels = G.labels;
+            E = reg.precompute_embeddings(G.chunks.text, C);
+            heatPNG = fullfile(tempdir, 'coretrieval_heatmap.png');
+            obj.Controller.plotCoRetrievalHeatmap(E, G.Y, heatPNG, G.labels);
+
+            report = struct('summaryTables', metrics, ...
+                            'irbSubset', [], ...
+                            'trendCharts', trendsPNG, ...
+                            'heatmap', heatPNG, ...
+                            'gold', goldRes);
+            obj.View.display(report);
+        end
+    end
+end

--- a/+reg/+view/ReportView.m
+++ b/+reg/+view/ReportView.m
@@ -3,12 +3,25 @@ classdef ReportView < reg.mvc.BaseView
     
     properties
         DisplayedData
+        SummaryTables
+        IRBSubset
+        TrendCharts
     end
-    
+
     methods
         function display(obj, data)
-            %DISPLAY Store report data for verification.
+            %DISPLAY Store report data for verification and expose key
+            %evaluation sections for tests.
             obj.DisplayedData = data;
+            if isstruct(data) && isfield(data, 'summaryTables')
+                obj.SummaryTables = data.summaryTables;
+            end
+            if isstruct(data) && isfield(data, 'irbSubset')
+                obj.IRBSubset = data.irbSubset;
+            end
+            if isstruct(data) && isfield(data, 'trendCharts')
+                obj.TrendCharts = data.trendCharts;
+            end
         end
     end
 end

--- a/tests/TestEvaluationController.m
+++ b/tests/TestEvaluationController.m
@@ -1,0 +1,46 @@
+classdef TestEvaluationController < RegTestCase
+    % Test the EvaluationController utility methods.
+
+    methods (Test)
+        function retrieval_metrics(tc)
+            G = reg.load_gold('gold');
+            C = config(); C.labels = G.labels;
+            E = reg.precompute_embeddings(G.chunks.text, C);
+            posSets = cell(height(G.chunks),1);
+            for i = 1:height(G.chunks)
+                labs = G.Y(i,:);
+                pos = find(any(G.Y(:,labs),2)); pos(pos==i) = [];
+                posSets{i} = pos;
+            end
+            ctrl = reg.controller.EvaluationController();
+            metrics = ctrl.retrievalMetrics(E, posSets, 10);
+            tc.verifyTrue(isfield(metrics, 'RecallAtK'));
+            tc.verifyTrue(isfield(metrics, 'mAP'));
+            tc.verifyTrue(isfield(metrics, 'nDCG'));
+        end
+
+        function gold_pack(tc)
+            ctrl = reg.controller.EvaluationController();
+            res = ctrl.evaluateGoldPack('gold');
+            tc.verifyTrue(isfield(res, 'overall'));
+            tc.verifyTrue(isfield(res, 'perLabel'));
+        end
+
+        function plotting(tc)
+            ctrl = reg.controller.EvaluationController();
+            % Trend plot
+            csv = fullfile(tempdir, 'metrics.csv');
+            T = table((1:3)', rand(3,1), 'VariableNames', {'Epoch','RecallAt10'});
+            writetable(T, csv);
+            png = fullfile(tempdir, 'trends.png');
+            ctrl.plotTrends(csv, png);
+            tc.verifyTrue(isfile(png));
+            % Co-retrieval heatmap
+            E = rand(5,4);
+            Y = eye(5) > 0;
+            png2 = fullfile(tempdir, 'heatmap.png');
+            ctrl.plotCoRetrievalHeatmap(E, Y, png2, "A"+(0:4));
+            tc.verifyTrue(isfile(png2));
+        end
+    end
+end

--- a/tests/TestEvaluationPipeline.m
+++ b/tests/TestEvaluationPipeline.m
@@ -1,0 +1,18 @@
+classdef TestEvaluationPipeline < RegTestCase
+    % Validate that EvaluationPipeline orchestrates controller and view.
+
+    methods (Test)
+        function run_pipeline(tc)
+            view = reg.view.ReportView();
+            ctrl = reg.controller.EvaluationController();
+            pipe = reg.controller.EvaluationPipeline(ctrl, view);
+            % Minimal metrics history for trend chart
+            csv = fullfile(tempdir, 'metrics.csv');
+            T = table((1:2)', rand(2,1), 'VariableNames', {'Epoch','RecallAt10'});
+            writetable(T, csv);
+            pipe.run('gold', csv);
+            tc.verifyTrue(isfield(view.DisplayedData, 'summaryTables'));
+            tc.verifyTrue(isfield(view.DisplayedData, 'trendCharts'));
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- introduce `EvaluationController` with helpers for retrieval metrics, gold pack evaluation, trend plots and co-retrieval heatmaps
- extend `ReportView` and add `EvaluationPipeline` to orchestrate evaluation and reporting
- add unit tests covering controller utilities and pipeline report generation

## Testing
- ⚠️ `matlab -batch "addpath('tests/fixtures'); results=runtests('tests/TestEvaluationController.m'); disp(results); assert(~any([results.Failed])); results=runtests('tests/TestEvaluationPipeline.m'); disp(results); assert(~any([results.Failed]));"` (command not found)
- ⚠️ `octave -qf --eval "addpath('tests/fixtures'); results=runtests('tests/TestEvaluationController.m'); disp(results);"` (command not found)

------
https://chatgpt.com/codex/tasks/task_b_689e3c6596e88330acba0595dae1ceaa