### PR TITLE
refactor: delegate embeddings to dedicated model

### DIFF
--- a/+reg/+model/EmbeddingModel.m
+++ b/+reg/+model/EmbeddingModel.m
@@ -1,0 +1,72 @@
+classdef EmbeddingModel < reg.mvc.BaseModel
+    %EMBEDDINGMODEL Stub model generating dense embeddings from features.
+    %   This model is responsible for transforming sparse feature
+    %   representations into dense vector embeddings.
+    %
+    % Inputs expected by PROCESS:
+    %   featureData (table) : Typically the output of FeatureModel.process
+    %
+    % Outputs returned by PROCESS:
+    %   embeddings (double matrix N×D) : dense embedding vectors per item
+    %   vocab      (string array)       : optional vocabulary mapping
+    %
+    % The actual embedding backend (e.g., BERT, fastText) is left to concrete
+    % subclasses or future implementations.
+
+    properties
+        % Shared configuration reference
+        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+    end
+
+    methods
+        function obj = EmbeddingModel(cfg)
+            %EMBEDDINGMODEL Construct embedding generation model.
+            %   OBJ = EMBEDDINGMODEL(cfg) uses parameters such as encoder
+            %   selection or batch size from cfg.
+            if nargin > 0
+                obj.cfg = cfg;
+            end
+        end
+
+        function featureData = load(~, varargin) %#ok<INUSD>
+            %LOAD Prepare data for embedding computation.
+            %   featureData = LOAD(obj, features) adapts feature structures
+            %   for embedding generation.
+            %   Parameters
+            %       varargin - Placeholder for future options or feature data.
+            %   Returns
+            %       featureData (table): Data ready for embedding.
+            %   Side Effects
+            %       None.
+            %   Extension Point
+            %       Override to read from cached feature matrices or other
+            %       data sources.
+            error("reg:model:NotImplemented", ...
+                "EmbeddingModel.load is not implemented.");
+        end
+
+        function [embeddings, vocab] = process(~, featureData) %#ok<INUSD>
+            %PROCESS Compute dense embeddings from features.
+            %   [embeddings, vocab] = PROCESS(obj, featureData) performs the
+            %   actual forward pass of the embedding model.
+            %   Parameters
+            %       featureData (table): Prepared features to embed.
+            %   Returns
+            %       embeddings (double matrix): Dense vectors.
+            %       vocab (string array): Optional vocabulary mapping.
+            %   Side Effects
+            %       May update cached embeddings on disk.
+            %   Legacy Reference
+            %       Equivalent to the embedding portion previously handled in
+            %       FeatureModel.process.
+            %   Extension Point
+            %       Implement embedding logic using specific neural models.
+            % Pseudocode:
+            %   1. Load encoder and tokenizer
+            %   2. Embed featureData into dense vectors
+            %   3. Return embeddings and vocabulary
+            error("reg:model:NotImplemented", ...
+                "EmbeddingModel.process is not implemented.");
+        end
+    end
+end

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -1,5 +1,7 @@
 classdef FeatureModel < reg.mvc.BaseModel
     %FEATUREMODEL Stub model generating feature representations.
+    %   Dense embedding generation has been split into
+    %   `reg.model.EmbeddingModel` and is no longer handled here.
     %
     % Input chunksTable schema (see TextChunkModel):
     %   chunk_id  (string) : chunk identifier
@@ -9,12 +11,11 @@ classdef FeatureModel < reg.mvc.BaseModel
     %   end_idx   (double) : ending token index
     %
     % Outputs returned by PROCESS:
-    %   features   (table) : columns
+    %   features (table) : columns
     %       - chunk_id (string) : reference to source chunk
     %       - doc_id   (string) : parent document identifier
     %       - tfidf    (double vector 1xV) : TF-IDF features
-    %   embeddings (double matrix N×D) : dense embedding vectors per chunk
-    %   vocab      (string array 1×V)  : vocabulary terms corresponding to tfidf
+    %   vocab    (string array 1×V)  : vocabulary terms corresponding to tfidf
 
     properties
         % Shared configuration reference
@@ -50,26 +51,26 @@ classdef FeatureModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented", ...
                 "FeatureModel.load is not implemented.");
         end
-        function [features, embeddings, vocab] = process(~, chunksTable) %#ok<INUSD>
-            %PROCESS Generate features and embeddings.
-            %   [features, embeddings, vocab] = PROCESS(obj, chunksTable)
-            %   produces numerical representations.
+        function [features, vocab] = process(~, chunksTable) %#ok<INUSD>
+            %PROCESS Generate sparse feature representations.
+            %   [features, vocab] = PROCESS(obj, chunksTable) produces
+            %   TF-IDF or other sparse features.  Any dense embedding
+            %   computation should be handled by `reg.model.EmbeddingModel`.
             %   Parameters
-            %       chunksTable (table): Text segments to embed.
+            %       chunksTable (table): Text segments to featurize.
             %   Returns
             %       features (table): Derived feature table.
-            %       embeddings (double matrix): Embedding vectors.
-            %       vocab (string array): Vocabulary mapping.
+            %       vocab    (string array): Vocabulary mapping.
             %   Side Effects
             %       May update feature caches on disk.
             %   Legacy Reference
-            %       Equivalent to `precompute_embeddings`.
+            %       Equivalent to the feature extraction portion of
+            %       `precompute_embeddings`.
             %   Extension Point
-            %       Customize embedding models or feature extraction steps.
+            %       Customize feature extraction steps or vocab pruning.
             % Pseudocode:
             %   1. Tokenize text in chunksTable
-            %   2. Compute embeddings using configured model
-            %   3. Assemble features table and vocabulary
+            %   2. Compute sparse features and vocabulary
             error("reg:model:NotImplemented", ...
                 "FeatureModel.process is not implemented.");
         end

--- a/CLASS_ARCHITECTURE.md
+++ b/CLASS_ARCHITECTURE.md
@@ -25,7 +25,8 @@ interfaces, data flow, and orchestration.
 | `reg.model.ConfigModel` | Retrieve configuration parameters |
 | `reg.model.PDFIngestModel` | Convert PDFs into a document table |
 | `reg.model.TextChunkModel` | Split documents into token chunks |
-| `reg.model.FeatureModel` | Generate TF‑IDF, topics, and embeddings |
+| `reg.model.FeatureModel` | Generate TF‑IDF and topic features |
+| `reg.model.EmbeddingModel` | Compute dense text embeddings |
 | `reg.model.ProjectionHeadModel` | Apply optional projection head |
 | `reg.model.WeakLabelModel` | Produce weak and bootstrapped labels |
 | `reg.model.ClassifierModel` | Train models and produce predictions |

--- a/tests/TestModelStubs.m
+++ b/tests/TestModelStubs.m
@@ -7,6 +7,7 @@ classdef TestModelStubs < matlab.unittest.TestCase
             'reg.model.PDFIngestModel',
             'reg.model.TextChunkModel',
             'reg.model.FeatureModel',
+            'reg.model.EmbeddingModel',
             'reg.model.ProjectionHeadModel',
             'reg.model.WeakLabelModel',
             'reg.model.ClassifierModel',

--- a/tests/TestPipelineController.m
+++ b/tests/TestPipelineController.m
@@ -11,6 +11,7 @@ classdef TestPipelineController < matlab.unittest.TestCase
             pdfModel = reg.model.PDFIngestModel();
             chunkModel = reg.model.TextChunkModel();
             featModel = reg.model.FeatureModel();
+            embModel = reg.model.EmbeddingModel();
             projModel = reg.model.ProjectionHeadModel();
             weakModel = reg.model.WeakLabelModel();
             clsModel = reg.model.ClassifierModel();
@@ -19,7 +20,7 @@ classdef TestPipelineController < matlab.unittest.TestCase
             logModel = reg.model.LoggingModel();
             reportModel = reg.model.ReportModel();
             view = reg.view.ReportView();
-            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, clsModel, searchModel, dbModel, logModel, reportModel, view);
+            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, embModel, projModel, weakModel, clsModel, searchModel, dbModel, logModel, reportModel, view);
         end
     end
     

--- a/tests/TestPipelineLogging.m
+++ b/tests/TestPipelineLogging.m
@@ -12,6 +12,7 @@ classdef TestPipelineLogging < RegTestCase
             pdfModel   = PassThroughModel();
             chunkModel = PassThroughModel();
             featModel  = FeatureStub();
+            embModel   = EmbeddingStub();
             projModel  = PassThroughModel();
             weakModel  = PassThroughModel();
             clsModel   = ClassifierStub();
@@ -20,7 +21,7 @@ classdef TestPipelineLogging < RegTestCase
             tc.LogModel = LogSpyModel();
             reportModel = PassThroughModel();
             view       = SpyView();
-            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, projModel, weakModel, ...
+            tc.Controller = reg.controller.PipelineController(cfgModel, pdfModel, chunkModel, featModel, embModel, projModel, weakModel, ...
                 clsModel, searchModel, dbModel, tc.LogModel, reportModel, view);
         end
     end
@@ -71,9 +72,21 @@ classdef FeatureStub < handle
         function data = load(~, ~)
             data = [];
         end
-        function [features, embeddings, vocab] = process(~, ~)
+        function [features, vocab] = process(~, ~)
             features = [];
-            embeddings = [];
+            vocab = [];
+        end
+    end
+end
+
+classdef EmbeddingStub < handle
+    methods
+        function data = load(~, in)
+            if nargin < 2, in = []; end
+            data = in;
+        end
+        function [embeddings, vocab] = process(~, data)
+            embeddings = data;
             vocab = [];
         end
     end


### PR DESCRIPTION
## Summary
- introduce `EmbeddingModel` stub for standalone embedding generation
- update `FeatureModel` and pipeline controllers to call new embedding model
- adjust tests and docs for split feature/embedding responsibilities

## Testing
- `matlab -batch "results=runtests('tests'); disp(results); assertSuccess(results);"` *(fails: command not found)*
- `octave -qf --eval "runtests('tests')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689f65a0b79c833096f1a88e6cc4ebc3