### PR TITLE
docs: clarify view data contracts

### DIFF
--- a/+reg/+view/MetricsView.m
+++ b/+reg/+view/MetricsView.m
@@ -1,16 +1,34 @@
 classdef MetricsView < reg.mvc.BaseView
-    %METRICSVIEW Stub view for presenting metrics.
-    
+    %METRICSVIEW Stub view for presenting metrics produced by controllers.
+    %   Expected fields in DATA include:
+    %       * overall  - struct of aggregate scores (RecallAtK, mAP, etc.)
+    %       * perLabel - table of metrics per label or class
+    %       * history  - optional arrays of metric values over time
+    %   Controllers such as ProjectionHeadController or FineTuneController
+    %   pass this view the metrics struct. A full implementation might log
+    %   these values, plot progress charts or render HTML tables.
+
     properties
         DisplayedMetrics
+
+        % Placeholder for future customisation hook ----------------------
+        OnDisplayCallback   % function handle executed after metrics stored
     end
-    
+
     methods
         function display(obj, data)
             %DISPLAY Store metrics for verification.
-            %   DISPLAY(obj, data) captures metric structures for later
-            %   inspection. Returns nothing. Equivalent to `log_metrics`.
+            %   DISPLAY(obj, DATA) captures metric structures for later
+            %   inspection. In a production view:
+            %       * overall scores could be printed or persisted to CSV
+            %       * perLabel tables might be turned into bar charts
+            %       * history arrays would feed trend plots
+            %   If OnDisplayCallback is set, it is invoked with DATA.
+
             obj.DisplayedMetrics = data;
+            if ~isempty(obj.OnDisplayCallback)
+                obj.OnDisplayCallback(data);
+            end
         end
     end
 end

--- a/+reg/+view/ReportView.m
+++ b/+reg/+view/ReportView.m
@@ -1,20 +1,37 @@
 classdef ReportView < reg.mvc.BaseView
-    %REPORTVIEW Stub view for rendering reports.
-    
+    %REPORTVIEW Stub view for rendering evaluation reports.
+    %   Expects a struct DATA with fields describing report content:
+    %       * summaryTables - table or cell array summarising overall metrics
+    %       * irbSubset     - subset of predictions flagged for IRB review
+    %       * trendCharts   - chart objects or file paths showing metric trends
+    %       * (optional) metric arrays or other artefacts to embed
+    %   Typical usage: PipelineController or EvalController assembles DATA
+    %   after running the pipeline and passes it to this view. A production
+    %   implementation would format tables into HTML/PDF, persist IRB subsets
+    %   to CSV for audit, and embed trend charts as images.
+
     properties
         DisplayedData
         SummaryTables
         IRBSubset
         TrendCharts
+
+        % Placeholders for future customisation hooks --------------------
+        TemplateName = "default_report"   % allows switching rendering templates
+        PostRenderCallback                 % optional callback executed after display
     end
 
     methods
         function display(obj, data)
-            %DISPLAY Store report data for verification and expose key
-            %evaluation sections for tests.
-            %   DISPLAY(obj, data) keeps summary tables, IRB subsets and
-            %   trend charts for inspection. Returns nothing. Equivalent to
-            %   rendering in `generate_reg_report`.
+            %DISPLAY Store report data for verification and expose key sections.
+            %   DISPLAY(obj, DATA) retains summary tables, IRB subsets and
+            %   trend charts for inspection. In a real view:
+            %       * summaryTables would be rendered to HTML/Markdown
+            %       * irbSubset could be written to a CSV for manual review
+            %       * trendCharts might be saved as PNG and embedded
+            %   Additional metric arrays would be handled similarly.
+            %   If PostRenderCallback is defined it is invoked with DATA.
+
             obj.DisplayedData = data;
             if isstruct(data) && isfield(data, 'summaryTables')
                 obj.SummaryTables = data.summaryTables;
@@ -25,6 +42,11 @@ classdef ReportView < reg.mvc.BaseView
             if isstruct(data) && isfield(data, 'trendCharts')
                 obj.TrendCharts = data.trendCharts;
             end
+
+            if ~isempty(obj.PostRenderCallback)
+                obj.PostRenderCallback(data);
+            end
         end
     end
 end
+


### PR DESCRIPTION
## Summary
- document expected report fields and add hooks in `ReportView`
- expand `MetricsView` documentation and allow display callbacks

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e5fbcffd083309f1558dcdf85dfb5