### PR TITLE
feat: stub hybrid search query for SearchIndexModel

### DIFF
--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -58,5 +58,36 @@ classdef SearchIndexModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented", ...
                 "SearchIndexModel.process is not implemented.");
         end
+
+        function results = query(~, queryString, alpha, topK) %#ok<INUSD>
+            %QUERY Retrieve ranked documents using hybrid search.
+            %   results = QUERY(obj, queryString, alpha, topK) blends lexical
+            %   TF-IDF scores with semantic embedding similarity similar to
+            %   `reg.hybrid_search`.
+            %   Parameters
+            %       queryString (string): Raw text query to search.
+            %       alpha (double): Weight for TF-IDF versus embedding score
+            %           where 1 favors lexical matching and 0 favors semantic
+            %           matching.
+            %       topK (double): Maximum number of results to return.
+            %   Returns
+            %       results (table): Struct or table of top hits with fields
+            %           such as `row` and `score` representing document index
+            %           and blended relevance score.
+            %   Side Effects
+            %       None.
+            %   Legacy Reference
+            %       Mirrors S.query within `reg.hybrid_search`.
+            %   Extension Point
+            %       Override to use alternative ranking or scoring logic.
+            %   Pseudocode:
+            %       1. Tokenize queryString and compute TF-IDF vector.
+            %       2. Embed queryString to obtain semantic vector.
+            %       3. Compute bm and em similarity scores.
+            %       4. Blend via: score = alpha*bm + (1-alpha)*em.
+            %       5. Return topK results sorted by score.
+            error("reg:model:NotImplemented", ...
+                "SearchIndexModel.query is not implemented.");
+        end
     end
 end

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -30,5 +30,10 @@ classdef TestModelStubs < matlab.unittest.TestCase
             model = feval(ModelClass);
             tc.verifyError(@() model.process([]), 'reg:model:NotImplemented');
         end
+        function searchQueryNotImplemented(tc)
+            model = reg.model.SearchIndexModel();
+            tc.verifyError(@() model.query("test", 0.5, 10), ...
+                'reg:model:NotImplemented');
+        end
     end
 end


### PR DESCRIPTION
## Summary
- stub `query` method on SearchIndexModel documenting hybrid TF-IDF/embedding blending
- add test ensuring SearchIndexModel.query raises NotImplemented

## Testing
- `matlab -batch "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*
- `octave --eval "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f0b0aef808330a15e267795f5a200