### PR TITLE
feat: add diff models and refactor controllers

### DIFF
--- a/+reg/+controller/DiffArticlesController.m
+++ b/+reg/+controller/DiffArticlesController.m
@@ -1,56 +1,36 @@
 classdef DiffArticlesController < reg.mvc.BaseController
     %DIFFARTICLESCONTROLLER Article-aware diff of two CRR corpora.
-    %   Wraps `crr_diff_articles` and exposes a controller interface for
-    %   comparing two directories produced by `fetch_crr_eba_parsed`.
-
-    properties
-        DiffFunction
-    end
+    %   Uses a `reg.model.DiffArticlesModel` to align articles and compute
+    %   statistics between two directories produced by
+    %   `fetch_crr_eba_parsed`.
 
     methods
-        function obj = DiffArticlesController(view, diffFunc)
-            %DIFFARTICLESCONTROLLER Construct controller with diff function.
-            %   OBJ = DIFFARTICLESCONTROLLER(view, diffFunc) sets the view
-            %   and function handle used for article-aware diffing. When
-            %   omitted, VIEW defaults to `reg.view.ReportView` and
-            %   DIFFFUNC defaults to `@reg.crr_diff_articles`.
-            if nargin < 1 || isempty(view)
+        function obj = DiffArticlesController(model, view)
+            %DIFFARTICLESCONTROLLER Construct controller with model and view.
+            %   OBJ = DIFFARTICLESCONTROLLER(model, view) wires a
+            %   DiffArticlesModel to a view. MODEL defaults to
+            %   `reg.model.DiffArticlesModel()` and VIEW defaults to
+            %   `reg.view.ReportView()`.
+            if nargin < 1 || isempty(model)
+                model = reg.model.DiffArticlesModel();
+            end
+            if nargin < 2 || isempty(view)
                 view = reg.view.ReportView();
             end
-            if nargin < 2 || isempty(diffFunc)
-                diffFunc = @reg.crr_diff_articles;
-            end
-            obj@reg.mvc.BaseController([], view);
-            obj.DiffFunction = diffFunc;
+            obj@reg.mvc.BaseController(model, view);
         end
 
         function result = run(obj, dirA, dirB, outDir)
             %RUN Compare CRR corpora by article number.
-            %   RESULT = RUN(obj, dirA, dirB, outDir) aligns articles using
-            %   the `index.csv` produced by `fetch_crr_eba_parsed` and
-            %   writes a CSV summary and a human-readable patch file.
-            %   Inputs
-            %       dirA, dirB (char/string): Directories each containing an
-            %           `index.csv` alongside article text files.
-            %       outDir (char/string): Optional directory for diff
-            %           artefacts. Default runs/crr_diff_articles.
-            %   Returns
-            %       result (struct): Counts of added, removed, changed and
-            %       same articles plus the output directory.
-            %   Errors
-            %       * Propagates any errors from the underlying diff
-            %         function, e.g. missing `index.csv` or unreadable
-            %         files.
-            %       * Creates `outDir`; failure to create it raises an
-            %         exception.
-            if nargin < 4 || isempty(outDir)
-                outDir = fullfile('runs', 'crr_diff_articles');
-            end
-            result = obj.DiffFunction(dirA, dirB, 'OutDir', outDir);
+            %   RESULT = RUN(obj, dirA, dirB, outDir) coordinates the model
+            %   to align articles using the `index.csv` produced by
+            %   `fetch_crr_eba_parsed` and writes a CSV summary and a
+            %   human-readable patch file.
+            params = obj.Model.load(dirA, dirB, outDir);
+            result = obj.Model.process(params);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end
         end
     end
 end
-

--- a/+reg/+model/DiffArticlesModel.m
+++ b/+reg/+model/DiffArticlesModel.m
@@ -1,0 +1,26 @@
+classdef DiffArticlesModel < reg.mvc.BaseModel
+  %DIFFARTICLESMODEL Compute article-level diffs between CRR corpora.
+  %   Encapsulates `crr_diff_articles` and exposes `load` and `process`
+  %   methods for controllers.
+
+  methods
+    function params = load(~, dirA, dirB, outDir)
+      %LOAD Prepare parameters for article-level diffing.
+      %   params = LOAD(obj, dirA, dirB, outDir) stores the directories to
+      %   compare and selects an output directory for diff artefacts.
+      %   When omitted, outDir defaults to runs/crr_diff_articles.
+      if nargin < 4 || isempty(outDir)
+        outDir = fullfile('runs', 'crr_diff_articles');
+      end
+      params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
+    end
+
+    function result = process(~, params)
+      %PROCESS Execute article-aware diffing and return results.
+      %   result = PROCESS(obj, params) wraps `reg.crr_diff_articles` using
+      %   the previously loaded parameters.
+      result = reg.crr_diff_articles(params.dirA, params.dirB, ...
+        'OutDir', params.outDir);
+    end
+  end
+end

--- a/+reg/+model/DiffVersionsModel.m
+++ b/+reg/+model/DiffVersionsModel.m
@@ -1,0 +1,25 @@
+classdef DiffVersionsModel < reg.mvc.BaseModel
+  %DIFFVERSIONSMODEL Compute file-level diffs between CRR corpora.
+  %   Wraps `crr_diff_versions` providing `load` and `process` hooks for
+  %   controllers.
+
+  methods
+    function params = load(~, dirA, dirB, outDir)
+      %LOAD Prepare parameters for file-level diffing.
+      %   params = LOAD(obj, dirA, dirB, outDir) records the directories to
+      %   compare and the output directory. outDir defaults to runs/crr_diff.
+      if nargin < 4 || isempty(outDir)
+        outDir = fullfile('runs', 'crr_diff');
+      end
+      params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
+    end
+
+    function result = process(~, params)
+      %PROCESS Execute file-level diffing and return results.
+      %   result = PROCESS(obj, params) calls `reg.crr_diff_versions` with
+      %   the supplied parameters and returns the diff statistics.
+      result = reg.crr_diff_versions(params.dirA, params.dirB, ...
+        'OutDir', params.outDir);
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add DiffArticlesModel and DiffVersionsModel encapsulating diff functions
- refactor DiffArticlesController and DiffVersionsController to use models
- controllers now orchestrate model load/process and view display

## Testing
- `matlab -batch "runtests('TestMVCUnit')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f35ad2e14833088f7f554d2f5b652