### PR TITLE
Stub visualization methods and split responsibilities

### DIFF
--- a/+reg/+model/CoRetrievalHeatmapModel.m
+++ b/+reg/+model/CoRetrievalHeatmapModel.m
@@ -1,0 +1,39 @@
+classdef CoRetrievalHeatmapModel < reg.mvc.BaseModel
+    %CORETRIEVALHEATMAPMODEL Stub model dedicated to co-retrieval heatmaps.
+    %   Encapsulates generation of label co-retrieval visualisations separate
+    %   from other plotting utilities.
+
+    methods
+        function pngPath = plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels) %#ok<INUSD>
+            %PLOTCORETRIEVALHEATMAP Visualise label co-retrieval frequencies.
+            %   Inputs
+            %       embeddings  - numeric matrix of embedding vectors.
+            %       labelMatrix - logical or numeric matrix denoting labels for
+            %                     each embedding.
+            %       pngPath     - destination file path for the heatmap PNG.
+            %       labels      - (optional) cell array of label names to use for
+            %                     axis annotations.
+            %   Output
+            %       pngPath     - the path where the heatmap image should be
+            %                     saved.
+            %   Side Effects
+            %       Should compute a co-retrieval matrix from the embeddings and
+            %       labels and persist a heatmap to pngPath.
+
+            error('reg:model:NotImplemented', ...
+                'CoRetrievalHeatmapModel.plotCoRetrievalHeatmap is not implemented.');
+        end
+
+        function data = load(~, varargin) %#ok<INUSD>
+            %LOAD Stub for interface completeness.
+            error('reg:model:NotImplemented', ...
+                'CoRetrievalHeatmapModel.load is not implemented.');
+        end
+
+        function result = process(~, data) %#ok<INUSD>
+            %PROCESS Stub for interface completeness.
+            error('reg:model:NotImplemented', ...
+                'CoRetrievalHeatmapModel.process is not implemented.');
+        end
+    end
+end

--- a/+reg/+model/TrendPlotModel.m
+++ b/+reg/+model/TrendPlotModel.m
@@ -1,0 +1,35 @@
+classdef TrendPlotModel < reg.mvc.BaseModel
+    %TRENPLOTMODEL Stub model dedicated to rendering metric trend plots.
+    %   Separates trend visualisation responsibilities from other plotting
+    %   utilities for finer granularity.
+
+    methods
+        function pngPath = plotTrends(~, csvPath, pngPath) %#ok<INUSD>
+            %PLOTTRENDS Visualise metric trends over time.
+            %   Inputs
+            %       csvPath - path to a CSV file containing historical metric
+            %                 values.
+            %       pngPath - destination file path for the generated PNG.
+            %   Output
+            %       pngPath - the path where the trend plot should be saved.
+            %   Side Effects
+            %       Should read metrics from csvPath and write a plot image to
+            %       pngPath.
+
+            error('reg:model:NotImplemented', ...
+                'TrendPlotModel.plotTrends is not implemented.');
+        end
+
+        function data = load(~, varargin) %#ok<INUSD>
+            %LOAD Stub for interface completeness.
+            error('reg:model:NotImplemented', ...
+                'TrendPlotModel.load is not implemented.');
+        end
+
+        function result = process(~, data) %#ok<INUSD>
+            %PROCESS Stub for interface completeness.
+            error('reg:model:NotImplemented', ...
+                'TrendPlotModel.process is not implemented.');
+        end
+    end
+end

--- a/+reg/+model/VisualizationModel.m
+++ b/+reg/+model/VisualizationModel.m
@@ -11,28 +11,35 @@ classdef VisualizationModel < reg.mvc.BaseModel
 
         function pngPath = plotTrends(~, csvPath, pngPath) %#ok<INUSD>
             %PLOTTRENDS Generate trend plots from metrics history.
-            %   pngPath = PLOTTRENDS(obj, csvPath, pngPath) should read a
-            %   CSV of historical metrics and render a trend PNG.
-            %   Legacy Reference
-            %       Equivalent to `reg.plot_trends`.
-            %   Pseudocode:
-            %       1. Read metrics from csvPath
-            %       2. Plot trends and save to pngPath
-            %       3. Return pngPath
+            %   Inputs
+            %       csvPath - file path to a metrics CSV containing
+            %                 historical values.
+            %       pngPath - destination file path for the rendered PNG.
+            %   Output
+            %       pngPath - the path where the plot should be written.
+            %   Side Effects
+            %       Should read metric values from csvPath and write a trend
+            %       plot image to pngPath.
+
             error("reg:model:NotImplemented", ...
                 "VisualizationModel.plotTrends is not implemented.");
         end
 
         function pngPath = plotCoRetrievalHeatmap(~, embeddings, labelMatrix, pngPath, labels) %#ok<INUSD>
             %PLOTCORETRIEVALHEATMAP Create a heatmap of label co-retrieval.
-            %   pngPath = PLOTCORETRIEVALHEATMAP(obj, embeddings, labelMatrix,
-            %   pngPath, labels) should visualise co-retrieval frequencies.
-            %   Legacy Reference
-            %       Equivalent to `reg.plot_coretrieval_heatmap`.
-            %   Pseudocode:
-            %       1. Derive co-retrieval matrix from embeddings/labels
-            %       2. Plot heatmap ordered by label frequency
-            %       3. Save to pngPath and return path
+            %   Inputs
+            %       embeddings   - numeric matrix of embedding vectors.
+            %       labelMatrix  - logical or numeric matrix indicating label
+            %                      assignments for each embedding.
+            %       pngPath      - destination file path for the heatmap PNG.
+            %       labels       - (optional) cell array of label names used to
+            %                      annotate axes.
+            %   Output
+            %       pngPath      - the path where the heatmap should be saved.
+            %   Side Effects
+            %       Should compute co-retrieval frequencies from inputs and
+            %       persist a heatmap image to pngPath.
+
             error("reg:model:NotImplemented", ...
                 "VisualizationModel.plotCoRetrievalHeatmap is not implemented.");
         end

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -19,6 +19,8 @@ classdef TestModelStubs < matlab.unittest.TestCase
             'reg.model.LoggingModel',
             'reg.model.GoldPackModel',
             'reg.model.VisualizationModel',
+            'reg.model.TrendPlotModel',
+            'reg.model.CoRetrievalHeatmapModel',
             'reg.model.ClusteringEvalModel',
             'reg.model.PerLabelEvalModel'
         };


### PR DESCRIPTION
## Summary
- document expected inputs/outputs for `VisualizationModel` plotting helpers and mark them as not implemented
- introduce `TrendPlotModel` and `CoRetrievalHeatmapModel` as dedicated stubs for plot generation
- cover new models in stub test suite

## Testing
- `matlab -batch "run('tests/TestModelStubs.m')"` *(command not found)*
- `octave --silent --eval "run('tests/TestModelStubs.m')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f5633ee1c8330859b395a0367534a