### PR TITLE
docs: describe legacy edge cases in mvc stubs

### DIFF
--- a/+reg/+controller/ProjectionHeadController.m
+++ b/+reg/+controller/ProjectionHeadController.m
@@ -55,6 +55,14 @@ classdef ProjectionHeadController < reg.mvc.BaseController
 
             % Step 5: train projection head using triplets
             %   Model should check dimensions and raise if triplets malformed.
+            %   Potential Failure Modes
+            %       * GPU out-of-memory during training batches.
+            %       * Triplet indices outside embedding range.
+            %       * Diverging loss due to extreme hyper‑parameters.
+            %   Mitigation
+            %       * Catch errors and retry on CPU or with reduced batch size.
+            %       * Validate triplet indices before invoking the model.
+            %       * Expose learning-rate and margin safeguards.
             headRaw = obj.ProjectionHeadModel.load(triplets);
             projE = obj.ProjectionHeadModel.process(headRaw);
 

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -33,10 +33,17 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %       Equivalent to `ensure_db` connection setup.
             %   Extension Point
             %       Override to use different database drivers or pools.
+            %   Edge Cases
+            %       * Credentials may be invalid or server unreachable.
+            %       * Connection reuse can leak handles if not closed.
+            %   Recommended Mitigation
+            %       * Implement retry/backoff and surface meaningful errors.
+            %       * Ensure existing connections are cleaned before opening new ones.
             % Pseudocode:
             %   1. If obj.conn is open, close it
             %   2. Create new connection using dbConfig
             %   3. Store handle in obj.conn and return struct
+            % TODO: add connection validation and retry logic
             error("reg:model:NotImplemented", ...
                 "DatabaseModel.load is not implemented.");
         end
@@ -57,10 +64,21 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %       Equivalent to `ensure_db` persistence.
             %   Extension Point
             %       Inject custom transaction handling or batching.
+            %   Edge Cases
+            %       * Target table may lack required `lbl_*`/`score_*` columns and
+            %         need ALTER TABLE statements similar to `upsert_chunks`.
+            %       * Concurrent writes can lead to conflicts or partial upserts.
+            %       * SQL errors may leave transactions open.
+            %   Recommended Mitigation
+            %       * Wrap writes in transactions with rollback on failure.
+            %       * Use parameterized queries to avoid injection and ensure
+            %         proper escaping.
+            %       * Provide idempotent retry logic for transient failures.
             % Pseudocode:
             %   1. Begin transaction on obj.conn
             %   2. Upsert rows from predictionTable into reg_chunks
             %   3. Commit or rollback transaction and close connection if done
+            % TODO: implement transactional upsert and conflict handling
             error("reg:model:NotImplemented", ...
                 "DatabaseModel.process is not implemented.");
         end

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -31,10 +31,18 @@ classdef PDFIngestModel < reg.mvc.BaseModel
             %       Equivalent to `ingest_pdfs` file discovery.
             %   Extension Point
             %       Override to support remote storage or filtering.
+            %   Edge Cases
+            %       * Directory may not exist or be empty.
+            %       * Filenames with special characters can break downstream
+            %         parsing.
+            %   Recommended Mitigation
+            %       * Validate inputDir and warn/raise when no PDFs found.
+            %       * Sanitize or normalize filenames before returning.
             % Pseudocode:
             %   1. Scan inputDir for *.pdf files
             %   2. Sort or filter list as needed
             %   3. Return pdfFiles
+            % TODO: implement checks for empty results and path validation
             error("reg:model:NotImplemented", ...
                 "PDFIngestModel.load is not implemented.");
         end
@@ -52,10 +60,20 @@ classdef PDFIngestModel < reg.mvc.BaseModel
             %       Equivalent to `ingest_pdfs`.
             %   Extension Point
             %       Hook to inject custom parsers or metadata extraction.
+            %   Edge Cases
+            %       * `extractFileText` can throw and force an OCR fallback.
+            %       * OCR may still fail or produce very short text.
+            %       * When no PDFs are available a dummy document is returned.
+            %   Recommended Mitigation
+            %       * Wrap text extraction with retries and detailed logging.
+            %       * Allow caller to opt out of dummy document creation.
+            %       * Normalize whitespace and enforce minimum length before
+            %         accepting text.
             % Pseudocode:
             %   1. Loop over pdfFiles and extract text
             %   2. Assemble document metadata into table rows
             %   3. Return documentsTable
+            % TODO: implement OCR fallback and dummy-document safeguards
             error("reg:model:NotImplemented", ...
                 "PDFIngestModel.process is not implemented.");
         end

--- a/+reg/+model/ProjectionHeadModel.m
+++ b/+reg/+model/ProjectionHeadModel.m
@@ -31,9 +31,18 @@ classdef ProjectionHeadModel < reg.mvc.BaseModel
             %       Equivalent to `train_projection_head` data loading.
             %   Extension Point
             %       Override to fetch embeddings from external services.
+            %   Edge Cases
+            %       * Stored embeddings may be missing or have unexpected
+            %         dimensionality.
+            %       * Data might already be on GPU or require conversion.
+            %   Recommended Mitigation
+            %       * Validate size/normalization before returning.
+            %       * Gracefully fallback to CPU when GPU tensors cannot be
+            %         transferred.
             % Pseudocode:
             %   1. Read existing embeddings from storage
             %   2. Return as embeddingsMatrix
+            % TODO: verify dimensionality and implement CPU/GPU transfer logic
             error("reg:model:NotImplemented", ...
                 "ProjectionHeadModel.load is not implemented.");
         end
@@ -51,10 +60,19 @@ classdef ProjectionHeadModel < reg.mvc.BaseModel
             %       Equivalent to `train_projection_head`.
             %   Extension Point
             %       Replace with custom projection architectures.
+            %   Edge Cases
+            %       * GPU memory exhaustion during batch training.
+            %       * Triplet indices out of range or containing NaNs.
+            %       * Loss may diverge with poor hyper‑parameters.
+            %   Recommended Mitigation
+            %       * Catch GPU errors and retry on CPU with smaller batches.
+            %       * Validate triplet structures before optimization.
+            %       * Clip gradients and surface warnings when loss explodes.
             % Pseudocode:
             %   1. Initialize projection head parameters
             %   2. Multiply embeddingsMatrix by projection weights
             %   3. Return projectedEmbeddings
+            % TODO: implement GPU fallback and input validation
             error("reg:model:NotImplemented", ...
                 "ProjectionHeadModel.process is not implemented.");
         end


### PR DESCRIPTION
## Summary
- document error conditions for PDF ingestion, projection head training, and database upserts
- add TODO markers in model stubs for recovery logic and validation
- outline potential failure modes in projection and pipeline controllers

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ede7ca0048330a54cd5b3db8687a8