### PR TITLE
Remove runtime toolbox license assertion

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -33,42 +33,15 @@ classdef Application < handle
 
         function start(obj)
             %START Kick off the application workflow.
-            %   Validates required toolbox licenses before delegating to
-            %   CONTROLLER.RUN which is expected to coordinate calls between
-            %   MODEL and VIEW. Any `reg:mvc:NotImplemented` errors from
-            %   stub components will surface here.
-
-            requiredToolboxes = {
-                'Text Analytics Toolbox',        'Text_Analytics_Toolbox';
-                'Deep Learning Toolbox',         'Deep_Learning_Toolbox';
-                'Statistics and Machine Learning Toolbox', 'Statistics_and_Machine_Learning_Toolbox';
-                'Database Toolbox',              'Database_Toolbox';
-                'Parallel Computing Toolbox',    'Parallel_Computing_Toolbox';
-                'MATLAB Report Generator',       'MATLAB_Report_Generator';
-                'Computer Vision Toolbox',       'Computer_Vision_Toolbox'
-            };
-            assertToolboxes(requiredToolboxes);
+            %   Delegates to CONTROLLER.RUN which is expected to coordinate
+            %   calls between MODEL and VIEW. Ensure the following MATLAB
+            %   toolboxes are installed prior to execution:
+            %   Text Analytics Toolbox, Deep Learning Toolbox, Statistics and
+            %   Machine Learning Toolbox, Database Toolbox, Parallel Computing
+            %   Toolbox, MATLAB Report Generator, Computer Vision Toolbox.
+            %   Dependency checks are not implemented here.
 
             obj.Controller.run();
         end
-    end
-end
-
-function assertToolboxes(requiredToolboxes)
-%ASSERTTOOLBOXES Ensure all required toolbox licenses are available.
-%   ASSERTTOOLBOXES(REQUIREDTOOLBOXES) tests each toolbox license and
-%   raises an error listing any missing toolboxes.
-
-    missing = {};
-    for i = 1:size(requiredToolboxes, 1)
-        displayName = requiredToolboxes{i,1};
-        licenseName = requiredToolboxes{i,2};
-        if ~license('test', licenseName)
-            missing{end+1} = displayName; %#ok<AGROW>
-        end
-    end
-
-    if ~isempty(missing)
-        error('Missing required MATLAB toolbox license(s): %s', strjoin(missing, ', '));
     end
 end


### PR DESCRIPTION
## Summary
- Simplify MVC application startup by removing runtime toolbox license check
- Document expected MATLAB toolboxes instead of asserting availability

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689f60abed8c8330b9236b9f3e8dee5e