### PR TITLE
Document Pair and Triplet helpers

### DIFF
--- a/+reg/+model/Pair.m
+++ b/+reg/+model/Pair.m
@@ -1,16 +1,26 @@
 classdef Pair
-    %PAIR Represents a pair of indices and label for contrastive learning.
+    %PAIR Data container for a sample index pair with optional label.
+    %   Mirrors the pair structures produced by `reg.build_pairs` and consumed
+    %   by projection head training.
+    %
+    %   Example:
+    %       p = reg.model.Pair(10, 20, 1);
+    %       disp(p.Label);   % -> 1
+    %
     properties
+        % A — integer index of the first sample
         A
+        % B — integer index of the second sample
         B
+        % Label — optional numeric relationship label (e.g., 1 for positive)
         Label
     end
     methods
         function obj = Pair(a, b, label)
             %PAIR Construct a contrastive pair.
             %   OBJ = PAIR(a, b, label) creates a pair of indices A and B
-            %   with optional label. Returns a reg.model.Pair instance.
-            %   Equivalent to pair creation in `build_pairs`.
+            %   with optional label. Equivalent to pair creation in
+            %   `build_pairs`.
             if nargin > 0
                 obj.A = a;
                 obj.B = b;

--- a/+reg/+model/Triplet.m
+++ b/+reg/+model/Triplet.m
@@ -1,17 +1,25 @@
 classdef Triplet
-    %TRIPLET Represents an anchor, positive, negative indices for contrastive learning.
+    %TRIPLET Data container for an anchor, positive and negative index.
+    %   Mirrors the triplet structures produced by `reg.ft_build_contrastive_dataset`.
+    %
+    %   Example:
+    %       t = reg.model.Triplet(1, 2, 3);
+    %       disp(t.Anchor);   % -> 1
+    %
     properties
+        % Anchor — integer index of the anchor sample in the embedding matrix
         Anchor
+        % Positive — integer index of the positive sample
         Positive
+        % Negative — integer index of the negative sample
         Negative
     end
     methods
         function obj = Triplet(anchor, positive, negative)
             %TRIPLET Construct a contrastive triplet.
-            %   OBJ = TRIPLET(anchor, positive, negative) creates a
-            %   Triplet object with indices for anchor, positive and
-            %   negative examples. Equivalent to triplet creation in
-            %   `ft_build_contrastive_dataset`.
+            %   OBJ = TRIPLET(anchor, positive, negative) creates a Triplet
+            %   object with indices for anchor, positive and negative examples.
+            %   Equivalent to triplet creation in `ft_build_contrastive_dataset`.
             if nargin > 0
                 obj.Anchor = anchor;
                 obj.Positive = positive;


### PR DESCRIPTION
## Summary
- clarify Triplet helper with property comments, usage example, and reference to `reg.ft_build_contrastive_dataset`
- document Pair helper with property descriptions, example usage, and reference to `reg.build_pairs`

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e624785ec8330a2dfaedd5f989c35