### PR TITLE
Add base MVC classes and example stubs

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -1,0 +1,34 @@
+classdef Application < handle
+    %APPLICATION Compose model, view and controller for execution.
+    %   Acts as a lightweight container. Calling `start` delegates to the
+    %   provided controller's `run` method. The flow mirrors launching
+    %   `reg_pipeline` where data is loaded, processed and then displayed.
+
+    properties
+        Model
+        View
+        Controller
+    end
+
+    methods
+        function obj = Application(model, view, controller)
+            %APPLICATION Construct the application container.
+            %   OBJ = APPLICATION(MODEL, VIEW, CONTROLLER) simply stores the
+            %   provided components for later execution.
+            if nargin > 0
+                obj.Model = model;
+                obj.View = view;
+                obj.Controller = controller;
+            end
+        end
+
+        function start(obj)
+            %START Kick off the application workflow.
+            %   START(obj) delegates to CONTROLLER.RUN which is expected to
+            %   coordinate calls between MODEL and VIEW. Any
+            %   `reg:mvc:NotImplemented` errors from stub components will
+            %   surface here.
+            obj.Controller.run();
+        end
+    end
+end

--- a/+reg/+mvc/BaseController.m
+++ b/+reg/+mvc/BaseController.m
@@ -1,0 +1,40 @@
+classdef BaseController < handle
+    %BASECONTROLLER Mediates between models and views in reg MVC.
+    %   Controllers coordinate application logic: they ask a model to
+    %   `load` and `process` data then pass the result to a view for
+    %   presentation. This mirrors the legacy `reg_pipeline` script which
+    %   sequentially loaded data, transformed it and printed reports.
+
+    properties
+        % Underlying model providing data
+        Model
+        % View responsible for presentation
+        View
+    end
+
+    methods
+        function obj = BaseController(model, view)
+            %BASECONTROLLER Construct controller wiring a model to a view.
+            %   OBJ = BASECONTROLLER(MODEL, VIEW) stores handles to MODEL
+            %   and VIEW. Subclasses may extend the constructor with
+            %   additional configuration. Typical usage:
+            %   MODEL = reg.model.SomeModel();
+            %   VIEW  = reg.view.SomeView();
+            %   CTLR  = reg.controller.SomeController(MODEL, VIEW);
+            %   CTLR.run();  % see `reg_pipeline` for a full example
+            if nargin > 0
+                obj.Model = model;
+                obj.View = view;
+            end
+        end
+
+        function run(obj) %#ok<MANU>
+            %RUN Execute controller workflow.
+            %   RUN(obj) should orchestrate calls to MODEL.LOAD,
+            %   MODEL.PROCESS and VIEW.DISPLAY. Subclasses implement
+            %   application-specific control flow.
+            error('reg:mvc:NotImplemented', ...
+                'Controllers must override run to execute workflows.');
+        end
+    end
+end

--- a/+reg/+mvc/BaseModel.m
+++ b/+reg/+mvc/BaseModel.m
@@ -1,0 +1,31 @@
+classdef BaseModel < handle
+    %BASEMODEL Abstract data model for the reg MVC framework.
+    %   Subclasses implement specific data acquisition and transformation
+    %   responsibilities. Controllers invoke the lifecycle methods in the
+    %   order `load` then `process`, mirroring the legacy `reg_pipeline`
+    %   script which first gathered raw inputs before generating
+    %   artefacts.
+
+    methods
+        function data = load(obj, varargin) %#ok<INUSD>
+            %LOAD Retrieve raw application data.
+            %   DATA = LOAD(obj) should collect information from files,
+            %   databases or external services. Implementations may accept
+            %   optional parameters via VARARGIN to specialise data
+            %   acquisition. The returned DATA is then forwarded to
+            %   `process` for transformation.
+            error('reg:mvc:NotImplemented', ...
+                'Models must override load to gather raw data.');
+        end
+
+        function result = process(obj, data) %#ok<INUSD>
+            %PROCESS Convert raw data into domain specific results.
+            %   RESULT = PROCESS(obj, DATA) receives the output of `load`
+            %   and transforms it into the form expected by controllers and
+            %   views. For example, in `reg_pipeline` a model may load text
+            %   chunks and process them into embeddings.
+            error('reg:mvc:NotImplemented', ...
+                'Models must override process to transform data.');
+        end
+    end
+end

--- a/+reg/+mvc/BaseView.m
+++ b/+reg/+mvc/BaseView.m
@@ -1,0 +1,19 @@
+classdef BaseView < handle
+    %BASEVIEW Presentation layer for the reg MVC framework.
+    %   Views render processed data produced by models. Controllers
+    %   orchestrate the flow and hand results to a view via `display`,
+    %   similar to how `reg_pipeline` produced textual summaries or
+    %   visualisations for inspection.
+
+    methods
+        function display(obj, data) %#ok<INUSD>
+            %DISPLAY Render processed results to an audience.
+            %   DISPLAY(obj, DATA) should present DATA to a user or external
+            %   system. Implementations may generate plots, print to the
+            %   command window or persist artefacts. Subclasses decide what
+            %   DATA represents.
+            error('reg:mvc:NotImplemented', ...
+                'Views must override display to present results.');
+        end
+    end
+end

--- a/+reg/+mvc/ExampleController.m
+++ b/+reg/+mvc/ExampleController.m
@@ -1,0 +1,10 @@
+classdef ExampleController < reg.mvc.BaseController
+    %EXAMPLECONTROLLER Minimal controller demonstrating BaseController usage.
+    %   Used in tests to exercise stub behavior.
+    methods
+        function obj = ExampleController(model, view)
+            %EXAMPLECONTROLLER Construct example controller wiring model and view.
+            obj@reg.mvc.BaseController(model, view);
+        end
+    end
+end

--- a/+reg/+mvc/ExampleModel.m
+++ b/+reg/+mvc/ExampleModel.m
@@ -1,0 +1,4 @@
+classdef ExampleModel < reg.mvc.BaseModel
+    %EXAMPLEMODEL Minimal model demonstrating BaseModel usage.
+    %   Used in tests to exercise stub behavior.
+end

--- a/+reg/+mvc/ExampleView.m
+++ b/+reg/+mvc/ExampleView.m
@@ -1,0 +1,4 @@
+classdef ExampleView < reg.mvc.BaseView
+    %EXAMPLEVIEW Minimal view demonstrating BaseView usage.
+    %   Used in tests to exercise stub behavior.
+end


### PR DESCRIPTION
## Summary
- add BaseModel, BaseView, and BaseController with documentation and NotImplemented stubs
- include simple Application and Example MVC classes to facilitate tests

## Testing
- `matlab -batch "runtests({'tests/TestMVCUnit.m','tests/TestMVCIntegration.m','tests/TestMVCSystem.m'})"` *(fails: command not found)*
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689e509471a4833098ce813c27dcafa6