### PR TITLE
Document search result schema and update consumers

### DIFF
--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -71,9 +71,21 @@ classdef SearchIndexModel < reg.mvc.BaseModel
             %           matching.
             %       topK (double): Maximum number of results to return.
             %   Returns
-            %       results (table): Struct or table of top hits with fields
-            %           such as `row` and `score` representing document index
-            %           and blended relevance score.
+            %       results (table): Top hits sorted by blended relevance with
+            %           the following schema:
+            %               * docId (double) - 1-based identifier of the
+            %                   matching document or chunk
+            %               * score (double) - blended relevance score where
+            %                   higher means more relevant
+            %               * rank (double) - 1-based rank position after
+            %                   sorting by score
+            %   Example
+            %       results =
+            %           docId    score    rank
+            %           _____    _____    ____
+            %             42     0.91      1
+            %              7     0.85      2
+            %             13     0.80      3
             %   Side Effects
             %       None.
             %   Legacy Reference

--- a/+reg/hybrid_search.m
+++ b/+reg/hybrid_search.m
@@ -1,5 +1,10 @@
 function S = hybrid_search(Xtfidf, E, vocab)
-%HYBRID_SEARCH Prepare structures and provide a query function
+%HYBRID_SEARCH Prepare structures and provide a query function.
+%   The returned struct S exposes a query(q, alpha) function. Calling QUERY
+%   yields a table with columns:
+%       docId (double) - 1-based identifier of the matching document
+%       score (double) - blended relevance score
+%       rank (double) - 1-based rank position
 E = single(E);
 E = E ./ max(1e-9, vecnorm(E,2,2));
 S = struct('Xtfidf', Xtfidf, 'E', E, 'vocab', {vocab});
@@ -34,5 +39,6 @@ bm = (S.Xtfidf * qtfidf') ./ max(1e-9, norm(qtfidf));
 em = single(S.E * qe');
 score = alpha*bm + (1-alpha)*em;
 [sv, idx] = maxk(score, 20);
-out = table(idx, sv, 'VariableNames', {'row','score'});
+rank = (1:numel(idx))';
+out = table(idx, sv, rank, 'VariableNames', {'docId','score','rank'});
 end

--- a/tests/TestHybridSearch.m
+++ b/tests/TestHybridSearch.m
@@ -10,12 +10,13 @@ classdef TestHybridSearch < RegTestCase
             S = reg.hybrid_search(Xtfidf, E, vocab);
             res = S.query("liquidity coverage ratio HQLA", 0.5);
             tc.verifyGreaterThan(height(res), 0);
-            tc.verifyEqual(res.row(1), 2);
+            tc.verifyEqual(res.docId(1), 2);
+            tc.verifyEqual(res.rank(1), 1);
 
             resLex = S.query("liquidity coverage ratio HQLA", 0.8);
             resSem = S.query("liquidity coverage ratio HQLA", 0.2);
-            tc.verifyEqual(resLex.row(1), 2);
-            tc.verifyEqual(resSem.row(1), 2);
+            tc.verifyEqual(resLex.docId(1), 2);
+            tc.verifyEqual(resSem.docId(1), 2);
             tc.verifyGreaterThan(resLex.score(1), resSem.score(1));
         end
     end


### PR DESCRIPTION
## Summary
- document SearchIndexModel query output schema with docId, score, and rank
- align hybrid_search output to return docId, score, and rank
- update hybrid search tests to use the documented result fields

## Testing
- ⚠️ `octave -qf --eval "runtests('tests')"` (octave: command not found)
- ⚠️ `matlab -batch "runtests('tests')"` (matlab: command not found)


------
https://chatgpt.com/codex/tasks/task_b_689f3bcdb5f0833098a46548b606bdfe