### PR TITLE
feat: add CRR fetch controller

### DIFF
--- a/+reg/+controller/CrrFetchController.m
+++ b/+reg/+controller/CrrFetchController.m
@@ -1,0 +1,60 @@
+classdef CrrFetchController < reg.mvc.BaseController
+    %CRRFETCHCONTROLLER Retrieve CRR corpora from public sources.
+    %   Provides high-level methods for downloading articles from the EBA
+    %   Interactive Single Rulebook and the consolidated regulation PDF
+    %   from EUR-Lex. Results may optionally be forwarded to a view such as
+    %   `reg.view.ReportView` for presentation.
+
+    methods
+        function obj = CrrFetchController(model, view)
+            %CRRFETCHCONTROLLER Construct controller wiring model and view.
+            %   OBJ = CRRFETCHCONTROLLER(model, view) creates a controller
+            %   backed by a `reg.model.CrrFetchModel` and a view for
+            %   displaying results. MODEL defaults to
+            %   `reg.model.CrrFetchModel()` and VIEW defaults to
+            %   `reg.view.ReportView()`.
+            if nargin < 1 || isempty(model)
+                model = reg.model.CrrFetchModel();
+            end
+            if nargin < 2 || isempty(view)
+                view = reg.view.ReportView();
+            end
+            obj@reg.mvc.BaseController(model, view);
+        end
+
+        function T = fetchEba(obj, varargin)
+            %FETCHEBA Download CRR articles from EBA Single Rulebook.
+            %   T = FETCHEBA(obj, Name, Value, ...) invokes the underlying
+            %   model to retrieve HTML/plaintext articles. The metadata
+            %   table T mirrors the output of `fetch_crr_eba`.
+            T = obj.Model.fetchEba(varargin{:});
+            if ~isempty(obj.View)
+                obj.View.display(T);
+            end
+        end
+
+        function T = fetchEbaParsed(obj, varargin)
+            %FETCHEBAPARSED Download CRR articles with parsed numbers.
+            %   T = FETCHEBAPARSED(obj, Name, Value, ...) retrieves
+            %   articles and augments metadata with a parsed `article_num`
+            %   column. The table is forwarded to the configured view when
+            %   present.
+            T = obj.Model.fetchEbaParsed(varargin{:});
+            if ~isempty(obj.View)
+                obj.View.display(T);
+            end
+        end
+
+        function pdfPath = fetchEurlex(obj, varargin)
+            %FETCHEURLEX Download consolidated CRR PDF from EUR-Lex.
+            %   pdfPath = FETCHEURLEX(obj, Name, Value, ...) downloads the
+            %   consolidated regulation PDF and returns the file path. The
+            %   path is forwarded to the view if one is configured.
+            pdfPath = obj.Model.fetchEurlex(varargin{:});
+            if ~isempty(obj.View)
+                obj.View.display(pdfPath);
+            end
+        end
+    end
+end
+


### PR DESCRIPTION
## Summary
- add CrrFetchController to wire fetching utilities through MVC layer
- expose fetchEba, fetchEbaParsed and fetchEurlex helpers with optional ReportView forwarding

## Testing
- `matlab -batch "exit"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f7189d0308330abb8fc8f2cd30d26