### PR TITLE
Stub reg model/controller interfaces

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -14,54 +14,35 @@ classdef EvaluationController < handle
                 obj.VisualizationModel = vizModel;
             end
         end
-        function metrics = retrievalMetrics(~, embeddings, posSets, k)
+        function metrics = retrievalMetrics(~, embeddings, posSets, k) %#ok<INUSD>
             %RETRIEVALMETRICS Compute retrieval metrics at K.
-            %   METRICS = RETRIEVALMETRICS(embeddings, posSets, k) returns a
-            %   struct with RecallAtK, mAP and nDCG computed from the
-            %   provided embeddings and positive sets. K defaults to 10.
-            %   Equivalent to `eval_retrieval`.
-            if nargin < 4, k = 10; end
-            [recallAtK, mAP] = reg.eval_retrieval(embeddings, posSets, k);
-            ndcgAtK = reg.metrics_ndcg(embeddings*embeddings.', posSets, k);
-            metrics = struct('RecallAtK', recallAtK, 'mAP', mAP, 'nDCG', ndcgAtK);
+            %   METRICS = RETRIEVALMETRICS(embeddings, posSets, k) should
+            %   produce Recall@K, mAP and nDCG scores for a set of embeddings
+            %   and positive index sets.
+            %   Legacy Reference
+            %       Equivalent to `reg.eval_retrieval` and `reg.metrics_ndcg`.
+            %   Pseudocode:
+            %       1. For each query embedding compute similarity scores
+            %       2. Derive recall, mAP and nDCG at K
+            %       3. Return metrics struct
+            error("reg:controller:NotImplemented", ...
+                "EvaluationController.retrievalMetrics is not implemented.");
         end
 
-        function results = evaluateGoldPack(obj, goldDir, opts)
+        function results = evaluateGoldPack(obj, goldDir, opts) %#ok<INUSD>
             %EVALUATEGOLDPACK Run evaluation against a gold mini-pack.
-            %   RESULTS = EVALUATEGOLDPACK(goldDir) loads the gold artefacts,
-            %   embeds the chunks and computes retrieval metrics overall and
-            %   per label. Optional metrics can be toggled via name-value
-            %   options:
-            %       ComputePerLabel   (default true)
-            %       ComputeClustering (default false)
-            %   Equivalent to `reg_eval_gold`.
-            arguments
-                obj
-                goldDir string
-                opts.ComputePerLabel logical = true
-                opts.ComputeClustering logical = false
-            end
-            G = reg.load_gold(goldDir);
-            C = config(); C.labels = G.labels;
-            E = reg.precompute_embeddings(G.chunks.text, C);
-            posSets = cell(height(G.chunks),1);
-            for i = 1:height(G.chunks)
-                labs = G.Y(i,:);
-                pos = find(any(G.Y(:,labs),2)); pos(pos==i) = [];
-                posSets{i} = pos;
-            end
-            overall = obj.retrievalMetrics(E, posSets, 10);
-            if opts.ComputePerLabel
-                per = reg.eval_per_label(E, G.Y, 10);
-                perTbl = table(G.labels(:), per.RecallAtK, ...
-                    'VariableNames', {'Label','RecallAt10'});
-            else
-                perTbl = table();
-            end
-            results = struct('overall', overall, 'perLabel', perTbl);
-            if opts.ComputeClustering
-                results.clustering = reg.eval_clustering(E, G.Y);
-            end
+            %   RESULTS = EVALUATEGOLDPACK(goldDir) should load gold
+            %   artefacts, embed chunks and compute retrieval metrics overall
+            %   and per label.
+            %   Legacy Reference
+            %       Equivalent to `reg_eval_gold`.
+            %   Pseudocode:
+            %       1. Load gold chunks and labels from goldDir
+            %       2. Embed chunks and form positive sets
+            %       3. Compute retrieval metrics and optional clustering
+            %       4. Return struct with overall and per-label results
+            error("reg:controller:NotImplemented", ...
+                "EvaluationController.evaluateGoldPack is not implemented.");
         end
     end
 end

--- a/+reg/+controller/EvaluationPipeline.m
+++ b/+reg/+controller/EvaluationPipeline.m
@@ -16,55 +16,21 @@ classdef EvaluationPipeline < handle
             obj.View = view;
         end
 
-        function run(obj, goldDir, metricsCSV)
+        function run(obj, goldDir, metricsCSV) %#ok<INUSD>
             %RUN Execute evaluation workflow and render report.
-            %   Evaluates a gold pack, plots historical trends and generates
-            %   a co-retrieval heatmap before displaying a summary report.
-            %
-            %   Preconditions
-            %       * goldDir contains gold chunk/label artefacts
-            %   Side Effects
-            %       * Temporary PNGs written to system temp directory
-            %       * Report struct dispatched to view
-            %
+            %   Should evaluate a gold pack, plot historical trends, generate
+            %   a co-retrieval heatmap and display a summary report.
             %   Legacy mapping:
             %       Step 1 ↔ `reg_eval_gold`
             %       Step 2 ↔ `plot_trends`
             %       Step 3 ↔ `plot_coretrieval_heatmap`
-
-            if nargin < 2, goldDir = 'gold'; end
-
-            % Step 1: evaluate gold pack and compute retrieval metrics,
-            %   per-label recall and optional clustering quality.
-            %   Controller should validate goldDir contents and report
-            %   missing files.
-            goldRes = obj.Controller.evaluateGoldPack(goldDir);
-            metrics = goldRes.overall;
-
-            % Step 2: plot metric trends if history provided
-            %   Trend plotting should ignore malformed CSVs with warnings.
-            trendsPNG = '';
-            if nargin >= 3 && ~isempty(metricsCSV) && isfile(metricsCSV)
-                trendsPNG = fullfile(tempdir, 'trends.png');
-                obj.Controller.VisualizationModel.plotTrends(metricsCSV, trendsPNG);
-            end
-
-            % Step 3: generate co-retrieval heatmap using gold embeddings
-            %   Any embedding errors should bubble up for visibility.
-            G = reg.load_gold(goldDir);
-            C = config(); C.labels = G.labels;
-            E = reg.precompute_embeddings(G.chunks.text, C);
-            heatPNG = fullfile(tempdir, 'coretrieval_heatmap.png');
-            obj.Controller.VisualizationModel.plotCoRetrievalHeatmap(E, G.Y, heatPNG, G.labels);
-
-            % Step 4: assemble report struct and forward to view
-            irbSubset = goldRes.perLabel;  % placeholder for IRB-specific slice
-            report = struct('summaryTables', metrics, ...
-                            'irbSubset', irbSubset, ...
-                            'trendCharts', trendsPNG, ...
-                            'heatmap', heatPNG, ...
-                            'gold', goldRes);
-            obj.View.display(report);
+            %   Pseudocode:
+            %       1. results = Controller.evaluateGoldPack(goldDir)
+            %       2. trendsPNG = VisualizationModel.plotTrends(metricsCSV)
+            %       3. heatPNG = VisualizationModel.plotCoRetrievalHeatmap(...)
+            %       4. View.display(struct(...))
+            error("reg:controller:NotImplemented", ...
+                "EvaluationPipeline.run is not implemented.");
         end
     end
 end

--- a/+reg/+model/ConfigModel.m
+++ b/+reg/+model/ConfigModel.m
@@ -109,105 +109,52 @@ classdef ConfigModel < reg.mvc.BaseModel
             end
         end
 
-        function K = loadKnobs(obj, varargin)
+        function K = loadKnobs(obj, varargin) %#ok<INUSD>
             %LOADKNOBS Load knob values from JSON and apply overrides.
-            %   K = LOADKNOBS(obj, jsonPath) reads knob settings from
-            %   `jsonPath` (default 'knobs.json') and stores them on the
-            %   model. Known fields override corresponding properties.
-            if ~isempty(varargin)
-                jsonPath = varargin{1};
-            else
-                jsonPath = "knobs.json";
-            end
-            try
-                K = reg.load_knobs(jsonPath);
-            catch ME
-                warning("reg:model:KnobsLoadFailed", ...
-                    "Knobs load failed: %s", ME.message);
-                K = struct();
-            end
-            obj.knobs = K;
-
-            % Apply knob overrides to properties when present
-            if isfield(K, 'BERT')
-                if isfield(K.BERT, 'MiniBatchSize')
-                    obj.bertMiniBatchSize = K.BERT.MiniBatchSize;
-                end
-                if isfield(K.BERT, 'MaxSeqLength')
-                    obj.bertMaxSeqLength = K.BERT.MaxSeqLength;
-                end
-            end
-            if isfield(K, 'Projection')
-                if isfield(K.Projection, 'ProjDim')
-                    obj.projDim = K.Projection.ProjDim;
-                end
-                if isfield(K.Projection, 'BatchSize')
-                    obj.projBatchSize = K.Projection.BatchSize;
-                end
-                if isfield(K.Projection, 'Epochs')
-                    obj.projEpochs = K.Projection.Epochs;
-                end
-                if isfield(K.Projection, 'LR')
-                    obj.projLR = K.Projection.LR;
-                end
-                if isfield(K.Projection, 'Margin')
-                    obj.projMargin = K.Projection.Margin;
-                end
-            end
-            if isfield(K, 'FineTune')
-                if isfield(K.FineTune, 'Loss')
-                    obj.fineTuneLoss = string(K.FineTune.Loss);
-                end
-                if isfield(K.FineTune, 'BatchSize')
-                    obj.fineTuneBatchSize = K.FineTune.BatchSize;
-                end
-                if isfield(K.FineTune, 'Epochs')
-                    obj.fineTuneEpochs = K.FineTune.Epochs;
-                end
-                if isfield(K.FineTune, 'MaxSeqLength')
-                    obj.fineTuneMaxSeqLength = K.FineTune.MaxSeqLength;
-                end
-                if isfield(K.FineTune, 'UnfreezeTopLayers')
-                    obj.fineTuneUnfreezeTopLayers = K.FineTune.UnfreezeTopLayers;
-                end
-                if isfield(K.FineTune, 'EncoderLR')
-                    obj.fineTuneEncoderLR = K.FineTune.EncoderLR;
-                end
-                if isfield(K.FineTune, 'HeadLR')
-                    obj.fineTuneHeadLR = K.FineTune.HeadLR;
-                end
-            end
-            if isfield(K, 'Chunk')
-                if isfield(K.Chunk, 'SizeTokens')
-                    obj.chunkSizeTokens = K.Chunk.SizeTokens;
-                end
-                if isfield(K.Chunk, 'Overlap')
-                    obj.chunkOverlap = K.Chunk.Overlap;
-                end
-            end
+            %   K = LOADKNOBS(obj, jsonPath) reads knob settings and stores
+            %   them on the model.
+            %   Legacy Reference
+            %       Equivalent to `reg.load_knobs`.
+            %   Pseudocode:
+            %       1. Read knob JSON file
+            %       2. Apply overrides to configuration properties
+            %       3. Return struct of knob values
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.loadKnobs is not implemented.");
         end
 
-        function validateKnobs(obj)
+        function validateKnobs(obj) %#ok<MANU>
             %VALIDATEKNOBS Perform basic sanity checks on loaded knobs.
-            if ~isempty(obj.knobs)
-                reg.validate_knobs(obj.knobs);
-            end
+            %   Intended to error when knob values fall outside supported
+            %   ranges.
+            %   Legacy Reference
+            %       Equivalent to `reg.validate_knobs`.
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.validateKnobs is not implemented.");
         end
 
-        function printActiveKnobs(obj)
+        function printActiveKnobs(obj) %#ok<MANU>
             %PRINTACTIVEKNOBS Pretty-print active knob configuration.
-            reg.print_active_knobs(struct('knobs', obj.knobs));
+            %   Legacy Reference
+            %       Equivalent to `reg.print_active_knobs`.
+            %   Pseudocode:
+            %       1. Format knob values into readable table
+            %       2. Display via fprintf or logging facility
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.printActiveKnobs is not implemented.");
         end
 
-        function S = applySeeds(obj, varargin)
+        function S = applySeeds(obj, varargin) %#ok<INUSD,MANU>
             %APPLYSEEDS Set RNG seeds for reproducibility.
-            if ~isempty(varargin)
-                seed = varargin{1};
-            else
-                seed = [];
-            end
-            S = reg.set_seeds(seed);
-            obj.seeds = S;
+            %   S = APPLYSEEDS(obj, seed) returns the applied seed struct.
+            %   Legacy Reference
+            %       Equivalent to `reg.set_seeds`.
+            %   Pseudocode:
+            %       1. Initialise random number generators
+            %       2. Store seeds on obj.seeds
+            %       3. Return seed struct
+            error("reg:model:NotImplemented", ...
+                "ConfigModel.applySeeds is not implemented.");
         end
 
         function cfgStruct = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/CrrFetchModel.m
+++ b/+reg/+model/CrrFetchModel.m
@@ -8,73 +8,47 @@ classdef CrrFetchModel < reg.mvc.BaseModel
     %   a documented entry point for controllers.
 
     methods
-        function T = fetchEba(~, varargin)
+        function T = fetchEba(~, varargin) %#ok<INUSD>
             %FETCHEBA Download CRR articles from the EBA Single Rulebook.
             %   T = FETCHEBA(obj, Name, Value, ...) retrieves HTML and
-            %   plaintext versions of CRR articles using the legacy helper
-            %   `fetch_crr_eba`.
-            %   Parameters
-            %       'Timeout'     (double)  - HTTP timeout per request in
-            %                                  seconds. Default 15.
-            %       'MaxArticles' (double)  - Maximum number of articles to
-            %                                  download. Default Inf.
-            %   Returns
-            %       T (table): Metadata with columns `article_id`, `title`,
-            %       `url` and `html_file` describing downloaded artefacts.
-            %   Side Effects
-            %       * Writes HTML and plaintext files under
-            %         data/eba_isrb/crr.
-            %       * Persists an `index.csv` alongside the files.
-            %   Errors
-            %       * Network failures or write errors emit warnings and
-            %         return any successfully fetched articles.
-            %       * Interrupt exceptions are rethrown to allow graceful
-            %         termination.
-            T = reg.fetch_crr_eba(varargin{:});
+            %   plaintext versions of CRR articles.
+            %   Returns metadata table mirroring `fetch_crr_eba`.
+            %   Legacy Reference
+            %       Equivalent to `fetch_crr_eba`.
+            %   Pseudocode:
+            %       1. Issue HTTP requests for CRR articles
+            %       2. Write HTML/plaintext files and index.csv
+            %       3. Return table describing downloaded artefacts
+            error("reg:model:NotImplemented", ...
+                "CrrFetchModel.fetchEba is not implemented.");
         end
 
-        function T = fetchEbaParsed(~, varargin)
+        function T = fetchEbaParsed(~, varargin) %#ok<INUSD>
             %FETCHEBAPARSED Download CRR articles with parsed article numbers.
-            %   T = FETCHEBAPARSED(obj, Name, Value, ...) wraps
-            %   `fetch_crr_eba_parsed` which augments each article with a
-            %   parsed `article_num` identifier.
-            %   Parameters
-            %       'OutDir' (string/char) - Output directory for HTML,
-            %                               text and index files. Defaults
-            %                               to data/eba_isrb/crr.
-            %   Returns
-            %       T (table): Metadata including `article_id`, `article_num`,
-            %       `title`, `url` and `html_file`.
-            %   Side Effects
-            %       * Creates `OutDir` if it does not exist.
-            %       * Writes HTML/plaintext files and an `index.csv`.
-            %   Errors
-            %       * Download issues generate warnings; rows for failed
-            %         articles are omitted from the returned table.
-            %       * Directory creation problems propagate as errors.
-            T = reg.fetch_crr_eba_parsed(varargin{:});
+            %   T = FETCHEBAPARSED(obj, Name, Value, ...) augments each
+            %   article with a parsed `article_num` identifier.
+            %   Legacy Reference
+            %       Equivalent to `fetch_crr_eba_parsed`.
+            %   Pseudocode:
+            %       1. Fetch articles as in fetchEba
+            %       2. Parse article numbers into `article_num`
+            %       3. Return metadata table including `article_num`
+            error("reg:model:NotImplemented", ...
+                "CrrFetchModel.fetchEbaParsed is not implemented.");
         end
 
-        function pdfPath = fetchEurlex(~, varargin)
+        function pdfPath = fetchEurlex(~, varargin) %#ok<INUSD>
             %FETCHEURLEX Download consolidated CRR PDF from EUR‑Lex.
-            %   pdfPath = FETCHEURLEX(obj, Name, Value, ...) wraps
-            %   `fetch_crr_eurlex` which retrieves the consolidated CRR
-            %   regulation as a single PDF.
-            %   Parameters
-            %       'Date' (string/char) - Consolidation code in YYYYMMDD
-            %                              format identifying the desired
-            %                              version. Default 20250629.
-            %   Returns
-            %       pdfPath (string): Absolute path to the downloaded PDF
-            %       saved under data/raw.
-            %   Side Effects
-            %       * Creates the data/raw directory if needed and writes
-            %         the PDF file within it.
-            %   Errors
-            %       * Any network or file system failure results in an
-            %         error being thrown; callers should handle these to
-            %         recover or retry.
-            pdfPath = reg.fetch_crr_eurlex(varargin{:});
+            %   pdfPath = FETCHEURLEX(obj, Name, Value, ...) retrieves the
+            %   consolidated regulation PDF.
+            %   Legacy Reference
+            %       Equivalent to `fetch_crr_eurlex`.
+            %   Pseudocode:
+            %       1. Build download URL from consolidation code
+            %       2. Download PDF into data/raw
+            %       3. Return absolute file path
+            error("reg:model:NotImplemented", ...
+                "CrrFetchModel.fetchEurlex is not implemented.");
         end
     end
 end

--- a/+reg/+model/DiffArticlesModel.m
+++ b/+reg/+model/DiffArticlesModel.m
@@ -15,12 +15,18 @@ classdef DiffArticlesModel < reg.mvc.BaseModel
       params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
     end
 
-    function result = process(~, params)
+    function result = process(~, params) %#ok<INUSD>
       %PROCESS Execute article-aware diffing and return results.
-      %   result = PROCESS(obj, params) wraps `reg.crr_diff_articles` using
-      %   the previously loaded parameters.
-      result = reg.crr_diff_articles(params.dirA, params.dirB, ...
-        'OutDir', params.outDir);
+      %   RESULT = PROCESS(obj, params) should compare articles between
+      %   two directories and emit summary statistics.
+      %   Legacy Reference
+      %       Equivalent to `reg.crr_diff_articles`.
+      %   Pseudocode:
+      %       1. Align articles using index.csv files
+      %       2. Compute textual differences per article
+      %       3. Return struct with diff statistics and artefact paths
+      error("reg:model:NotImplemented", ...
+        "DiffArticlesModel.process is not implemented.");
     end
   end
 end

--- a/+reg/+model/DiffVersionsModel.m
+++ b/+reg/+model/DiffVersionsModel.m
@@ -14,12 +14,18 @@ classdef DiffVersionsModel < reg.mvc.BaseModel
       params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
     end
 
-    function result = process(~, params)
+    function result = process(~, params) %#ok<INUSD>
       %PROCESS Execute file-level diffing and return results.
-      %   result = PROCESS(obj, params) calls `reg.crr_diff_versions` with
-      %   the supplied parameters and returns the diff statistics.
-      result = reg.crr_diff_versions(params.dirA, params.dirB, ...
-        'OutDir', params.outDir);
+      %   RESULT = PROCESS(obj, params) should compare directory trees and
+      %   report line-level differences.
+      %   Legacy Reference
+      %       Equivalent to `reg.crr_diff_versions`.
+      %   Pseudocode:
+      %       1. Align files by relative path
+      %       2. Compute line-level diffs and statistics
+      %       3. Return struct with summary tables and patch file paths
+      error("reg:model:NotImplemented", ...
+        "DiffVersionsModel.process is not implemented.");
     end
   end
 end

--- a/+reg/+model/MethodDiffModel.m
+++ b/+reg/+model/MethodDiffModel.m
@@ -16,13 +16,18 @@ classdef MethodDiffModel < reg.mvc.BaseModel
         'config', config);
     end
 
-    function result = process(~, params)
+    function result = process(~, params) %#ok<INUSD>
       %PROCESS Execute method diffing and return results.
-      %   RESULT = PROCESS(obj, params) delegates to `reg.diff_methods`
-      %   using the previously loaded parameters and returns the
-      %   comparison struct.
-      result = reg.diff_methods(params.queries, params.chunksT, ...
-        params.config);
+      %   RESULT = PROCESS(obj, params) should compare retrieval results
+      %   across multiple embedding methods.
+      %   Legacy Reference
+      %       Equivalent to `reg.diff_methods`.
+      %   Pseudocode:
+      %       1. Embed queries using baseline and alternative encoders
+      %       2. Retrieve Top-K results for each method
+      %       3. Return struct summarising differences
+      error("reg:model:NotImplemented", ...
+        "MethodDiffModel.process is not implemented.");
     end
   end
 end

--- a/+reg/+model/VisualizationModel.m
+++ b/+reg/+model/VisualizationModel.m
@@ -9,19 +9,32 @@ classdef VisualizationModel < reg.mvc.BaseModel
             %   symmetry with other models in the MVC framework.
         end
 
-        function pngPath = plotTrends(~, csvPath, pngPath)
+        function pngPath = plotTrends(~, csvPath, pngPath) %#ok<INUSD>
             %PLOTTRENDS Generate trend plots from metrics history.
-            %   pngPath = PLOTTRENDS(obj, csvPath, pngPath) wraps
-            %   reg.plot_trends.
-            pngPath = reg.plot_trends(csvPath, pngPath);
+            %   pngPath = PLOTTRENDS(obj, csvPath, pngPath) should read a
+            %   CSV of historical metrics and render a trend PNG.
+            %   Legacy Reference
+            %       Equivalent to `reg.plot_trends`.
+            %   Pseudocode:
+            %       1. Read metrics from csvPath
+            %       2. Plot trends and save to pngPath
+            %       3. Return pngPath
+            error("reg:model:NotImplemented", ...
+                "VisualizationModel.plotTrends is not implemented.");
         end
 
-        function pngPath = plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels)
+        function pngPath = plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels) %#ok<INUSD>
             %PLOTCORETRIEVALHEATMAP Create a heatmap of label co-retrieval.
             %   pngPath = PLOTCORETRIEVALHEATMAP(obj, embeddings, labelMatrix,
-            %   pngPath, labels) delegates to reg.plot_coretrieval_heatmap.
-            [M, order] = reg.label_coretrieval_matrix(embeddings, labelMatrix, 10);
-            pngPath = reg.plot_coretrieval_heatmap(M(order,order), string(labels(order)), pngPath);
+            %   pngPath, labels) should visualise co-retrieval frequencies.
+            %   Legacy Reference
+            %       Equivalent to `reg.plot_coretrieval_heatmap`.
+            %   Pseudocode:
+            %       1. Derive co-retrieval matrix from embeddings/labels
+            %       2. Plot heatmap ordered by label frequency
+            %       3. Save to pngPath and return path
+            error("reg:model:NotImplemented", ...
+                "VisualizationModel.plotCoRetrievalHeatmap is not implemented.");
         end
 
         function data = load(~, varargin) %#ok<INUSD>

--- a/tests/TestEvaluationPipeline.m
+++ b/tests/TestEvaluationPipeline.m
@@ -1,18 +1,12 @@
-classdef TestEvaluationPipeline < RegTestCase
-    % Validate that EvaluationPipeline orchestrates controller and view.
+classdef TestEvaluationPipeline < matlab.unittest.TestCase
+    %TESTEVALUATIONPIPELINE Ensure pipeline stub raises NotImplemented.
 
     methods (Test)
-        function run_pipeline(tc)
+        function runNotImplemented(tc)
             view = reg.view.ReportView();
             ctrl = reg.controller.EvaluationController();
             pipe = reg.controller.EvaluationPipeline(ctrl, view);
-            % Minimal metrics history for trend chart
-            csv = fullfile(tempdir, 'metrics.csv');
-            T = table((1:2)', rand(2,1), 'VariableNames', {'Epoch','RecallAt10'});
-            writetable(T, csv);
-            pipe.run('gold', csv);
-            tc.verifyTrue(isfield(view.DisplayedData, 'summaryTables'));
-            tc.verifyTrue(isfield(view.DisplayedData, 'trendCharts'));
+            tc.verifyError(@() pipe.run('gold'), 'reg:controller:NotImplemented');
         end
     end
 end

--- a/tests/TestFetchers.m
+++ b/tests/TestFetchers.m
@@ -1,32 +1,17 @@
-classdef TestFetchers < RegTestCase
+classdef TestFetchers < matlab.unittest.TestCase
+    %TESTFETCHERS Ensure CRR fetcher model stubs raise NotImplemented.
     methods (Test)
-        function eurlex_url_build(tc)
-            try
-                out = reg.fetch_crr_eurlex('Date','20250629'); %#ok<NASGU>
-            catch ME
-                % We only verify the function exists and builds a URL; net may be blocked.
-                tc.assertTrue(contains(ME.message, "download failed") || contains(lower(ME.message),'unable') || true);
-            end
+        function fetchEbaNotImplemented(tc)
+            model = reg.model.CrrFetchModel();
+            tc.verifyError(@() model.fetchEba(), 'reg:model:NotImplemented');
         end
-        function eba_fetch_signature(tc)
-            % Mock webread so the fetcher returns a table even without network access
-            testDir = fileparts(mfilename('fullpath'));
-            timeoutDir = fullfile(testDir, 'fixtures', 'webread_timeout');
-            addpath(timeoutDir);
-            tc.addTeardown(@() rmpath(timeoutDir));
-            T = reg.fetch_crr_eba();
-            tc.verifyTrue(istable(T));
+        function fetchEbaParsedNotImplemented(tc)
+            model = reg.model.CrrFetchModel();
+            tc.verifyError(@() model.fetchEbaParsed(), 'reg:model:NotImplemented');
         end
-
-        function eba_fetch_timeout(tc)
-            % Simulate webread timing out and ensure graceful return
-            testDir = fileparts(mfilename('fullpath'));
-            timeoutDir = fullfile(testDir, 'fixtures', 'webread_timeout');
-            addpath(timeoutDir);
-            tc.addTeardown(@() rmpath(timeoutDir));
-            T = reg.fetch_crr_eba();
-            tc.verifyTrue(istable(T));
-            tc.verifyEqual(height(T), 0);
+        function fetchEurlexNotImplemented(tc)
+            model = reg.model.CrrFetchModel();
+            tc.verifyError(@() model.fetchEurlex(), 'reg:model:NotImplemented');
         end
     end
 end


### PR DESCRIPTION
## Summary
- replace reg.* helper invocations in models and controllers with NotImplemented stubs
- document expected behaviour and IO for fetcher, diff, visualization and evaluation APIs
- update tests to target stubbed interfaces

## Testing
- `runtests tests/TestFetchers.m tests/TestEvaluationPipeline.m tests/TestModelStubs.m` *(fails: command not found)*
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f4aa5c37c8330bb4a3d2f217d8a94