### PR TITLE
feat: add visualization model to evaluation pipeline

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -1,10 +1,19 @@
 classdef EvaluationController < handle
     %EVALUATIONCONTROLLER Provide utilities for evaluation and reporting.
     %   This controller bundles common evaluation routines used across the
-    %   project such as retrieval metrics, gold-pack evaluation, trend
-    %   plotting and co-retrieval heatmap generation.
+    %   project such as retrieval metrics and gold-pack evaluation.
+
+    properties
+        VisualizationModel reg.model.VisualizationModel = reg.model.VisualizationModel();
+    end
 
     methods
+        function obj = EvaluationController(vizModel)
+            %EVALUATIONCONTROLLER Construct controller with visualization model.
+            if nargin > 0
+                obj.VisualizationModel = vizModel;
+            end
+        end
         function metrics = retrievalMetrics(~, embeddings, posSets, k)
             %RETRIEVALMETRICS Compute retrieval metrics at K.
             %   METRICS = RETRIEVALMETRICS(embeddings, posSets, k) returns a
@@ -53,19 +62,6 @@ classdef EvaluationController < handle
             if opts.ComputeClustering
                 results.clustering = reg.eval_clustering(E, G.Y);
             end
-        end
-
-        function plotTrends(~, csvPath, pngPath)
-            %PLOTTRENDS Generate trend plots from a metrics CSV history.
-            %   Equivalent to `plot_trends`.
-            reg.plot_trends(csvPath, pngPath);
-        end
-
-        function plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels)
-            %PLOTCORETRIEVALHEATMAP Create a heatmap of label co-retrieval.
-            %   Equivalent to `plot_coretrieval_heatmap`.
-            [M, order] = reg.label_coretrieval_matrix(embeddings, labelMatrix, 10);
-            reg.plot_coretrieval_heatmap(M(order,order), string(labels(order)), pngPath);
         end
     end
 end

--- a/+reg/+controller/EvaluationPipeline.m
+++ b/+reg/+controller/EvaluationPipeline.m
@@ -46,7 +46,7 @@ classdef EvaluationPipeline < handle
             trendsPNG = '';
             if nargin >= 3 && ~isempty(metricsCSV) && isfile(metricsCSV)
                 trendsPNG = fullfile(tempdir, 'trends.png');
-                obj.Controller.plotTrends(metricsCSV, trendsPNG);
+                obj.Controller.VisualizationModel.plotTrends(metricsCSV, trendsPNG);
             end
 
             % Step 3: generate co-retrieval heatmap using gold embeddings
@@ -55,7 +55,7 @@ classdef EvaluationPipeline < handle
             C = config(); C.labels = G.labels;
             E = reg.precompute_embeddings(G.chunks.text, C);
             heatPNG = fullfile(tempdir, 'coretrieval_heatmap.png');
-            obj.Controller.plotCoRetrievalHeatmap(E, G.Y, heatPNG, G.labels);
+            obj.Controller.VisualizationModel.plotCoRetrievalHeatmap(E, G.Y, heatPNG, G.labels);
 
             % Step 4: assemble report struct and forward to view
             irbSubset = goldRes.perLabel;  % placeholder for IRB-specific slice

--- a/+reg/+model/VisualizationModel.m
+++ b/+reg/+model/VisualizationModel.m
@@ -1,0 +1,39 @@
+classdef VisualizationModel < reg.mvc.BaseModel
+    %VISUALIZATIONMODEL Stub model for generating evaluation plots.
+    %   Provides helpers to render trend lines and co-retrieval heatmaps.
+
+    methods
+        function obj = VisualizationModel(varargin) %#ok<INUSD>
+            %VISUALIZATIONMODEL Construct visualization model.
+            %   Currently accepts no configuration but is defined for
+            %   symmetry with other models in the MVC framework.
+        end
+
+        function pngPath = plotTrends(~, csvPath, pngPath)
+            %PLOTTRENDS Generate trend plots from metrics history.
+            %   pngPath = PLOTTRENDS(obj, csvPath, pngPath) wraps
+            %   reg.plot_trends.
+            pngPath = reg.plot_trends(csvPath, pngPath);
+        end
+
+        function pngPath = plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels)
+            %PLOTCORETRIEVALHEATMAP Create a heatmap of label co-retrieval.
+            %   pngPath = PLOTCORETRIEVALHEATMAP(obj, embeddings, labelMatrix,
+            %   pngPath, labels) delegates to reg.plot_coretrieval_heatmap.
+            [M, order] = reg.label_coretrieval_matrix(embeddings, labelMatrix, 10);
+            pngPath = reg.plot_coretrieval_heatmap(M(order,order), string(labels(order)), pngPath);
+        end
+
+        function data = load(~, varargin) %#ok<INUSD>
+            %LOAD Stub for interface completeness.
+            error("reg:model:NotImplemented", ...
+                "VisualizationModel.load is not implemented.");
+        end
+
+        function result = process(~, data) %#ok<INUSD>
+            %PROCESS Stub for interface completeness.
+            error("reg:model:NotImplemented", ...
+                "VisualizationModel.process is not implemented.");
+        end
+    end
+end

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -17,7 +17,8 @@ classdef TestModelStubs < matlab.unittest.TestCase
             'reg.model.EncoderFineTuneModel',
             'reg.model.EvaluationModel',
             'reg.model.LoggingModel',
-            'reg.model.GoldPackModel'
+            'reg.model.GoldPackModel',
+            'reg.model.VisualizationModel'
         };
     end
     


### PR DESCRIPTION
## Summary
- add VisualizationModel with helper stubs for trend and co-retrieval plots
- route EvaluationController through VisualizationModel
- update EvaluationPipeline to call visualization model methods

## Testing
- ⚠️ `octave -qf run_smoke_test.m` *(command not found: octave)*

------
https://chatgpt.com/codex/tasks/task_b_689f2d8735648330a620b84bafcbdeb9