### PR TITLE
Document clustering and per-label metrics

### DIFF
--- a/+reg/+controller/EvaluationPipeline.m
+++ b/+reg/+controller/EvaluationPipeline.m
@@ -34,7 +34,8 @@ classdef EvaluationPipeline < handle
 
             if nargin < 2, goldDir = 'gold'; end
 
-            % Step 1: evaluate gold pack and compute retrieval metrics
+            % Step 1: evaluate gold pack and compute retrieval metrics,
+            %   per-label recall and optional clustering quality.
             %   Controller should validate goldDir contents and report
             %   missing files.
             goldRes = obj.Controller.evaluateGoldPack(goldDir);

--- a/+reg/eval_clustering.m
+++ b/+reg/eval_clustering.m
@@ -1,6 +1,12 @@
 function S = eval_clustering(E, labelsLogical, Kclusters)
-%EVAL_CLUSTERING k-means clustering + purity and silhouette score (approx)
-% labelsLogical: [N x L] -> turn into single label by argmax for purity proxy
+%EVAL_CLUSTERING k-means clustering + purity and silhouette score (approx).
+%   S = EVAL_CLUSTERING(E, labelsLogical, Kclusters) clusters the embeddings
+%   and returns a struct with fields:
+%       * purity     – fraction of items whose majority cluster label matches
+%       * silhouette – mean cosine silhouette value
+%       * idx        – cluster assignment vector (N x 1)
+%   labelsLogical is an [N x L] logical label matrix; ties are resolved by
+%   argmax for the purity proxy.
 N = size(E,1);
 if nargin<3, Kclusters = max(2, round(sqrt(N/10))); end
 [idx, ~] = kmeans(E, Kclusters, 'MaxIter',200, 'Replicates',3, 'Distance','cosine');

--- a/+reg/eval_per_label.m
+++ b/+reg/eval_per_label.m
@@ -1,5 +1,11 @@
-function T = eval_per_label(E, Ylogical, K)
-%EVAL_PER_LABEL Per-label Recall@K using cosine similarity
+function [T, recall] = eval_per_label(E, Ylogical, K)
+%EVAL_PER_LABEL Per-label Recall@K using cosine similarity.
+%   T = EVAL_PER_LABEL(E, Ylogical, K) computes recall for each label and
+%   returns a table with columns:
+%       * LabelIdx  – numeric label index (1..L)
+%       * RecallAtK – per-label recall@K
+%       * Support   – number of query examples considered for that label
+%   [T, RECALL] = EVAL_PER_LABEL(...) also returns the raw recall vector.
 if nargin<3, K=10; end
 N = size(E,1); L = size(Ylogical,2);
 E = E ./ vecnorm(E, 2, 2); % normalize each row for cosine similarity
@@ -22,5 +28,6 @@ recall = zeros(L,1);
 for l=1:L
     if denom(l)>0, recall(l) = rec(l)/denom(l); else, recall(l)=NaN; end
 end
-T = table((1:L).', recall, 'VariableNames', {'LabelIdx','RecallAtK'});
+T = table((1:L).', recall, denom, ...
+    'VariableNames', {'LabelIdx','RecallAtK','Support'});
 end

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -181,6 +181,7 @@ table(results)
 - Fine-tune early stopping on nDCG@10 with patience + min-delta; saves `checkpoints/ft_best.mat`.
 - Simple **hard-negative mining** between epochs using current encoder.
 - **Per-label metrics** helper (`+reg/eval_per_label.m`).
+- **Clustering metrics** helper (`+reg/eval_clustering.m`).
 - **Golden artifact test** (`tests/TestReportArtifact.m`) ensuring `reg_eval_report.pdf` exists and is non-trivial.
 
 ---

--- a/docs/SYSTEM_BUILD_PLAN.md
+++ b/docs/SYSTEM_BUILD_PLAN.md
@@ -78,8 +78,8 @@ This guide outlines a clean-room rebuild of the MATLAB-based regulatory topic cl
 - **Goal:** Quantify performance and produce human-readable reports.
 - **Depends on:** Baseline/Projection/Fine-Tuned models.
 - **Implementation:**
-  - `reg.eval_retrieval` and `reg.eval_per_label` for metrics.
-  - `reg_eval_and_report.m` generates `reg_eval_report.pdf` and trends.
+  - `reg.eval_retrieval`, `reg.eval_per_label`, and `reg.eval_clustering` for metrics.
+  - `reg_eval_and_report.m` generates `reg_eval_report.pdf`, trends, and clustering summaries.
   - Gold mini-pack support via `reg.load_gold` and `reg_eval_gold.m`.
 - **Testing:** `tests/TestMetricsExpectedJSON.m`, `tests/TestGoldMetrics.m`, `tests/TestReportArtifact.m`.
 - **Output:** Metrics CSVs, PDF/HTML reports, gold evaluation results.

--- a/reg_eval_and_report.m
+++ b/reg_eval_and_report.m
@@ -1,4 +1,5 @@
-% Evaluate baseline vs projection head vs fine-tuned encoder and generate a PDF report
+% Evaluate baseline vs projection head vs fine-tuned encoder and generate a PDF
+% report including per-label recall and clustering quality metrics.
 import mlreportgen.report.*
 import mlreportgen.dom.*
 


### PR DESCRIPTION
## Summary
- clarify eval_per_label outputs and include support counts
- describe eval_clustering struct fields and optional clustering evaluation hooks
- note clustering and per-label metrics in controller, pipeline, and docs

## Testing
- `matlab -batch "runtests('tests','IncludeSubfolders',true,'UseParallel',false);"` *(fails: command not found)*
- `octave -qf --eval "runtests('tests', 'warn', 'verbose');"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689f21c3221c8330b5f2fd409376cbad