### PR TITLE
Introduce specialized views for diff, embedding and plot rendering

### DIFF
--- a/+reg/+controller/DiffArticlesController.m
+++ b/+reg/+controller/DiffArticlesController.m
@@ -13,12 +13,13 @@ classdef DiffArticlesController < reg.mvc.BaseController
             %   OBJ = DIFFARTICLESCONTROLLER(service, view) wires a
             %   DiffService to a view. SERVICE defaults to
             %   `reg.service.DiffService()` and VIEW defaults to
-            %   `reg.view.ReportView()`.
+            %   `reg.view.DiffView()` which focuses purely on rendering
+            %   diff artefacts.
             if nargin < 1 || isempty(service)
                 service = reg.service.DiffService();
             end
             if nargin < 2 || isempty(view)
-                view = reg.view.ReportView();
+                view = reg.view.DiffView();
             end
             obj@reg.mvc.BaseController([], view);
             obj.DiffService = service;

--- a/+reg/+controller/DiffVersionsController.m
+++ b/+reg/+controller/DiffVersionsController.m
@@ -9,12 +9,13 @@ classdef DiffVersionsController < reg.mvc.BaseController
             %   OBJ = DIFFVERSIONSCONTROLLER(model, view) wires a
             %   DiffVersionsModel to a view. MODEL defaults to
             %   `reg.model.DiffVersionsModel()` and VIEW defaults to
-            %   `reg.view.ReportView()`.
+            %   `reg.view.DiffView()` which is responsible solely for
+            %   rendering diff results.
             if nargin < 1 || isempty(model)
                 model = reg.model.DiffVersionsModel();
             end
             if nargin < 2 || isempty(view)
-                view = reg.view.ReportView();
+                view = reg.view.DiffView();
             end
             obj@reg.mvc.BaseController(model, view);
         end

--- a/+reg/+controller/MethodsDiffController.m
+++ b/+reg/+controller/MethodsDiffController.m
@@ -9,12 +9,12 @@ classdef MethodsDiffController < reg.mvc.BaseController
             %   OBJ = METHODSDIFFCONTROLLER(model, view) wires a
             %   MethodDiffModel to a view. MODEL defaults to
             %   `reg.model.MethodDiffModel()` and VIEW defaults to
-            %   `reg.view.ReportView()`.
+            %   `reg.view.DiffView()` for rendering retrieval differences.
             if nargin < 1 || isempty(model)
                 model = reg.model.MethodDiffModel();
             end
             if nargin < 2 || isempty(view)
-                view = reg.view.ReportView();
+                view = reg.view.DiffView();
             end
             obj@reg.mvc.BaseController(model, view);
         end

--- a/+reg/+view/DiffView.m
+++ b/+reg/+view/DiffView.m
@@ -1,0 +1,27 @@
+classdef DiffView < reg.mvc.BaseView
+    %DIFFVIEW Stub view for presenting diff results between corpora or methods.
+    %   Expects DATA representing domain differences such as tables, structs
+    %   or file paths. Controllers like DiffArticlesController forward diff
+    %   results here for rendering or persistence.
+
+    properties
+        DiffResult
+
+        % Optional callback executed after display ------------------------
+        OnDisplayCallback
+    end
+
+    methods
+        function display(obj, data)
+            %DISPLAY Store diff data for inspection.
+            %   DISPLAY(obj, DATA) retains diff structures for verification.
+            %   In a production setting this method might pretty-print
+            %   summaries or write patch files to disk.
+
+            obj.DiffResult = data;
+            if ~isempty(obj.OnDisplayCallback)
+                obj.OnDisplayCallback(data);
+            end
+        end
+    end
+end

--- a/+reg/+view/EmbeddingView.m
+++ b/+reg/+view/EmbeddingView.m
@@ -1,0 +1,36 @@
+classdef EmbeddingView < reg.mvc.BaseView
+    %EMBEDDINGVIEW Stub view for rendering embedding outputs.
+    %   Expects DATA as a numeric matrix or reg.service.EmbeddingOutput.
+    %   Rendering is limited to printing vector dimensions or persisting
+    %   via callbacks; all computation remains within services.
+
+    properties
+        DisplayedEmbeddings
+
+        % Optional callback executed after display ------------------------
+        OnDisplayCallback
+    end
+
+    methods
+        function display(obj, data)
+            %DISPLAY Store embedding data for inspection.
+            %   DISPLAY(obj, DATA) retains embedding vectors and reports
+            %   their dimensions. In production this might serialise
+            %   embeddings or send them to a visualiser.
+
+            obj.DisplayedEmbeddings = data;
+            vecs = [];
+            if isa(data, 'reg.service.EmbeddingOutput')
+                vecs = data.Vectors;
+            elseif isnumeric(data)
+                vecs = data;
+            end
+            if ~isempty(vecs)
+                fprintf('Embeddings: %d-by-%d matrix\n', size(vecs,1), size(vecs,2));
+            end
+            if ~isempty(obj.OnDisplayCallback)
+                obj.OnDisplayCallback(data);
+            end
+        end
+    end
+end

--- a/+reg/+view/PlotView.m
+++ b/+reg/+view/PlotView.m
@@ -1,0 +1,34 @@
+classdef PlotView < reg.mvc.BaseView
+    %PLOTVIEW Stub view for displaying plot artefacts like PNGs or figures.
+    %   Expects DATA struct containing plot file paths or chart handles.
+
+    properties
+        DisplayedPlots
+
+        % Optional callback executed after display ------------------------
+        OnDisplayCallback
+    end
+
+    methods
+        function display(obj, data)
+            %DISPLAY Store plot references and optionally print paths.
+            %   DISPLAY(obj, DATA) captures plot artefacts for verification.
+            %   A real implementation might embed images into reports or
+            %   open figures interactively.
+
+            obj.DisplayedPlots = data;
+            if isstruct(data)
+                fns = fieldnames(data);
+                for i = 1:numel(fns)
+                    val = data.(fns{i});
+                    if ischar(val) || isstring(val)
+                        fprintf('Plot saved to %s\n', string(val));
+                    end
+                end
+            end
+            if ~isempty(obj.OnDisplayCallback)
+                obj.OnDisplayCallback(data);
+            end
+        end
+    end
+end

--- a/tests/TestEvaluationPipeline.m
+++ b/tests/TestEvaluationPipeline.m
@@ -6,10 +6,11 @@ classdef TestEvaluationPipeline < matlab.unittest.TestCase
             % Set up stubbed controller, visualization model and view
             viz  = StubVizModel();
             ctrl = StubEvalController(viz);
-            view = SpyView();
+            metricsView = SpyView();
+            plotView = SpyView();
 
             % Execute pipeline
-            pipe = reg.controller.EvaluationPipeline(ctrl, view);
+            pipe = reg.controller.EvaluationPipeline(ctrl, metricsView, plotView);
             pipe.run('goldDir', 'metrics.csv');
 
             % Controller should evaluate gold pack
@@ -18,11 +19,14 @@ classdef TestEvaluationPipeline < matlab.unittest.TestCase
             % Visualization model should receive metrics CSV
             tc.verifyEqual(viz.TrendsArgs{1}, 'metrics.csv');
 
-            % View should be handed paths to generated plots
-            tc.verifyEqual(view.DisplayedData.TrendsPNG, ...
+            % Plot view should be handed paths to generated plots
+            tc.verifyEqual(plotView.DisplayedData.TrendsPNG, ...
                 fullfile(tempdir(), 'trends.png'));
-            tc.verifyEqual(view.DisplayedData.HeatmapPNG, ...
+            tc.verifyEqual(plotView.DisplayedData.HeatmapPNG, ...
                 fullfile(tempdir(), 'heatmap.png'));
+
+            % Metrics view should receive evaluation results
+            tc.verifyTrue(isstruct(metricsView.DisplayedData));
         end
     end
 end


### PR DESCRIPTION
## Summary
- add `DiffView`, `EmbeddingView`, and `PlotView` to isolate rendering of diffs, embeddings and charts
- route diff controllers to `DiffView` and pass embedding outputs to a dedicated view in `PipelineController`
- split `EvaluationPipeline` outputs so plots render via `PlotView` and metrics via the main view

## Testing
- `matlab -batch "cd tests; results=runtests('TestEvaluationPipeline'); disp(results); exit(~all([results.Passed]));"` *(fails: command not found)*
- `octave --eval "cd tests; results=runtests('TestEvaluationPipeline.m'); disp(results);"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f80af06608330862fe3845e0a7cdd