### PR TITLE
Add clustering and per-label evaluation stubs

### DIFF
--- a/+reg/+controller/EvalController.m
+++ b/+reg/+controller/EvalController.m
@@ -5,18 +5,29 @@ classdef EvalController < reg.mvc.BaseController
         EvaluationModel
         LoggingModel
         ReportModel
+        ClusteringEvalModel = []
+        PerLabelEvalModel = []
     end
-    
+
     methods
-        function obj = EvalController(evalModel, logModel, reportModel, view)
+        function obj = EvalController(evalModel, logModel, reportModel, view, varargin)
             %EVALCONTROLLER Construct evaluation controller.
             %   OBJ = EVALCONTROLLER(evalModel, logModel, reportModel, view)
             %   wires the models to a view. Equivalent to
             %   `reg_eval_and_report` setup.
+            %   Additional optional models:
+            %       varargin{1} - clustering evaluation model
+            %       varargin{2} - per-label evaluation model
             obj@reg.mvc.BaseController(evalModel, view);
             obj.EvaluationModel = evalModel;
             obj.LoggingModel = logModel;
             obj.ReportModel = reportModel;
+            if numel(varargin) >= 1
+                obj.ClusteringEvalModel = varargin{1};
+            end
+            if numel(varargin) >= 2
+                obj.PerLabelEvalModel = varargin{2};
+            end
         end
 
         function run(obj)
@@ -34,12 +45,28 @@ classdef EvalController < reg.mvc.BaseController
             %
             %   Legacy mapping:
             %       Step 1 ↔ `eval_retrieval`
+            %       Step 1a ↔ `eval_per_label`
+            %       Step 1b ↔ `eval_clustering`
             %       Step 2 ↔ `log_metrics`
             %       Step 3 ↔ report generation in `reg_eval_and_report`
 
             % Step 1: load evaluation inputs and compute metrics
             evalRaw = obj.EvaluationModel.load();
             metrics = obj.EvaluationModel.process(evalRaw);  % `eval_retrieval`
+
+            % Optional: per-label evaluation
+            if ~isempty(obj.PerLabelEvalModel)
+                perLabelRaw = obj.PerLabelEvalModel.load();
+                perLabelMetrics = obj.PerLabelEvalModel.process(perLabelRaw);  % `eval_per_label`
+                metrics.perLabel = perLabelMetrics;
+            end
+
+            % Optional: clustering evaluation
+            if ~isempty(obj.ClusteringEvalModel)
+                clusterRaw = obj.ClusteringEvalModel.load();
+                clusterMetrics = obj.ClusteringEvalModel.process(clusterRaw);  % `eval_clustering`
+                metrics.clustering = clusterMetrics;
+            end
 
             % Step 2: persist metrics using logging model
             %   LoggingModel should validate schema and handle IO errors.

--- a/+reg/+model/ClusteringEvalModel.m
+++ b/+reg/+model/ClusteringEvalModel.m
@@ -1,0 +1,70 @@
+classdef ClusteringEvalModel < reg.mvc.BaseModel
+    %CLUSTERINGEVALMODEL Stub model evaluating embedding clusters.
+
+    properties
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+    end
+
+    methods
+        function obj = ClusteringEvalModel(cfg)
+            %CLUSTERINGEVALMODEL Construct clustering evaluation model.
+            %   OBJ = CLUSTERINGEVALMODEL(cfg) accesses fields such as
+            %   cfg.clusterK for the number of clusters.
+            if nargin > 0
+                obj.cfg = cfg;
+            end
+        end
+
+        function raw = load(~, varargin) %#ok<INUSD>
+            %LOAD Gather embeddings and labels for clustering.
+            %   raw = LOAD(obj) returns data needed for clustering metrics.
+            %   Parameters
+            %       varargin - Placeholder for future options (unused)
+            %   Returns
+            %       raw (struct):
+            %           .embeddings   (N x D double)   - feature vectors
+            %           .labelsLogical(N x L logical) - label matrix
+            %           .k            (scalar)         - cluster count
+            %   Side Effects
+            %       None.
+            %   Legacy Reference
+            %       Mirrors data preparation in `eval_clustering`.
+            %   Extension Point
+            %       Override to source embeddings or dynamic cluster counts.
+            %   Pseudocode:
+            %       1. Fetch embeddings and label matrix
+            %       2. Assemble into raw struct
+            %       3. Return raw
+            error("reg:model:NotImplemented", ...
+                "ClusteringEvalModel.load is not implemented.");
+        end
+
+        function metrics = process(~, raw) %#ok<INUSD>
+            %PROCESS Compute clustering purity and silhouette.
+            %   metrics = PROCESS(obj, raw) evaluates clusters.
+            %   Parameters
+            %       raw (struct):
+            %           .embeddings   (N x D double)
+            %           .labelsLogical(N x L logical)
+            %           .k            (scalar)
+            %   Returns
+            %       metrics (struct):
+            %           .purity     (double) - majority label purity
+            %           .silhouette (double) - mean cosine silhouette
+            %           .idx        (N x 1 double) - cluster assignments
+            %   Side Effects
+            %       May generate diagnostic plots.
+            %   Legacy Reference
+            %       Equivalent to `eval_clustering`.
+            %   Extension Point
+            %       Swap k-means for alternate clustering algorithms.
+            %   Pseudocode:
+            %       1. Run k-means clustering on embeddings
+            %       2. Derive purity and silhouette metrics
+            %       3. Return metrics struct
+            error("reg:model:NotImplemented", ...
+                "ClusteringEvalModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/PerLabelEvalModel.m
+++ b/+reg/+model/PerLabelEvalModel.m
@@ -1,0 +1,70 @@
+classdef PerLabelEvalModel < reg.mvc.BaseModel
+    %PERLABELEVALMODEL Stub model computing recall per label.
+
+    properties
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+    end
+
+    methods
+        function obj = PerLabelEvalModel(cfg)
+            %PERLABELEVALMODEL Construct per-label evaluation model.
+            %   OBJ = PERLABELEVALMODEL(cfg) uses fields such as cfg.recallK
+            %   for the cutoff K.
+            if nargin > 0
+                obj.cfg = cfg;
+            end
+        end
+
+        function raw = load(~, varargin) %#ok<INUSD>
+            %LOAD Gather embeddings and labels for recall evaluation.
+            %   raw = LOAD(obj) returns inputs for per-label recall@K.
+            %   Parameters
+            %       varargin - Placeholder for future options (unused)
+            %   Returns
+            %       raw (struct):
+            %           .embeddings   (N x D double)   - document vectors
+            %           .labelsLogical(N x L logical) - label matrix
+            %           .k            (scalar)         - recall cutoff
+            %   Side Effects
+            %       None.
+            %   Legacy Reference
+            %       Mirrors data preparation in `eval_per_label`.
+            %   Extension Point
+            %       Override to retrieve embeddings from cache or disk.
+            %   Pseudocode:
+            %       1. Fetch embeddings and label matrix
+            %       2. Assemble into raw struct
+            %       3. Return raw
+            error("reg:model:NotImplemented", ...
+                "PerLabelEvalModel.load is not implemented.");
+        end
+
+        function perLabel = process(~, raw) %#ok<INUSD>
+            %PROCESS Compute per-label Recall@K.
+            %   perLabel = PROCESS(obj, raw) returns recall metrics.
+            %   Parameters
+            %       raw (struct):
+            %           .embeddings   (N x D double)
+            %           .labelsLogical(N x L logical)
+            %           .k            (scalar)
+            %   Returns
+            %       perLabel (table): columns
+            %           LabelIdx  double
+            %           RecallAtK double
+            %           Support   double
+            %   Side Effects
+            %       None.
+            %   Legacy Reference
+            %       Equivalent to `eval_per_label`.
+            %   Extension Point
+            %       Include precision or other metrics per label.
+            %   Pseudocode:
+            %       1. Compute cosine similarities
+            %       2. Evaluate recall@K for each label
+            %       3. Return per-label table
+            error("reg:model:NotImplemented", ...
+                "PerLabelEvalModel.process is not implemented.");
+        end
+    end
+end

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -18,7 +18,9 @@ classdef TestModelStubs < matlab.unittest.TestCase
             'reg.model.EvaluationModel',
             'reg.model.LoggingModel',
             'reg.model.GoldPackModel',
-            'reg.model.VisualizationModel'
+            'reg.model.VisualizationModel',
+            'reg.model.ClusteringEvalModel',
+            'reg.model.PerLabelEvalModel'
         };
     end
     


### PR DESCRIPTION
## Summary
- add `ClusteringEvalModel` and `PerLabelEvalModel` stub classes
- extend `EvalController` to orchestrate optional clustering and per-label evaluations
- ensure stub tests cover new models

## Testing
- `matlab -batch "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*
- `octave --eval "runtests('tests/TestModelStubs.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f5014c1788330a0a74c67884ea5be