### PR TITLE
refactor: remove default run paths and date

### DIFF
--- a/+reg/+model/DiffArticlesModel.m
+++ b/+reg/+model/DiffArticlesModel.m
@@ -8,9 +8,10 @@ classdef DiffArticlesModel < reg.mvc.BaseModel
       %LOAD Prepare parameters for article-level diffing.
       %   params = LOAD(obj, dirA, dirB, outDir) stores the directories to
       %   compare and selects an output directory for diff artefacts.
-      %   When omitted, outDir defaults to runs/crr_diff_articles.
+      %   outDir must be specified by the caller; no default is provided.
       if nargin < 4 || isempty(outDir)
-        outDir = fullfile('runs', 'crr_diff_articles');
+        error("reg:model:NotImplemented", ...
+          "outDir must be specified; no default directory is provided.");
       end
       params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
     end

--- a/+reg/+model/DiffVersionsModel.m
+++ b/+reg/+model/DiffVersionsModel.m
@@ -7,9 +7,10 @@ classdef DiffVersionsModel < reg.mvc.BaseModel
     function params = load(~, dirA, dirB, outDir)
       %LOAD Prepare parameters for file-level diffing.
       %   params = LOAD(obj, dirA, dirB, outDir) records the directories to
-      %   compare and the output directory. outDir defaults to runs/crr_diff.
+      %   compare and the output directory. Caller must supply outDir.
       if nargin < 4 || isempty(outDir)
-        outDir = fullfile('runs', 'crr_diff');
+        error("reg:model:NotImplemented", ...
+          "outDir must be specified; no default directory is provided.");
       end
       params = struct('dirA', dirA, 'dirB', dirB, 'outDir', outDir);
     end

--- a/+reg/+model/SyncModel.m
+++ b/+reg/+model/SyncModel.m
@@ -9,12 +9,13 @@ classdef SyncModel < reg.mvc.BaseModel
             %   params = LOAD(obj, date) records the target snapshot date.
             %   Parameters
             %       date (char): target snapshot date in yyyymmdd format
-            %           (defaults to current date)
+            %           (must be provided explicitly)
             %   Returns
             %       params (struct): struct with field
             %           date - synchronization date
             if nargin < 2 || isempty(date)
-                date = datestr(now, 'yyyymmdd');
+                error("reg:model:NotImplemented", ...
+                    "date must be specified; default current date removed.");
             end
             params = struct('date', date);
         end


### PR DESCRIPTION
## Summary
- require explicit outDir for DiffArticlesModel and DiffVersionsModel instead of defaulting to runs paths
- require explicit date for SyncModel load

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f5d7e25c88330b26943a5b5093173