### PR TITLE
Add evaluation metric stubs to EvaluationModel

### DIFF
--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -1,5 +1,9 @@
 classdef EvaluationModel < reg.mvc.BaseModel
     %EVALUATIONMODEL Stub model computing evaluation metrics.
+    %   This model outlines retrieval metrics including Normalized
+    %   Discounted Cumulative Gain (NDCG), Recall@K, and mean Average
+    %   Precision (mAP).  The methods below provide placeholders and
+    %   pseudocode for future metric implementations.
 
     properties
         % Shared configuration reference
@@ -40,7 +44,7 @@ classdef EvaluationModel < reg.mvc.BaseModel
         function metricsStruct = process(~, evaluationInputs) %#ok<INUSD>
             %PROCESS Compute evaluation metrics.
             %   metricsStruct = PROCESS(obj, evaluationInputs) returns a
-            %   struct of scores.
+            %   struct of scores such as NDCG, Recall@K, and mAP.
             %   Parameters
             %       evaluationInputs (struct): Predictions and references.
             %   Returns
@@ -51,12 +55,72 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %       Equivalent to `eval_retrieval`.
             %   Extension Point
             %       Add custom metrics or visualizations here.
-            % Pseudocode:
-            %   1. Compare predictions against gold labels
-            %   2. Aggregate results into metricsStruct
-            %   3. Return metricsStruct
+            %   Pseudocode:
+            %   1. Compute NDCG using computeNDCG
+            %   2. Compute Recall@K using computeRecallAtK
+            %   3. Compute mAP using computeMAP
+            %   4. Aggregate metrics into metricsStruct
+            %   5. Return metricsStruct
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.process is not implemented.");
+        end
+
+        function ndcg = computeNDCG(~, predictions, references) %#ok<INUSD>
+            %COMPUTENDCG Calculate Normalized Discounted Cumulative Gain.
+            %   ndcg = COMPUTENDCG(obj, predictions, references) returns
+            %   the average NDCG across all queries.
+            %   Parameters
+            %       predictions: Ranked retrieval results for each query.
+            %       references: Relevant items for each query.
+            %   Returns
+            %       ndcg (double): Normalized DCG score.
+            %   Pseudocode:
+            %   1. For each query, sort predictions by confidence.
+            %   2. Compute DCG using log2 discounting of ranks.
+            %   3. Compute ideal DCG using perfect ranking.
+            %   4. Divide DCG by ideal DCG and average across queries.
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.computeNDCG is not implemented.");
+        end
+
+        function recall = computeRecallAtK(~, predictions, references, K) %#ok<INUSD>
+            %COMPUTERECALLATK Calculate Recall at rank K.
+            %   recall = COMPUTERECALLATK(obj, predictions, references, K)
+            %   returns the proportion of relevant items retrieved within
+            %   the top K results.
+            %   Parameters
+            %       predictions: Ranked retrieval results for each query.
+            %       references: Relevant items for each query.
+            %       K (int): Cutoff for evaluation.
+            %   Returns
+            %       recall (double): Recall@K score.
+            %   Pseudocode:
+            %   1. For each query, take the top K predicted items.
+            %   2. Count how many are present in the reference set.
+            %   3. Divide by the total number of reference items.
+            %   4. Average the recall across queries.
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.computeRecallAtK is not implemented.");
+        end
+
+        function mAP = computeMAP(~, predictions, references) %#ok<INUSD>
+            %COMPUTEMAP Calculate mean Average Precision.
+            %   mAP = COMPUTEMAP(obj, predictions, references) returns the
+            %   mean of average precision scores across queries.
+            %   Parameters
+            %       predictions: Ranked retrieval results for each query.
+            %       references: Relevant items for each query.
+            %   Returns
+            %       mAP (double): Mean average precision.
+            %   Pseudocode:
+            %   1. For each query, iterate through ranked predictions.
+            %   2. Each time a relevant item is found, compute precision
+            %      up to that rank and accumulate.
+            %   3. Divide accumulated precision by number of relevant
+            %      items to get AP per query.
+            %   4. Average AP scores across queries for final mAP.
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.computeMAP is not implemented.");
         end
     end
 end


### PR DESCRIPTION
## Summary
- document expected retrieval metrics (NDCG, Recall@K, mAP)
- add stubbed methods with pseudocode for NDCG, Recall@K, and mean Average Precision

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "disp('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f61e23670833086ee5fccaf0a9db3