### PR TITLE
feat: add CRR fetch model and diff controllers

### DIFF
--- a/+reg/+controller/DiffArticlesController.m
+++ b/+reg/+controller/DiffArticlesController.m
@@ -1,0 +1,56 @@
+classdef DiffArticlesController < reg.mvc.BaseController
+    %DIFFARTICLESCONTROLLER Article-aware diff of two CRR corpora.
+    %   Wraps `crr_diff_articles` and exposes a controller interface for
+    %   comparing two directories produced by `fetch_crr_eba_parsed`.
+
+    properties
+        DiffFunction
+    end
+
+    methods
+        function obj = DiffArticlesController(view, diffFunc)
+            %DIFFARTICLESCONTROLLER Construct controller with diff function.
+            %   OBJ = DIFFARTICLESCONTROLLER(view, diffFunc) sets the view
+            %   and function handle used for article-aware diffing. When
+            %   omitted, VIEW defaults to `reg.view.ReportView` and
+            %   DIFFFUNC defaults to `@reg.crr_diff_articles`.
+            if nargin < 1 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            if nargin < 2 || isempty(diffFunc)
+                diffFunc = @reg.crr_diff_articles;
+            end
+            obj@reg.mvc.BaseController([], view);
+            obj.DiffFunction = diffFunc;
+        end
+
+        function result = run(obj, dirA, dirB, outDir)
+            %RUN Compare CRR corpora by article number.
+            %   RESULT = RUN(obj, dirA, dirB, outDir) aligns articles using
+            %   the `index.csv` produced by `fetch_crr_eba_parsed` and
+            %   writes a CSV summary and a human-readable patch file.
+            %   Inputs
+            %       dirA, dirB (char/string): Directories each containing an
+            %           `index.csv` alongside article text files.
+            %       outDir (char/string): Optional directory for diff
+            %           artefacts. Default runs/crr_diff_articles.
+            %   Returns
+            %       result (struct): Counts of added, removed, changed and
+            %       same articles plus the output directory.
+            %   Errors
+            %       * Propagates any errors from the underlying diff
+            %         function, e.g. missing `index.csv` or unreadable
+            %         files.
+            %       * Creates `outDir`; failure to create it raises an
+            %         exception.
+            if nargin < 4 || isempty(outDir)
+                outDir = fullfile('runs', 'crr_diff_articles');
+            end
+            result = obj.DiffFunction(dirA, dirB, 'OutDir', outDir);
+            if ~isempty(obj.View)
+                obj.View.display(result);
+            end
+        end
+    end
+end
+

--- a/+reg/+controller/DiffVersionsController.m
+++ b/+reg/+controller/DiffVersionsController.m
@@ -1,0 +1,53 @@
+classdef DiffVersionsController < reg.mvc.BaseController
+    %DIFFVERSIONSCONTROLLER File-level diff of two CRR corpora.
+    %   Wraps `crr_diff_versions` and exposes a simple controller interface
+    %   for comparing two directories of plain text files.
+
+    properties
+        DiffFunction
+    end
+
+    methods
+        function obj = DiffVersionsController(view, diffFunc)
+            %DIFFVERSIONSCONTROLLER Construct controller with diff function.
+            %   OBJ = DIFFVERSIONSCONTROLLER(view, diffFunc) wires a view
+            %   and diff function. VIEW defaults to `reg.view.ReportView`
+            %   and DIFFFUNC defaults to `@reg.crr_diff_versions`.
+            if nargin < 1 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            if nargin < 2 || isempty(diffFunc)
+                diffFunc = @reg.crr_diff_versions;
+            end
+            obj@reg.mvc.BaseController([], view);
+            obj.DiffFunction = diffFunc;
+        end
+
+        function result = run(obj, dirA, dirB, outDir)
+            %RUN Diff directories on a file-by-file basis.
+            %   RESULT = RUN(obj, dirA, dirB, outDir) aligns plain text
+            %   files by name, records line-level changes and writes a CSV
+            %   summary plus a patch file.
+            %   Inputs
+            %       dirA, dirB (char/string): Directories containing `.txt`
+            %           files for comparison.
+            %       outDir (char/string): Optional output directory for
+            %           artefacts. Default runs/crr_diff.
+            %   Returns
+            %       result (struct): Counts of added, removed, changed and
+            %       same files plus the output directory.
+            %   Errors
+            %       * Propagates errors from the diff function such as
+            %         unreadable files.
+            %       * Directory creation failures raise exceptions.
+            if nargin < 4 || isempty(outDir)
+                outDir = fullfile('runs', 'crr_diff');
+            end
+            result = obj.DiffFunction(dirA, dirB, 'OutDir', outDir);
+            if ~isempty(obj.View)
+                obj.View.display(result);
+            end
+        end
+    end
+end
+

--- a/+reg/+model/CrrFetchModel.m
+++ b/+reg/+model/CrrFetchModel.m
@@ -1,0 +1,81 @@
+classdef CrrFetchModel < reg.mvc.BaseModel
+    %CRRFETCHMODEL Retrieve CRR corpora from public sources.
+    %   Encapsulates helper functions that download Capital Requirements
+    %   Regulation (CRR) documents from the EBA Interactive Single Rulebook
+    %   and the EUR‑Lex portal. The model exposes convenience methods for
+    %   fetching raw HTML/plaintext articles or the consolidated PDF.
+    %   Each method mirrors an existing procedural helper whilst providing
+    %   a documented entry point for controllers.
+
+    methods
+        function T = fetchEba(~, varargin)
+            %FETCHEBA Download CRR articles from the EBA Single Rulebook.
+            %   T = FETCHEBA(obj, Name, Value, ...) retrieves HTML and
+            %   plaintext versions of CRR articles using the legacy helper
+            %   `fetch_crr_eba`.
+            %   Parameters
+            %       'Timeout'     (double)  - HTTP timeout per request in
+            %                                  seconds. Default 15.
+            %       'MaxArticles' (double)  - Maximum number of articles to
+            %                                  download. Default Inf.
+            %   Returns
+            %       T (table): Metadata with columns `article_id`, `title`,
+            %       `url` and `html_file` describing downloaded artefacts.
+            %   Side Effects
+            %       * Writes HTML and plaintext files under
+            %         data/eba_isrb/crr.
+            %       * Persists an `index.csv` alongside the files.
+            %   Errors
+            %       * Network failures or write errors emit warnings and
+            %         return any successfully fetched articles.
+            %       * Interrupt exceptions are rethrown to allow graceful
+            %         termination.
+            T = reg.fetch_crr_eba(varargin{:});
+        end
+
+        function T = fetchEbaParsed(~, varargin)
+            %FETCHEBAPARSED Download CRR articles with parsed article numbers.
+            %   T = FETCHEBAPARSED(obj, Name, Value, ...) wraps
+            %   `fetch_crr_eba_parsed` which augments each article with a
+            %   parsed `article_num` identifier.
+            %   Parameters
+            %       'OutDir' (string/char) - Output directory for HTML,
+            %                               text and index files. Defaults
+            %                               to data/eba_isrb/crr.
+            %   Returns
+            %       T (table): Metadata including `article_id`, `article_num`,
+            %       `title`, `url` and `html_file`.
+            %   Side Effects
+            %       * Creates `OutDir` if it does not exist.
+            %       * Writes HTML/plaintext files and an `index.csv`.
+            %   Errors
+            %       * Download issues generate warnings; rows for failed
+            %         articles are omitted from the returned table.
+            %       * Directory creation problems propagate as errors.
+            T = reg.fetch_crr_eba_parsed(varargin{:});
+        end
+
+        function pdfPath = fetchEurlex(~, varargin)
+            %FETCHEURLEX Download consolidated CRR PDF from EUR‑Lex.
+            %   pdfPath = FETCHEURLEX(obj, Name, Value, ...) wraps
+            %   `fetch_crr_eurlex` which retrieves the consolidated CRR
+            %   regulation as a single PDF.
+            %   Parameters
+            %       'Date' (string/char) - Consolidation code in YYYYMMDD
+            %                              format identifying the desired
+            %                              version. Default 20250629.
+            %   Returns
+            %       pdfPath (string): Absolute path to the downloaded PDF
+            %       saved under data/raw.
+            %   Side Effects
+            %       * Creates the data/raw directory if needed and writes
+            %         the PDF file within it.
+            %   Errors
+            %       * Any network or file system failure results in an
+            %         error being thrown; callers should handle these to
+            %         recover or retry.
+            pdfPath = reg.fetch_crr_eurlex(varargin{:});
+        end
+    end
+end
+


### PR DESCRIPTION
## Summary
- add `CrrFetchModel` to wrap CRR fetching helpers
- introduce controllers for article and version diffs

## Testing
- `octave -qf run_smoke_test.m` *(command not found)*
- `apt-get update` *(repository not signed; unable to install Octave)*

------
https://chatgpt.com/codex/tasks/task_b_689ee8a21fa483308a1f4e609d9a3cce