### PR TITLE
Document model data schemas and reference in controllers

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -66,6 +66,7 @@ classdef PipelineController < reg.mvc.BaseController
             % Step 2: Ingest PDFs into documents table
             %   PDFIngestModel should verify file readability and handle OCR
             %   failures gracefully.
+            %   See reg.model.PDFIngestModel for documentsTable schema.
             %   Failure Modes
             %       * Input directory missing/empty resulting in dummy docs.
             %       * `extractFileText` errors or unusable OCR output.
@@ -78,12 +79,14 @@ classdef PipelineController < reg.mvc.BaseController
 
             % Step 3: Chunk documents into text segments
             %   Relies on tokens/overlap parameters from cfg.
+            %   See reg.model.TextChunkModel for chunksTable schema.
             chunksRaw = obj.TextChunkModel.load(docsT);
             chunksT = obj.TextChunkModel.process(chunksRaw);
 
             % Step 4: Extract features and embeddings
             %   FeatureModel expected to fall back (e.g., to fastText) if the
             %   preferred embedding backend fails.
+            %   See reg.model.FeatureModel for feature matrix and embedding schema.
             featuresRaw = obj.FeatureModel.load(chunksT);
             [features, embeddings, vocab] = obj.FeatureModel.process(featuresRaw); %#ok<NASGU>
 
@@ -100,6 +103,7 @@ classdef PipelineController < reg.mvc.BaseController
 
             % Step 7: Train classifiers and make predictions
             %   ClassifierModel should validate that Yweak is non-empty.
+            %   See reg.model.ClassifierModel for prediction output schema.
             clsRaw = obj.ClassifierModel.load(Yweak);
             [models, scores, thresholds, pred] = obj.ClassifierModel.process(clsRaw); %#ok<NASGU>
 

--- a/+reg/+model/ClassifierModel.m
+++ b/+reg/+model/ClassifierModel.m
@@ -1,5 +1,10 @@
 classdef ClassifierModel < reg.mvc.BaseModel
     %CLASSIFIERMODEL Stub model training classifiers and predicting labels.
+    %
+    % Prediction outputs returned by PROCESS:
+    %   scores      (double matrix N×K) : probabilities per chunk and label
+    %   thresholds  (double vector 1×K) : decision threshold per label
+    %   predLabels  (logical matrix N×K): final binary predictions
 
     properties
         % Shared configuration reference

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -1,5 +1,20 @@
 classdef FeatureModel < reg.mvc.BaseModel
     %FEATUREMODEL Stub model generating feature representations.
+    %
+    % Input chunksTable schema (see TextChunkModel):
+    %   chunk_id  (string) : chunk identifier
+    %   doc_id    (string) : parent document identifier
+    %   text      (string) : chunk text content
+    %   start_idx (double) : starting token index
+    %   end_idx   (double) : ending token index
+    %
+    % Outputs returned by PROCESS:
+    %   features   (table) : columns
+    %       - chunk_id (string) : reference to source chunk
+    %       - doc_id   (string) : parent document identifier
+    %       - tfidf    (double vector 1xV) : TF-IDF features
+    %   embeddings (double matrix N×D) : dense embedding vectors per chunk
+    %   vocab      (string array 1×V)  : vocabulary terms corresponding to tfidf
 
     properties
         % Shared configuration reference

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -1,5 +1,13 @@
 classdef PDFIngestModel < reg.mvc.BaseModel
     %PDFINGESTMODEL Stub model converting PDFs to document table.
+    %
+    % Expected documentsTable schema returned by PROCESS:
+    %   doc_id (string) : unique document identifier
+    %   text   (string) : full text extracted from each PDF
+    %   meta   (struct) : file metadata with fields
+    %       - path (string)    : absolute source path
+    %       - bytes (double)   : file size in bytes
+    %       - modified (double): datenum timestamp of last change
 
     properties
         % Shared configuration reference

--- a/+reg/+model/TextChunkModel.m
+++ b/+reg/+model/TextChunkModel.m
@@ -1,5 +1,17 @@
 classdef TextChunkModel < reg.mvc.BaseModel
     %TEXTCHUNKMODEL Stub model splitting documents into chunks.
+    %
+    % Input documentsTable schema (see PDFIngestModel):
+    %   doc_id (string) : unique document identifier
+    %   text   (string) : full document text
+    %   meta   (struct) : file metadata
+    %
+    % Output chunksTable schema returned by PROCESS:
+    %   chunk_id  (string) : unique chunk identifier
+    %   doc_id    (string) : parent document identifier
+    %   text      (string) : chunk text content
+    %   start_idx (double) : starting token index in source doc
+    %   end_idx   (double) : ending token index in source doc
 
     properties
         % Shared configuration reference


### PR DESCRIPTION
## Summary
- Document `documentsTable` schema in `PDFIngestModel`
- Detail `chunksTable` fields in `TextChunkModel`
- Describe feature matrices and prediction outputs in `FeatureModel` and `ClassifierModel`
- Reference schema docs from `PipelineController` when transferring data

## Testing
- `octave -qf --eval "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*
- `matlab -batch "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_b_689f324c295c833091b953c61c32c152