### PR TITLE
Add configurable properties to model stubs

### DIFF
--- a/+reg/+model/ClassifierModel.m
+++ b/+reg/+model/ClassifierModel.m
@@ -1,7 +1,18 @@
 classdef ClassifierModel < reg.mvc.BaseModel
     %CLASSIFIERMODEL Stub model training classifiers and predicting labels.
-    
+
+    properties
+        % Structure containing classifier configuration
+        config
+    end
+
     methods
+        function obj = ClassifierModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "ClassifierModel.load is not implemented.");

--- a/+reg/+model/ConfigModel.m
+++ b/+reg/+model/ConfigModel.m
@@ -1,7 +1,18 @@
 classdef ConfigModel < reg.mvc.BaseModel
     %CONFIGMODEL Stub model retrieving configuration parameters.
-    
+
+    properties
+        % Configuration settings to retrieve
+        config
+    end
+
     methods
+        function obj = ConfigModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function data = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "ConfigModel.load is not implemented.");

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -1,7 +1,18 @@
 classdef DatabaseModel < reg.mvc.BaseModel
     %DATABASEMODEL Stub model persisting predictions to a database.
-    
+
+    properties
+        % Database configuration structure
+        dbConfig
+    end
+
     methods
+        function obj = DatabaseModel(dbConfig)
+            if nargin > 0
+                obj.dbConfig = dbConfig;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "DatabaseModel.load is not implemented.");

--- a/+reg/+model/EncoderFineTuneModel.m
+++ b/+reg/+model/EncoderFineTuneModel.m
@@ -1,7 +1,18 @@
 classdef EncoderFineTuneModel < reg.mvc.BaseModel
     %ENCODERFINETUNEMODEL Stub model for encoder fine-tuning.
-    
+
+    properties
+        % Fine-tuning configuration
+        config
+    end
+
     methods
+        function obj = EncoderFineTuneModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "EncoderFineTuneModel.load is not implemented.");

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -1,7 +1,18 @@
 classdef EvaluationModel < reg.mvc.BaseModel
     %EVALUATIONMODEL Stub model computing evaluation metrics.
-    
+
+    properties
+        % Evaluation configuration
+        config
+    end
+
     methods
+        function obj = EvaluationModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.load is not implemented.");

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -1,7 +1,18 @@
 classdef FeatureModel < reg.mvc.BaseModel
     %FEATUREMODEL Stub model generating feature representations.
-    
+
+    properties
+        % Feature extraction configuration
+        config
+    end
+
     methods
+        function obj = FeatureModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function chunksT = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "FeatureModel.load is not implemented.");

--- a/+reg/+model/FineTuneDataModel.m
+++ b/+reg/+model/FineTuneDataModel.m
@@ -1,7 +1,18 @@
 classdef FineTuneDataModel < reg.mvc.BaseModel
     %FINETUNEDATAMODEL Stub model building contrastive triplets.
-    
+
+    properties
+        % Settings for constructing fine-tuning data
+        config
+    end
+
     methods
+        function obj = FineTuneDataModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "FineTuneDataModel.load is not implemented.");

--- a/+reg/+model/GoldPackModel.m
+++ b/+reg/+model/GoldPackModel.m
@@ -1,7 +1,18 @@
 classdef GoldPackModel < reg.mvc.BaseModel
     %GOLDPACKMODEL Stub model providing labelled gold data.
-    
+
+    properties
+        % Configuration for gold data retrieval
+        config
+    end
+
     methods
+        function obj = GoldPackModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function data = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "GoldPackModel.load is not implemented.");

--- a/+reg/+model/LoggingModel.m
+++ b/+reg/+model/LoggingModel.m
@@ -1,7 +1,18 @@
 classdef LoggingModel < reg.mvc.BaseModel
     %LOGGINGMODEL Stub model for persisting metrics.
-    
+
+    properties
+        % Logging configuration such as file path or endpoint
+        config
+    end
+
     methods
+        function obj = LoggingModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function metrics = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "LoggingModel.load is not implemented.");

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -1,7 +1,18 @@
 classdef PDFIngestModel < reg.mvc.BaseModel
     %PDFINGESTMODEL Stub model converting PDFs to document table.
-    
+
+    properties
+        % Directory containing the PDF files to ingest
+        inputDir
+    end
+
     methods
+        function obj = PDFIngestModel(inputDir)
+            if nargin > 0
+                obj.inputDir = inputDir;
+            end
+        end
+
         function files = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "PDFIngestModel.load is not implemented.");

--- a/+reg/+model/ProjectionHeadModel.m
+++ b/+reg/+model/ProjectionHeadModel.m
@@ -1,7 +1,18 @@
 classdef ProjectionHeadModel < reg.mvc.BaseModel
     %PROJECTIONHEADMODEL Stub model applying projection head to embeddings.
-    
+
+    properties
+        % Configuration for projection head
+        config
+    end
+
     methods
+        function obj = ProjectionHeadModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function E = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "ProjectionHeadModel.load is not implemented.");

--- a/+reg/+model/ReportModel.m
+++ b/+reg/+model/ReportModel.m
@@ -1,7 +1,18 @@
 classdef ReportModel < reg.mvc.BaseModel
     %REPORTMODEL Stub model assembling report data.
-    
+
+    properties
+        % Report generation configuration
+        config
+    end
+
     methods
+        function obj = ReportModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "ReportModel.load is not implemented.");

--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -1,7 +1,18 @@
 classdef SearchIndexModel < reg.mvc.BaseModel
     %SEARCHINDEXMODEL Stub model building retrieval index.
-    
+
+    properties
+        % Configuration for building the search index
+        config
+    end
+
     methods
+        function obj = SearchIndexModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function inputs = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "SearchIndexModel.load is not implemented.");

--- a/+reg/+model/TextChunkModel.m
+++ b/+reg/+model/TextChunkModel.m
@@ -1,7 +1,18 @@
 classdef TextChunkModel < reg.mvc.BaseModel
     %TEXTCHUNKMODEL Stub model splitting documents into chunks.
-    
+
+    properties
+        % Number of tokens per chunk
+        chunkSizeTokens
+    end
+
     methods
+        function obj = TextChunkModel(chunkSizeTokens)
+            if nargin > 0
+                obj.chunkSizeTokens = chunkSizeTokens;
+            end
+        end
+
         function docsT = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "TextChunkModel.load is not implemented.");

--- a/+reg/+model/WeakLabelModel.m
+++ b/+reg/+model/WeakLabelModel.m
@@ -1,7 +1,18 @@
 classdef WeakLabelModel < reg.mvc.BaseModel
     %WEAKLABELMODEL Stub model generating weak supervision labels.
-    
+
+    properties
+        % Configuration for weak labeling
+        config
+    end
+
     methods
+        function obj = WeakLabelModel(config)
+            if nargin > 0
+                obj.config = config;
+            end
+        end
+
         function chunksT = load(~, varargin) %#ok<INUSD>
             error("reg:model:NotImplemented", ...
                 "WeakLabelModel.load is not implemented.");


### PR DESCRIPTION
## Summary
- expose configuration structures on all reg.model stubs
- add dedicated settings like `inputDir`, `chunkSizeTokens`, and `dbConfig`

## Testing
- `matlab -batch "run('run_smoke_test.m');"` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_b_689e40f793908330842433f7361d5667