### PR TITLE
refactor: centralize configuration

### DIFF
--- a/+reg/+model/ClassifierModel.m
+++ b/+reg/+model/ClassifierModel.m
@@ -2,17 +2,17 @@ classdef ClassifierModel < reg.mvc.BaseModel
     %CLASSIFIERMODEL Stub model training classifiers and predicting labels.
 
     properties
-        % Structure containing classifier configuration (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ClassifierModel(config)
+        function obj = ClassifierModel(cfg)
             %CLASSIFIERMODEL Construct classifier model.
-            %   OBJ = CLASSIFIERMODEL(config) sets classifier parameters.
-            %   Equivalent to initialization in `predict_multilabel`.
+            %   OBJ = CLASSIFIERMODEL(cfg) uses shared configuration
+            %   parameters, e.g. cfg.kfold or cfg.minRuleConf.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/ConfigModel.m
+++ b/+reg/+model/ConfigModel.m
@@ -1,60 +1,124 @@
 classdef ConfigModel < reg.mvc.BaseModel
-    %CONFIGMODEL Stub model retrieving configuration parameters.
+    %CONFIGMODEL Centralised configuration shared across models.
 
     properties
-        % Configuration settings loaded from knobs.json (default: struct())
-        config = struct();
+        % Directory containing source PDF documents
+        inputDir string = "data/pdfs";
+
+        % Flag indicating whether GPU acceleration is allowed
+        gpuEnabled logical = true;
+
+        % === Chunking ===
+        % Number of tokens per text chunk
+        chunkSizeTokens double = 300;
+        % Overlap in tokens between consecutive chunks
+        chunkOverlap double = 80;
+
+        % === BERT embedding ===
+        % Mini-batch size for BERT embeddings
+        bertMiniBatchSize double = 96;
+        % Maximum sequence length for BERT model inputs
+        bertMaxSeqLength double = 256;
+
+        % === Projection head ===
+        % Dimensionality of projected embeddings
+        projDim double = 384;
+        % Number of epochs to train the projection head
+        projEpochs double = 5;
+        % Training mini-batch size for projection head
+        projBatchSize double = 768;
+        % Learning rate for projection head optimiser
+        projLR double = 1e-3;
+        % Margin used in triplet loss during projection training
+        projMargin double = 0.2;
+
+        % === Encoder fine-tuning ===
+        % Loss function for encoder fine-tuning
+        fineTuneLoss string = "triplet";
+        % Mini-batch size during encoder fine-tuning
+        fineTuneBatchSize double = 32;
+        % Maximum sequence length for fine-tuning inputs
+        fineTuneMaxSeqLength double = 256;
+        % Number of top encoder layers to unfreeze
+        fineTuneUnfreezeTopLayers double = 4;
+        % Epochs for encoder fine-tuning
+        fineTuneEpochs double = 4;
+        % Learning rate applied to encoder weights
+        fineTuneEncoderLR double = 1e-5;
+        % Learning rate applied to added head parameters
+        fineTuneHeadLR double = 1e-3;
+
+        % === Miscellaneous ===
+        % Minimum confidence to accept weak rule labels
+        minRuleConf double = 0.7;
+        % Number of folds for cross-validation
+        kfold double = 5;
+        % Number of latent Dirichlet allocation topics
+        ldaTopics double = 12;
+        % Title used in generated reports
+        reportTitle string = "Banking Regulation Topic Classifier — Snapshot";
+        % Database connection settings
+        db struct = struct('enable', false, 'vendor','postgres', ...
+            'dbname','reg_topics', 'user','user', 'pass','pass', ...
+            'server','localhost', 'port',5432, ...
+            'sqlitePath','./data/db/my_reg_topics.sqlite');
     end
 
     methods
-        function obj = ConfigModel(config)
-            %CONFIGMODEL Construct configuration model.
-            %   OBJ = CONFIGMODEL(config) stores configuration parameters.
-            %   Equivalent to initialization in `load_knobs`.
+        function obj = ConfigModel(args)
+            %CONFIGMODEL Construct configuration model with overrides.
+            %   OBJ = CONFIGMODEL(args) accepts a struct of fields to
+            %   override defaults defined as properties above.
             if nargin > 0
-                obj.config = config;
+                f = fieldnames(args);
+                for i = 1:numel(f)
+                    if isprop(obj, f{i})
+                        obj.(f{i}) = args.(f{i});
+                    end
+                end
+            end
+        end
+
+        function validatePaths(obj)
+            %VALIDATEPATHS Ensure required file system paths exist.
+            %   VALIDATEPATHS(obj) throws when mandatory paths are missing.
+            if ~isfolder(obj.inputDir)
+                error("reg:model:InvalidPath", ...
+                    "Input directory not found: %s", obj.inputDir);
+            end
+        end
+
+        function validateGPUAvailability(obj)
+            %VALIDATEGPUAVAILABILITY Confirm GPU can be used when requested.
+            %   VALIDATEGPUAVAILABILITY(obj) errors if gpuEnabled is true
+            %   but no GPU device is present.
+            if obj.gpuEnabled && exist('gpuDeviceCount','file') == 2
+                if gpuDeviceCount == 0
+                    error("reg:model:NoGPU", ...
+                        "Configuration requests GPU but none available.");
+                end
+            elseif obj.gpuEnabled
+                error("reg:model:NoGPU", ...
+                    "GPU support is not available in this environment.");
             end
         end
 
         function cfgStruct = load(~, varargin) %#ok<INUSD>
             %LOAD Retrieve configuration from source.
             %   cfgStruct = LOAD(obj) reads knob settings.
-            %   Parameters
-            %       varargin - Placeholder for future options (unused)
-            %   Returns
-            %       cfgStruct (struct): Key/value pairs of configuration.
-            %   Side Effects
-            %       None.
-            %   Legacy Reference
-            %       Equivalent to `load_knobs`.
-            %   Extension Point
-            %       Override to pull configuration from remote stores.
-            % Pseudocode:
-            %   1. Read knobs.json from disk
-            %   2. Decode JSON into struct cfgStruct
-            %   3. Return cfgStruct to caller
+            %   This stub retains legacy semantics of `load_knobs` and
+            %   should be overridden by concrete implementations.
             error("reg:model:NotImplemented", ...
                 "ConfigModel.load is not implemented.");
         end
+
         function validatedCfg = process(~, cfgStruct) %#ok<INUSD>
             %PROCESS Validate configuration values.
             %   validatedCfg = PROCESS(obj, cfgStruct) performs sanity checks.
-            %   Parameters
-            %       cfgStruct (struct): Configuration to validate.
-            %   Returns
-            %       validatedCfg (struct): Sanitized configuration.
-            %   Side Effects
-            %       May log warnings for missing fields.
-            %   Legacy Reference
-            %       Equivalent to `validate_knobs`.
-            %   Extension Point
-            %       Extend to enforce custom validation rules.
-            % Pseudocode:
-            %   1. Verify required fields exist in cfgStruct
-            %   2. Fill defaults for missing values
-            %   3. Return validatedCfg
+            %   Override in subclasses to apply custom validation logic.
             error("reg:model:NotImplemented", ...
                 "ConfigModel.process is not implemented.");
         end
     end
 end
+

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -5,17 +5,17 @@ classdef DatabaseModel < reg.mvc.BaseModel
         % Database connection handle created in `load` (default: [])
         conn = [];
 
-        % Database configuration structure (default: struct())
-        dbConfig = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = DatabaseModel(dbConfig)
+        function obj = DatabaseModel(cfg)
             %DATABASEMODEL Construct database model.
-            %   OBJ = DATABASEMODEL(dbConfig) stores DB configuration for
-            %   later use. Equivalent to initialization in `ensure_db`.
+            %   OBJ = DATABASEMODEL(cfg) uses database settings from
+            %   cfg.db.* such as cfg.db.enable or cfg.db.sqlitePath.
             if nargin > 0
-                obj.dbConfig = dbConfig;
+                obj.cfg = cfg;
             end
         end
 
@@ -41,7 +41,7 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %       * Ensure existing connections are cleaned before opening new ones.
             % Pseudocode:
             %   1. If obj.conn is open, close it
-            %   2. Create new connection using dbConfig
+            %   2. Create new connection using cfg.db parameters
             %   3. Store handle in obj.conn and return struct
             % TODO: add connection validation and retry logic
             error("reg:model:NotImplemented", ...

--- a/+reg/+model/EncoderFineTuneModel.m
+++ b/+reg/+model/EncoderFineTuneModel.m
@@ -2,18 +2,17 @@ classdef EncoderFineTuneModel < reg.mvc.BaseModel
     %ENCODERFINETUNEMODEL Stub model for encoder fine-tuning.
 
     properties
-        % Fine-tuning configuration (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = EncoderFineTuneModel(config)
+        function obj = EncoderFineTuneModel(cfg)
             %ENCODERFINETUNEMODEL Construct fine-tuning model.
-            %   OBJ = ENCODERFINETUNEMODEL(config) sets parameters for
-            %   encoder training. Equivalent to initialization in
-            %   `ft_train_encoder`.
+            %   OBJ = ENCODERFINETUNEMODEL(cfg) consumes parameters such as
+            %   cfg.fineTuneLoss or cfg.fineTuneBatchSize.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -2,17 +2,17 @@ classdef EvaluationModel < reg.mvc.BaseModel
     %EVALUATIONMODEL Stub model computing evaluation metrics.
 
     properties
-        % Evaluation configuration (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = EvaluationModel(config)
+        function obj = EvaluationModel(cfg)
             %EVALUATIONMODEL Construct evaluation model.
-            %   OBJ = EVALUATIONMODEL(config) stores evaluation options.
-            %   Equivalent to setup in `eval_retrieval`.
+            %   OBJ = EVALUATIONMODEL(cfg) provides access to evaluation
+            %   options held in cfg, such as cfg.labels.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -2,18 +2,17 @@ classdef FeatureModel < reg.mvc.BaseModel
     %FEATUREMODEL Stub model generating feature representations.
 
     properties
-        % Feature extraction configuration (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = FeatureModel(config)
+        function obj = FeatureModel(cfg)
             %FEATUREMODEL Construct feature extraction model.
-            %   OBJ = FEATUREMODEL(config) stores parameters for feature
-            %   generation. Equivalent to initialization in
-            %   `precompute_embeddings`.
+            %   OBJ = FEATUREMODEL(cfg) uses parameters such as
+            %   cfg.bertMiniBatchSize when computing embeddings.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/FineTuneDataModel.m
+++ b/+reg/+model/FineTuneDataModel.m
@@ -2,18 +2,17 @@ classdef FineTuneDataModel < reg.mvc.BaseModel
     %FINETUNEDATAMODEL Stub model building contrastive triplets.
 
     properties
-        % Settings for constructing fine-tuning data (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = FineTuneDataModel(config)
+        function obj = FineTuneDataModel(cfg)
             %FINETUNEDATAMODEL Construct contrastive data model.
-            %   OBJ = FINETUNEDATAMODEL(config) stores settings for
-            %   generating training triplets. Equivalent to
-            %   `ft_build_contrastive_dataset` setup.
+            %   OBJ = FINETUNEDATAMODEL(cfg) utilises fields such as
+            %   cfg.fineTuneLoss and cfg.fineTuneBatchSize.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/GoldPackModel.m
+++ b/+reg/+model/GoldPackModel.m
@@ -2,17 +2,17 @@ classdef GoldPackModel < reg.mvc.BaseModel
     %GOLDPACKMODEL Stub model providing labelled gold data.
 
     properties
-        % Configuration for gold data retrieval (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = GoldPackModel(config)
+        function obj = GoldPackModel(cfg)
             %GOLDPACKMODEL Construct gold data model.
-            %   OBJ = GOLDPACKMODEL(config) stores retrieval settings.
-            %   Equivalent to initialization in `load_gold`.
+            %   OBJ = GOLDPACKMODEL(cfg) reads paths such as cfg.inputDir
+            %   when locating packaged gold datasets.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/LoggingModel.m
+++ b/+reg/+model/LoggingModel.m
@@ -2,17 +2,17 @@ classdef LoggingModel < reg.mvc.BaseModel
     %LOGGINGMODEL Stub model for persisting metrics.
 
     properties
-        % Logging configuration such as file path or endpoint (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = LoggingModel(config)
+        function obj = LoggingModel(cfg)
             %LOGGINGMODEL Construct logging model.
-            %   OBJ = LOGGINGMODEL(config) stores logging configuration.
-            %   Equivalent to initialization in `log_metrics`.
+            %   OBJ = LOGGINGMODEL(cfg) uses settings such as cfg.reportTitle
+            %   or destination paths when recording metrics.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -2,18 +2,17 @@ classdef PDFIngestModel < reg.mvc.BaseModel
     %PDFINGESTMODEL Stub model converting PDFs to document table.
 
     properties
-        % Directory containing the PDF files to ingest (default: "")
-        inputDir = "";
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = PDFIngestModel(inputDir)
+        function obj = PDFIngestModel(cfg)
             %PDFINGESTMODEL Construct the ingest model.
-            %   OBJ = PDFINGESTMODEL(inputDir) creates a model pointing to the
-            %   directory containing PDF files. Equivalent to `ingest_pdfs`
-            %   initialization logic.
+            %   OBJ = PDFINGESTMODEL(cfg) consumes cfg.inputDir to locate
+            %   PDF files. Equivalent to `ingest_pdfs` initialization logic.
             if nargin > 0
-                obj.inputDir = inputDir;
+                obj.cfg = cfg;
             end
         end
 
@@ -36,10 +35,10 @@ classdef PDFIngestModel < reg.mvc.BaseModel
             %       * Filenames with special characters can break downstream
             %         parsing.
             %   Recommended Mitigation
-            %       * Validate inputDir and warn/raise when no PDFs found.
+            %       * Validate cfg.inputDir and warn/raise when no PDFs found.
             %       * Sanitize or normalize filenames before returning.
             % Pseudocode:
-            %   1. Scan inputDir for *.pdf files
+            %   1. Scan cfg.inputDir for *.pdf files
             %   2. Sort or filter list as needed
             %   3. Return pdfFiles
             % TODO: implement checks for empty results and path validation

--- a/+reg/+model/ProjectionHeadModel.m
+++ b/+reg/+model/ProjectionHeadModel.m
@@ -2,18 +2,17 @@ classdef ProjectionHeadModel < reg.mvc.BaseModel
     %PROJECTIONHEADMODEL Stub model applying projection head to embeddings.
 
     properties
-        % Configuration for projection head (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ProjectionHeadModel(config)
+        function obj = ProjectionHeadModel(cfg)
             %PROJECTIONHEADMODEL Construct projection head model.
-            %   OBJ = PROJECTIONHEADMODEL(config) sets projection head
-            %   parameters. Equivalent to initialization in
-            %   `train_projection_head`.
+            %   OBJ = PROJECTIONHEADMODEL(cfg) uses parameters such as
+            %   cfg.projDim or cfg.gpuEnabled when training projection heads.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/ReportModel.m
+++ b/+reg/+model/ReportModel.m
@@ -2,17 +2,17 @@ classdef ReportModel < reg.mvc.BaseModel
     %REPORTMODEL Stub model assembling report data.
 
     properties
-        % Report generation configuration (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ReportModel(config)
+        function obj = ReportModel(cfg)
             %REPORTMODEL Construct report generation model.
-            %   OBJ = REPORTMODEL(config) stores reporting parameters.
-            %   Equivalent to initialization in `generate_reg_report`.
+            %   OBJ = REPORTMODEL(cfg) accesses values like cfg.reportTitle
+            %   when assembling output.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -2,17 +2,17 @@ classdef SearchIndexModel < reg.mvc.BaseModel
     %SEARCHINDEXMODEL Stub model building retrieval index.
 
     properties
-        % Configuration for building the search index (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = SearchIndexModel(config)
+        function obj = SearchIndexModel(cfg)
             %SEARCHINDEXMODEL Construct search index model.
-            %   OBJ = SEARCHINDEXMODEL(config) stores index configuration.
-            %   Equivalent to initialization in `upsert_chunks`.
+            %   OBJ = SEARCHINDEXMODEL(cfg) uses settings such as
+            %   cfg.gpuEnabled or cfg.projDim when creating indexes.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 

--- a/+reg/+model/TextChunkModel.m
+++ b/+reg/+model/TextChunkModel.m
@@ -2,18 +2,17 @@ classdef TextChunkModel < reg.mvc.BaseModel
     %TEXTCHUNKMODEL Stub model splitting documents into chunks.
 
     properties
-        % Number of tokens per chunk (default: 0)
-        chunkSizeTokens = 0;
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = TextChunkModel(chunkSizeTokens)
+        function obj = TextChunkModel(cfg)
             %TEXTCHUNKMODEL Construct text chunking model.
-            %   OBJ = TEXTCHUNKMODEL(chunkSizeTokens) defines the token
-            %   size for each chunk. Equivalent to configuration in
-            %   `chunk_text`.
+            %   OBJ = TEXTCHUNKMODEL(cfg) reads chunking parameters such as
+            %   cfg.chunkSizeTokens and cfg.chunkOverlap.
             if nargin > 0
-                obj.chunkSizeTokens = chunkSizeTokens;
+                obj.cfg = cfg;
             end
         end
 
@@ -52,7 +51,7 @@ classdef TextChunkModel < reg.mvc.BaseModel
             %       Customize chunk boundaries or overlapping logic.
             % Pseudocode:
             %   1. Tokenize each document
-            %   2. Break tokens into chunkSizeTokens segments
+            %   2. Break tokens into cfg.chunkSizeTokens segments
             %   3. Assemble chunksTable with metadata
             error("reg:model:NotImplemented", ...
                 "TextChunkModel.process is not implemented.");

--- a/+reg/+model/WeakLabelModel.m
+++ b/+reg/+model/WeakLabelModel.m
@@ -2,17 +2,17 @@ classdef WeakLabelModel < reg.mvc.BaseModel
     %WEAKLABELMODEL Stub model generating weak supervision labels.
 
     properties
-        % Configuration for weak labeling (default: struct())
-        config = struct();
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = WeakLabelModel(config)
+        function obj = WeakLabelModel(cfg)
             %WEAKLABELMODEL Construct weak labeling model.
-            %   OBJ = WEAKLABELMODEL(config) stores rules configuration.
-            %   Equivalent to initialization in `weak_rules`.
+            %   OBJ = WEAKLABELMODEL(cfg) uses configuration fields like
+            %   cfg.minRuleConf when applying heuristics.
             if nargin > 0
-                obj.config = config;
+                obj.cfg = cfg;
             end
         end
 


### PR DESCRIPTION
## Summary
- enumerate shared configuration parameters in `ConfigModel` with defaults
- reference shared config (`cfg`) across model stubs instead of ad-hoc fields
- add path and GPU validation helpers

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689ee16dc6bc833089cb062f3c63e106