### PR TITLE
Document pair generation stub in FineTuneDataModel

### DIFF
--- a/+reg/+model/FineTuneDataModel.m
+++ b/+reg/+model/FineTuneDataModel.m
@@ -36,10 +36,34 @@ classdef FineTuneDataModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented", ...
                 "FineTuneDataModel.load is not implemented.");
         end
+
+        function pairs = buildPairs(~, labelsLogical) %#ok<INUSD>
+            %BUILDPairs Generate anchor-positive-negative pairs from labels.
+            %   pairs = BUILDPairs(obj, labelsLogical) wraps the standalone
+            %   `reg.build_pairs` utility and prepares pair indices prior to
+            %   triplet assembly.
+            %   Parameters
+            %       labelsLogical (logical matrix): Label matrix per sample.
+            %   Returns
+            %       pairs (struct): Fields anchor, positive, negative.
+            %   Legacy Reference
+            %       Mirrors `reg.build_pairs` behaviour.
+            %   Extension Point
+            %       Override to inject alternative sampling strategies.
+            % Pseudocode:
+            %   1. Validate labelsLogical input
+            %   2. Call build_pairs(labelsLogical, ...)
+            %   3. Return pairs
+            error("reg:model:NotImplemented", ...
+                "FineTuneDataModel.buildPairs is not implemented.");
+        end
+
         function triplets = process(~, rawData) %#ok<INUSD>
             %PROCESS Build contrastive triplets from inputs.
             %   triplets = PROCESS(obj, rawData) returns an array of triplet
-            %   structs.
+            %   structs. Internally uses buildPairs (wrapping `reg.build_pairs`)
+            %   to form anchor-positive-negative candidates prior to triplet
+            %   assembly.
             %   Parameters
             %       rawData (struct): Raw positive/negative pairs.
             %   Returns
@@ -51,8 +75,8 @@ classdef FineTuneDataModel < reg.mvc.BaseModel
             %   Extension Point
             %       Customize sampling strategies or hard negative mining.
             % Pseudocode:
-            %   1. Pair anchors with positives and negatives
-            %   2. Assemble into triplets table
+            %   1. Generate pair indices using buildPairs
+            %   2. Assemble pairs into triplets table
             %   3. Return triplets
             error("reg:model:NotImplemented", ...
                 "FineTuneDataModel.process is not implemented.");


### PR DESCRIPTION
## Summary
- document that triplet assembly uses pair generation via `buildPairs`
- add `buildPairs` stub wrapping `reg.build_pairs`

## Testing
- `apt-get update` *(fails: repository not signed 403)*
- `octave --no-gui --eval "run('run_smoke_test.m')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f688472608330b2793479be69cdcd