### PR TITLE
feat: add knob and seed utilities

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -56,6 +56,10 @@ classdef PipelineController < reg.mvc.BaseController
             %       Step 10 ↔ `generate_reg_report`
 
             % Step 1: Retrieve configuration
+            obj.ConfigModel.applySeeds();
+            obj.ConfigModel.loadKnobs();
+            obj.ConfigModel.validateKnobs();
+            obj.ConfigModel.printActiveKnobs();
             cfgRaw = obj.ConfigModel.load();
             cfg = obj.ConfigModel.process(cfgRaw);
 


### PR DESCRIPTION
## Summary
- add knob loading/validation/printing and seed application helpers to `ConfigModel`
- load and display knob settings and seeds during `PipelineController` setup

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('test')"` *(fails: command not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f2bdddb1883309ee706b171c7b364