### PR TITLE
Stub saveModel with NotImplemented placeholder

### DIFF
--- a/+reg/+controller/FineTuneController.m
+++ b/+reg/+controller/FineTuneController.m
@@ -53,12 +53,21 @@ classdef FineTuneController < reg.mvc.BaseController
             %SAVEMODEL Persist fine-tuned encoder to disk.
             %   SAVEMODEL(obj, net, filename) saves the network to a MAT
             %   file. Equivalent to model saving in `ft_train_encoder`.
-            if ~isempty(varargin)
-                filename = varargin{1};
-            else
-                filename = "fine_tuned_encoder.mat";
-            end
-            save(filename, "net", "-v7.3");
+
+            error("NotImplemented: model checkpointing");
+
+            % Pseudocode for future implementation:
+            % checkpointDir = "./checkpoints";
+            % if ~exist(checkpointDir, "dir")
+            %     mkdir(checkpointDir);
+            % end
+            % if ~isempty(varargin)
+            %     fileName = varargin{1};
+            % else
+            %     fileName = "fine_tuned_encoder.mat";
+            % end
+            % checkpointPath = fullfile(checkpointDir, fileName);
+            % save(checkpointPath, "net", "-v7.3");
         end
 
         function run(obj)


### PR DESCRIPTION
## Summary
- stub FineTuneController.saveModel to raise a NotImplemented error
- include pseudocode for future checkpoint saving logic

## Testing
- `octave -qf run_smoke_test.m` *(fails: command not found)*
- `matlab -batch "run('run_smoke_test.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f5ed62fe88330a2eb6d4ececd4229