### PR TITLE
Add method diff MVC components

### DIFF
--- a/+reg/+controller/MethodsDiffController.m
+++ b/+reg/+controller/MethodsDiffController.m
@@ -1,0 +1,35 @@
+classdef MethodsDiffController < reg.mvc.BaseController
+    %METHODSDIFFCONTROLLER Compare retrieval across encoder variants.
+    %   Coordinates a `reg.model.MethodDiffModel` and a view to present
+    %   Top-K differences for various embedding methods.
+
+    methods
+        function obj = MethodsDiffController(model, view)
+            %METHODSDIFFCONTROLLER Construct controller with model and view.
+            %   OBJ = METHODSDIFFCONTROLLER(model, view) wires a
+            %   MethodDiffModel to a view. MODEL defaults to
+            %   `reg.model.MethodDiffModel()` and VIEW defaults to
+            %   `reg.view.ReportView()`.
+            if nargin < 1 || isempty(model)
+                model = reg.model.MethodDiffModel();
+            end
+            if nargin < 2 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            obj@reg.mvc.BaseController(model, view);
+        end
+
+        function result = run(obj, queries, chunksT, config)
+            %RUN Compute method diffs for supplied queries and chunks.
+            %   RESULT = RUN(obj, queries, chunksT, config) orchestrates the
+            %   model to compare Top-K retrievals across baseline,
+            %   projection and fine-tuned encoders. CONFIG may be omitted
+            %   and defaults to an empty struct.
+            params = obj.Model.load(queries, chunksT, config);
+            result = obj.Model.process(params);
+            if ~isempty(obj.View)
+                obj.View.display(result);
+            end
+        end
+    end
+end

--- a/+reg/+model/MethodDiffModel.m
+++ b/+reg/+model/MethodDiffModel.m
@@ -1,0 +1,28 @@
+classdef MethodDiffModel < reg.mvc.BaseModel
+  %METHODDIFFMODEL Compare Top-K retrievals across encoder variants.
+  %   Wraps the `reg.diff_methods` function exposing `load` and `process`
+  %   hooks for controllers.
+
+  methods
+    function params = load(~, queries, chunksT, config)
+      %LOAD Prepare parameters for method comparison.
+      %   PARAMS = LOAD(obj, queries, chunksT, config) stores the query
+      %   strings, chunk table and configuration struct. CONFIG may be
+      %   omitted and defaults to an empty struct.
+      if nargin < 4
+        config = struct();
+      end
+      params = struct('queries', queries, 'chunksT', chunksT, ...
+        'config', config);
+    end
+
+    function result = process(~, params)
+      %PROCESS Execute method diffing and return results.
+      %   RESULT = PROCESS(obj, params) delegates to `reg.diff_methods`
+      %   using the previously loaded parameters and returns the
+      %   comparison struct.
+      result = reg.diff_methods(params.queries, params.chunksT, ...
+        params.config);
+    end
+  end
+end

--- a/CLASS_ARCHITECTURE.md
+++ b/CLASS_ARCHITECTURE.md
@@ -57,6 +57,7 @@ interfaces, data flow, and orchestration.
 | `reg.controller.ProjectionHeadController` | Feature, fine‑tune data, projection head, evaluation models + `MetricsView` | Train and evaluate projection head |
 | `reg.controller.FineTuneController` | PDF ingest, chunk, weak label, fine‑tune data, encoder fine‑tune, evaluation models + `MetricsView` | Build contrastive set and fine‑tune encoder |
 | `reg.controller.EvalController` | Evaluation, logging, report models + `ReportView` | Evaluate embeddings and generate reports |
+| `reg.controller.MethodsDiffController` | `MethodDiffModel` + `ReportView` | Compare Top‑K retrievals across encoder variants |
 
 ---
 


### PR DESCRIPTION
## Summary
- add `reg.model.MethodDiffModel` wrapping `reg.diff_methods`
- introduce `reg.controller.MethodsDiffController` to orchestrate method comparison
- mention MethodsDiffController in class architecture docs

## Testing
- `matlab -batch "run_smoke_test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f44c98e308330b9e05d807bd6c6a2