### PR TITLE
Add controller tests with setup/teardown fixtures

### DIFF
--- a/tests/TestDiffReportController.m
+++ b/tests/TestDiffReportController.m
@@ -1,0 +1,38 @@
+classdef TestDiffReportController < RegTestCase
+    %TESTDIFFREPORTCONTROLLER Verify diff report generation writes artifacts.
+
+    properties
+        WorkFolder
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            tc.WorkFolder = pwd;
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.WorkFolder = [];
+        end
+    end
+
+    methods(Test)
+        function generatesReport(tc)
+            tc.assumeTrue(exist('mlreportgen.report.Report','class') == 8, ...
+                'Requires MATLAB Report Generator');
+            dirA = fullfile(tc.WorkFolder,'A');
+            dirB = fullfile(tc.WorkFolder,'B');
+            mkdir(dirA); mkdir(dirB);
+            writelines("foo", fullfile(dirA,'f.txt'));
+            writelines("bar", fullfile(dirB,'f.txt'));
+            outDir = fullfile(tc.WorkFolder,'out');
+            reg_crr_diff_report(dirA, dirB, 'OutDir', outDir);
+            tc.verifyTrue(isfile(fullfile(outDir,'crr_diff_report.pdf')));
+            tc.verifyTrue(isfile(fullfile(outDir,'summary.csv')));
+            tc.verifyTrue(isfile(fullfile(outDir,'patch.txt')));
+        end
+    end
+end
+

--- a/tests/TestEvaluationController.m
+++ b/tests/TestEvaluationController.m
@@ -1,0 +1,62 @@
+classdef TestEvaluationController < RegTestCase
+    %TESTEVALUATIONCONTROLLER Verify EvalController integrates models and view.
+
+    properties
+        Controller
+        View
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            evalModel   = StubModel();
+            logModel    = StubModel();
+            reportModel = StubModel(struct('OutputPath','report.pdf'));
+            tc.View = SpyView();
+            tc.Controller = reg.controller.EvalController(evalModel, logModel, reportModel, tc.View);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+            tc.View = [];
+        end
+    end
+
+    methods(Test)
+        function runDisplaysReport(tc)
+            tc.Controller.run();
+            tc.verifyEqual(tc.View.DisplayedData.OutputPath, 'report.pdf');
+        end
+    end
+end
+
+classdef StubModel < handle
+    properties
+        ProcessOutput
+    end
+    methods
+        function obj = StubModel(out)
+            if nargin < 1, out = []; end
+            obj.ProcessOutput = out;
+        end
+        function data = load(~)
+            data = [];
+        end
+        function out = process(obj, ~)
+            out = obj.ProcessOutput;
+        end
+    end
+end
+
+classdef SpyView < handle
+    properties
+        DisplayedData
+    end
+    methods
+        function display(obj, data)
+            obj.DisplayedData = data;
+        end
+    end
+end
+

--- a/tests/TestFineTuneController.m
+++ b/tests/TestFineTuneController.m
@@ -1,0 +1,65 @@
+classdef TestFineTuneController < RegTestCase
+    %TESTFINETUNECONTROLLER Verify FineTuneController integrates models and view.
+
+    properties
+        Controller
+        View
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            pdfModel     = StubModel("files");
+            chunkModel   = StubModel("chunks");
+            weakModel    = StubModel("Yweak","Yboot");
+            dataModel    = StubModel("triplets");
+            encoderModel = StubModel("net");
+            evalModel    = StubModel(struct('Accuracy',0.42));
+            tc.View = SpyView();
+            tc.Controller = reg.controller.FineTuneController(pdfModel, chunkModel, weakModel, dataModel, encoderModel, evalModel, tc.View);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+            tc.View = [];
+        end
+    end
+
+    methods(Test)
+        function runDisplaysMetrics(tc)
+            tc.Controller.run();
+            tc.verifyEqual(tc.View.DisplayedData.Accuracy, 0.42);
+        end
+    end
+end
+
+classdef StubModel < handle
+    properties
+        ProcessOutputs
+    end
+    methods
+        function obj = StubModel(varargin)
+            obj.ProcessOutputs = varargin;
+        end
+        function varargout = load(~)
+            varargout = cell(1,nargout);
+            [varargout{:}] = deal([]);
+        end
+        function varargout = process(obj, ~)
+            varargout = obj.ProcessOutputs;
+        end
+    end
+end
+
+classdef SpyView < handle
+    properties
+        DisplayedData
+    end
+    methods
+        function display(obj, data)
+            obj.DisplayedData = data;
+        end
+    end
+end
+

--- a/tests/TestSyncController.m
+++ b/tests/TestSyncController.m
@@ -1,0 +1,29 @@
+classdef TestSyncController < RegTestCase
+    %TESTSYNCCONTROLLER Verify sync orchestrator returns paths.
+
+    properties
+        WorkFolder
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            tc.applyFixture(matlab.unittest.fixtures.WorkingFolderFixture);
+            tc.WorkFolder = pwd;
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.WorkFolder = [];
+        end
+    end
+
+    methods(Test)
+        function returnsArtifactPaths(tc)
+            out = reg_crr_sync('Date','20200101');
+            tc.verifyTrue(isfolder(out.eba_dir));
+            tc.verifyEqual(out.eba_index, fullfile(out.eba_dir,'index.csv'));
+        end
+    end
+end
+


### PR DESCRIPTION
## Summary
- Add `matlab.unittest` cases for evaluation, fine-tune, diff report, and sync controllers
- Verify controller runs propagate data to views and produce artifact paths

## Testing
- `matlab -batch "cd tests; results=runtests({'TestEvaluationController','TestFineTuneController','TestDiffReportController','TestSyncController'}); disp(results); assert(~any([results.Failed]));"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e3c72a06483309905a6f862ed5306