### PR TITLE
Clarify controller run workflows and data flow

### DIFF
--- a/+reg/+controller/EvalController.m
+++ b/+reg/+controller/EvalController.m
@@ -21,14 +21,35 @@ classdef EvalController < reg.mvc.BaseController
 
         function run(obj)
             %RUN Execute evaluation and reporting pipeline.
-            %   RUN(obj) loads data, computes metrics, logs them and
-            %   displays a report. Equivalent to `reg_eval_and_report`.
-            evalRaw = obj.EvaluationModel.load(); %#ok<NASGU>
-            metrics = obj.EvaluationModel.process([]); %#ok<NASGU>
-            logRaw = obj.LoggingModel.load(); %#ok<NASGU>
-            obj.LoggingModel.process([]);
-            repRaw = obj.ReportModel.load(); %#ok<NASGU>
-            reportData = obj.ReportModel.process([]); %#ok<NASGU>
+            %   RUN(obj) orchestrates metric computation, persistence and
+            %   report rendering.
+            %
+            %   Preconditions
+            %       * EvaluationModel supplies predictions and gold labels
+            %       * LoggingModel has write access to metrics store
+            %       * ReportModel expects a metrics struct
+            %   Side Effects
+            %       * Metrics appended to history (e.g., CSV)
+            %       * Summary report displayed via associated view
+            %
+            %   Legacy mapping:
+            %       Step 1 ↔ `eval_retrieval`
+            %       Step 2 ↔ `log_metrics`
+            %       Step 3 ↔ report generation in `reg_eval_and_report`
+
+            % Step 1: load evaluation inputs and compute metrics
+            evalRaw = obj.EvaluationModel.load();
+            metrics = obj.EvaluationModel.process(evalRaw);  % `eval_retrieval`
+
+            % Step 2: persist metrics using logging model
+            %   LoggingModel should validate schema and handle IO errors.
+            logRaw = obj.LoggingModel.load(metrics);
+            obj.LoggingModel.process(logRaw);  % `log_metrics`
+
+            % Step 3: assemble and render report from metrics
+            %   ReportModel is expected to verify metric fields.
+            repRaw = obj.ReportModel.load(metrics);
+            reportData = obj.ReportModel.process(repRaw);
             obj.View.display(reportData);
         end
     end

--- a/+reg/+controller/SyncController.m
+++ b/+reg/+controller/SyncController.m
@@ -25,13 +25,28 @@ classdef SyncController < reg.mvc.BaseController
 
         function out = run(obj, date)
             %RUN Execute synchronization for a given date.
-            %   OUT = RUN(obj, date) calls the underlying sync function and
-            %   passes the resulting struct to the view. Equivalent to
-            %   invoking `reg_crr_sync`.
+            %   OUT = RUN(obj, date) delegates to a sync routine and
+            %   forwards results to the view.
+            %
+            %   Preconditions
+            %       * SyncFunction accepts a 'Date' parameter
+            %   Side Effects
+            %       * May create or update local files and databases
+            %       * Displays summary via view
+            %
+            %   Legacy mapping: invokes `reg_crr_sync`
+
+            % Step 1: determine target date (defaults to today)
             if nargin < 2 || isempty(date)
                 date = datestr(now, 'yyyymmdd');
             end
+
+            % Step 2: perform synchronization via legacy routine
+            %   SyncFunction should validate the date format and handle
+            %   network or IO errors internally.
             out = obj.SyncFunction('Date', date);
+
+            % Step 3: display sync summary
             obj.View.display(out);
         end
     end


### PR DESCRIPTION
## Summary
- expand `run` method docstrings across controllers with preconditions, side effects, and legacy function references
- replace empty placeholders with outputs from prior steps and annotate data flow and error-handling expectations
- note interactions between models during evaluation, projection head training, sync, and pipeline execution

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e5d28099c8330baeaf747025a6aef