### PR TITLE
Add toolbox license checks and prerequisites

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -4,6 +4,15 @@ classdef Application < handle
     %   provided controller's `run` method. The flow mirrors launching
     %   `reg_pipeline` where data is loaded, processed and then displayed.
 
+    % Mandatory MATLAB toolboxes for running the pipeline:
+    % - Text Analytics Toolbox
+    % - Deep Learning Toolbox
+    % - Statistics and Machine Learning Toolbox
+    % - Database Toolbox
+    % - Parallel Computing Toolbox
+    % - MATLAB Report Generator
+    % - Computer Vision Toolbox
+
     properties
         Model
         View
@@ -24,11 +33,42 @@ classdef Application < handle
 
         function start(obj)
             %START Kick off the application workflow.
-            %   START(obj) delegates to CONTROLLER.RUN which is expected to
-            %   coordinate calls between MODEL and VIEW. Any
-            %   `reg:mvc:NotImplemented` errors from stub components will
-            %   surface here.
+            %   Validates required toolbox licenses before delegating to
+            %   CONTROLLER.RUN which is expected to coordinate calls between
+            %   MODEL and VIEW. Any `reg:mvc:NotImplemented` errors from
+            %   stub components will surface here.
+
+            requiredToolboxes = {
+                'Text Analytics Toolbox',        'Text_Analytics_Toolbox';
+                'Deep Learning Toolbox',         'Deep_Learning_Toolbox';
+                'Statistics and Machine Learning Toolbox', 'Statistics_and_Machine_Learning_Toolbox';
+                'Database Toolbox',              'Database_Toolbox';
+                'Parallel Computing Toolbox',    'Parallel_Computing_Toolbox';
+                'MATLAB Report Generator',       'MATLAB_Report_Generator';
+                'Computer Vision Toolbox',       'Computer_Vision_Toolbox'
+            };
+            assertToolboxes(requiredToolboxes);
+
             obj.Controller.run();
         end
+    end
+end
+
+function assertToolboxes(requiredToolboxes)
+%ASSERTTOOLBOXES Ensure all required toolbox licenses are available.
+%   ASSERTTOOLBOXES(REQUIREDTOOLBOXES) tests each toolbox license and
+%   raises an error listing any missing toolboxes.
+
+    missing = {};
+    for i = 1:size(requiredToolboxes, 1)
+        displayName = requiredToolboxes{i,1};
+        licenseName = requiredToolboxes{i,2};
+        if ~license('test', licenseName)
+            missing{end+1} = displayName; %#ok<AGROW>
+        end
+    end
+
+    if ~isempty(missing)
+        error('Missing required MATLAB toolbox license(s): %s', strjoin(missing, ', '));
     end
 end

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ End-to-end MATLAB project for ingesting banking regulations (PDFs), chunking, we
 multi-label training, hybrid retrieval, and reporting. Includes a full MATLAB Test suite and a DB
 test using SQLite (no external server required).
 
+## Prerequisites
+This project requires MATLAB with the following toolboxes:
+- Text Analytics Toolbox
+- Deep Learning Toolbox
+- Statistics and Machine Learning Toolbox
+- Database Toolbox
+- Parallel Computing Toolbox
+- MATLAB Report Generator
+- Computer Vision Toolbox
+
 ## Layout
 - `pipeline.json` — pipeline-wide settings (input dir, backend, DB, etc.)
 - `config.m` — loads defaults from JSON (labels, chunking, DB, etc.)


### PR DESCRIPTION
## Summary
- document required MATLAB toolboxes in Application component
- assert availability of mandatory toolboxes at startup
- list toolboxes in README prerequisites

## Testing
- `matlab -batch "results=runtests('tests','IncludeSubfolders',true,'UseParallel',false); disp(table(results));"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689e75cc065883308b8a6223d7496437