### PR TITLE
feat: add logging into pipeline controller

### DIFF
--- a/CLASS_ARCHITECTURE.md
+++ b/CLASS_ARCHITECTURE.md
@@ -53,7 +53,7 @@ interfaces, data flow, and orchestration.
 
 | Class | Collaborators | Responsibility |
 |-------|---------------|---------------|
-| `reg.controller.PipelineController` | All pipeline models + `ReportView` | Ingest → chunk → features → labels → classifier → index → DB → report |
+| `reg.controller.PipelineController` | All pipeline models + `LoggingModel` + `ReportView` | Ingest → chunk → features → labels → classifier → index → DB → report |
 | `reg.controller.ProjectionHeadController` | Feature, fine‑tune data, projection head, evaluation models + `MetricsView` | Train and evaluate projection head |
 | `reg.controller.FineTuneController` | PDF ingest, chunk, weak label, fine‑tune data, encoder fine‑tune, evaluation models + `MetricsView` | Build contrastive set and fine‑tune encoder |
 | `reg.controller.EvalController` | Evaluation, logging, report models + `ReportView` | Evaluate embeddings and generate reports |

--- a/tests/TestPipelineController.m
+++ b/tests/TestPipelineController.m
@@ -16,9 +16,10 @@ classdef TestPipelineController < matlab.unittest.TestCase
             clsModel = reg.model.ClassifierModel();
             searchModel = reg.model.SearchIndexModel();
             dbModel = reg.model.DatabaseModel();
+            logModel = reg.model.LoggingModel();
             reportModel = reg.model.ReportModel();
             view = reg.view.ReportView();
-            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, clsModel, searchModel, dbModel, reportModel, view);
+            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, clsModel, searchModel, dbModel, logModel, reportModel, view);
         end
     end
     

--- a/tests/TestPipelineLogging.m
+++ b/tests/TestPipelineLogging.m
@@ -1,0 +1,119 @@
+classdef TestPipelineLogging < RegTestCase
+    %TESTPIPELINELOGGING Verify PipelineController logs metrics.
+
+    properties
+        Controller
+        LogModel
+    end
+
+    methods(TestMethodSetup)
+        function setup(tc)
+            cfgModel   = ConfigStub();
+            pdfModel   = PassThroughModel();
+            chunkModel = PassThroughModel();
+            featModel  = FeatureStub();
+            projModel  = PassThroughModel();
+            weakModel  = PassThroughModel();
+            clsModel   = ClassifierStub();
+            searchModel = PassThroughModel();
+            dbModel    = PassThroughModel();
+            tc.LogModel = LogSpyModel();
+            reportModel = PassThroughModel();
+            view       = SpyView();
+            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, ...
+                clsModel, searchModel, dbModel, tc.LogModel, reportModel, view);
+        end
+    end
+
+    methods(TestMethodTeardown)
+        function teardown(tc)
+            tc.Controller = [];
+            tc.LogModel = [];
+        end
+    end
+
+    methods(Test)
+        function runLogsTrainingMetrics(tc)
+            tc.Controller.run();
+            tc.verifyGreaterThanOrEqual(numel(tc.LogModel.Processed), 1);
+            tc.verifyEqual(tc.LogModel.Processed{1}, 42);
+        end
+    end
+end
+
+classdef ConfigStub < handle
+    methods
+        function applySeeds(~), end
+        function loadKnobs(~), end
+        function validateKnobs(~), end
+        function printActiveKnobs(~), end
+        function cfg = load(~), cfg = []; end
+        function cfg = process(~, cfgIn)
+            cfg = cfgIn;
+        end
+    end
+end
+
+classdef PassThroughModel < handle
+    methods
+        function out = load(~, data)
+            if nargin < 2, data = []; end
+            out = data;
+        end
+        function out = process(~, data)
+            out = data;
+        end
+    end
+end
+
+classdef FeatureStub < handle
+    methods
+        function data = load(~, ~)
+            data = [];
+        end
+        function [features, embeddings, vocab] = process(~, ~)
+            features = [];
+            embeddings = [];
+            vocab = [];
+        end
+    end
+end
+
+classdef ClassifierStub < handle
+    methods
+        function data = load(~, ~)
+            data = [];
+        end
+        function [models, scores, thresholds, pred] = process(~, ~)
+            models = [];
+            scores = 42;
+            thresholds = [];
+            pred = [];
+        end
+    end
+end
+
+classdef LogSpyModel < handle
+    properties
+        Processed = {}
+    end
+    methods
+        function dataOut = load(~, dataIn)
+            dataOut = dataIn;
+        end
+        function process(obj, data)
+            obj.Processed{end+1} = data;
+        end
+    end
+end
+
+classdef SpyView < handle
+    properties
+        Displayed
+    end
+    methods
+        function display(obj, data)
+            obj.Displayed = data;
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add `LoggingModel` dependency to `PipelineController`
- record training and evaluation metrics via `LoggingModel`
- test pipeline logging behavior and update docs

## Testing
- `octave -qf --eval "runtests('tests/TestPipelineLogging.m')"` *(fails: command not found)*
- `matlab -batch "runtests('tests/TestPipelineLogging.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f38f9ae508330ad6410a919c8ab25