### PR TITLE
refactor: centralize configuration service

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -1,8 +1,8 @@
 classdef PipelineController < reg.mvc.BaseController
     %PIPELINECONTROLLER Orchestrates end-to-end pipeline flow.
-    
+
     properties
-        ConfigModel
+        ConfigService
         IngestionService
         EmbeddingService
         EvaluationService
@@ -11,7 +11,7 @@ classdef PipelineController < reg.mvc.BaseController
     end
 
     methods
-        function obj = PipelineController(cfgModel, ingestSvc, embedSvc, evalSvc, logModel, view, embView)
+        function obj = PipelineController(cfgSvc, ingestSvc, embedSvc, evalSvc, logModel, view, embView)
             %PIPELINECONTROLLER Construct controller wiring core services.
             %   OBJ = PIPELINECONTROLLER(CFG, INGEST, EMBED, EVAL, LOG, VIEW, EMBVIEW)
             %   stores references to the provided services, a metrics view
@@ -22,8 +22,8 @@ classdef PipelineController < reg.mvc.BaseController
             if nargin < 7 || isempty(embView)
                 embView = reg.view.EmbeddingView();
             end
-            obj@reg.mvc.BaseController(cfgModel, view);
-            obj.ConfigModel = cfgModel;
+            obj@reg.mvc.BaseController(cfgSvc, view);
+            obj.ConfigService = cfgSvc;
             obj.IngestionService = ingestSvc;
             obj.EmbeddingService = embedSvc;
             obj.EvaluationService = evalSvc;
@@ -36,8 +36,7 @@ classdef PipelineController < reg.mvc.BaseController
             %   Sequencing: Config -> Ingestion -> Embedding -> Evaluation.
 
             % Step 1: retrieve configuration
-            cfgRaw = obj.ConfigModel.load();
-            cfg = obj.ConfigModel.process(cfgRaw);
+            cfg = obj.ConfigService.getConfig();
 
             % Step 2: ingest documents/features via service
             ingestOut = obj.IngestionService.ingest(cfg);

--- a/+reg/+model/ClassifierModel.m
+++ b/+reg/+model/ClassifierModel.m
@@ -7,18 +7,11 @@ classdef ClassifierModel < reg.mvc.BaseModel
     %   predLabels  (logical matrix N×K): final binary predictions
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ClassifierModel(cfg)
-            %CLASSIFIERMODEL Construct classifier model.
-            %   OBJ = CLASSIFIERMODEL(cfg) uses shared configuration
-            %   parameters, e.g. cfg.kfold or cfg.minRuleConf.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = ClassifierModel(varargin)
+            %#ok<INUSD>
         end
 
         function trainingInputs = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/ClusteringEvalModel.m
+++ b/+reg/+model/ClusteringEvalModel.m
@@ -2,18 +2,11 @@ classdef ClusteringEvalModel < reg.mvc.BaseModel
     %CLUSTERINGEVALMODEL Stub model evaluating embedding clusters.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ClusteringEvalModel(cfg)
-            %CLUSTERINGEVALMODEL Construct clustering evaluation model.
-            %   OBJ = CLUSTERINGEVALMODEL(cfg) accesses fields such as
-            %   cfg.clusterK for the number of clusters.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = ClusteringEvalModel(varargin)
+            %#ok<INUSD>
         end
 
         function raw = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -4,19 +4,11 @@ classdef DatabaseModel < reg.mvc.BaseModel
     properties
         % Database connection handle created in `load` (default: [])
         conn = [];
-
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = DatabaseModel(cfg)
-            %DATABASEMODEL Construct database model.
-            %   OBJ = DATABASEMODEL(cfg) uses database settings from
-            %   cfg.db.* such as cfg.db.enable or cfg.db.sqlitePath.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = DatabaseModel(varargin)
+            %#ok<INUSD>
         end
 
         function dbHandles = load(obj, varargin) %#ok<INUSD>
@@ -41,7 +33,7 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %       * Ensure existing connections are cleaned before opening new ones.
             % Pseudocode:
             %   1. If obj.conn is open, close it
-            %   2. Create new connection using cfg.db parameters
+            %   2. Create new connection using configuration parameters
             %   3. Store handle in obj.conn and return struct
             % TODO: add connection validation and retry logic
             error("reg:model:NotImplemented", ...

--- a/+reg/+model/EncoderFineTuneModel.m
+++ b/+reg/+model/EncoderFineTuneModel.m
@@ -2,18 +2,11 @@ classdef EncoderFineTuneModel < reg.mvc.BaseModel
     %ENCODERFINETUNEMODEL Stub model for encoder fine-tuning.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = EncoderFineTuneModel(cfg)
-            %ENCODERFINETUNEMODEL Construct fine-tuning model.
-            %   OBJ = ENCODERFINETUNEMODEL(cfg) consumes parameters such as
-            %   cfg.fineTuneLoss or cfg.fineTuneBatchSize.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = EncoderFineTuneModel(varargin)
+            %#ok<INUSD>
         end
 
         function trainingData = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/FeatureModel.m
+++ b/+reg/+model/FeatureModel.m
@@ -18,25 +18,19 @@ classdef FeatureModel < reg.mvc.BaseModel
     %   vocab    (string array 1×V)  : vocabulary terms corresponding to tfidf
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+        % Configuration is supplied via method inputs.
     end
 
     methods
-        function obj = FeatureModel(cfg)
-            %FEATUREMODEL Construct feature extraction model.
-            %   OBJ = FEATUREMODEL(cfg) uses parameters such as
-            %   cfg.bertMiniBatchSize when computing embeddings.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = FeatureModel(varargin)
+            %#ok<INUSD>
         end
 
-        function chunksTable = load(~, varargin) %#ok<INUSD>
+        function chunksTable = load(~, cfg) %#ok<INUSD>
             %LOAD Retrieve text chunks for feature extraction.
-            %   chunksTable = LOAD(obj) returns a table of text segments.
+            %   chunksTable = LOAD(obj, cfg) returns a table of text segments.
             %   Parameters
-            %       varargin - Placeholder for future options (unused)
+            %       cfg - configuration struct with options
             %   Returns
             %       chunksTable (table): Text segments awaiting embedding.
             %   Side Effects

--- a/+reg/+model/FineTuneDataModel.m
+++ b/+reg/+model/FineTuneDataModel.m
@@ -2,18 +2,11 @@ classdef FineTuneDataModel < reg.mvc.BaseModel
     %FINETUNEDATAMODEL Stub model building contrastive triplets.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = FineTuneDataModel(cfg)
-            %FINETUNEDATAMODEL Construct contrastive data model.
-            %   OBJ = FINETUNEDATAMODEL(cfg) utilises fields such as
-            %   cfg.fineTuneLoss and cfg.fineTuneBatchSize.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = FineTuneDataModel(varargin)
+            %#ok<INUSD>
         end
 
         function rawData = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/GoldPackModel.m
+++ b/+reg/+model/GoldPackModel.m
@@ -2,18 +2,11 @@ classdef GoldPackModel < reg.mvc.BaseModel
     %GOLDPACKMODEL Stub model providing labelled gold data.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = GoldPackModel(cfg)
-            %GOLDPACKMODEL Construct gold data model.
-            %   OBJ = GOLDPACKMODEL(cfg) reads paths such as cfg.inputDir
-            %   when locating packaged gold datasets.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = GoldPackModel(varargin)
+            %#ok<INUSD>
         end
 
         function goldDataStruct = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/LoggingModel.m
+++ b/+reg/+model/LoggingModel.m
@@ -2,18 +2,11 @@ classdef LoggingModel < reg.mvc.BaseModel
     %LOGGINGMODEL Stub model for persisting metrics.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = LoggingModel(cfg)
-            %LOGGINGMODEL Construct logging model.
-            %   OBJ = LOGGINGMODEL(cfg) uses settings such as cfg.reportTitle
-            %   or destination paths when recording metrics.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = LoggingModel(varargin)
+            %#ok<INUSD>
         end
 
         function metricsStruct = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/PDFIngestModel.m
+++ b/+reg/+model/PDFIngestModel.m
@@ -10,26 +10,20 @@ classdef PDFIngestModel < reg.mvc.BaseModel
     %       - modified (double): datenum timestamp of last change
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+        % No configuration stored on the model; values are supplied by callers.
     end
 
     methods
-        function obj = PDFIngestModel(cfg)
-            %PDFINGESTMODEL Construct the ingest model.
-            %   OBJ = PDFINGESTMODEL(cfg) consumes cfg.inputDir to locate
-            %   PDF files. Equivalent to `ingest_pdfs` initialization logic.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = PDFIngestModel(varargin)
+            %#ok<INUSD>
         end
 
-        function pdfFiles = load(~, varargin) %#ok<INUSD>
+        function pdfFiles = load(~, cfg) %#ok<INUSD>
             %LOAD Locate PDF files for ingestion.
-            %   pdfFiles = LOAD(obj) returns a list of file paths to be
+            %   pdfFiles = LOAD(obj, cfg) returns a list of file paths to be
             %   processed.
             %   Parameters
-            %       varargin - Placeholder for future options (unused)
+            %       cfg - Configuration struct with paths and options
             %   Returns
             %       pdfFiles (string array): Paths to PDF documents.
             %   Side Effects

--- a/+reg/+model/PerLabelEvalModel.m
+++ b/+reg/+model/PerLabelEvalModel.m
@@ -2,18 +2,11 @@ classdef PerLabelEvalModel < reg.mvc.BaseModel
     %PERLABELEVALMODEL Stub model computing recall per label.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = PerLabelEvalModel(cfg)
-            %PERLABELEVALMODEL Construct per-label evaluation model.
-            %   OBJ = PERLABELEVALMODEL(cfg) uses fields such as cfg.recallK
-            %   for the cutoff K.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = PerLabelEvalModel(varargin)
+            %#ok<INUSD>
         end
 
         function raw = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/ProjectionHeadModel.m
+++ b/+reg/+model/ProjectionHeadModel.m
@@ -2,18 +2,11 @@ classdef ProjectionHeadModel < reg.mvc.BaseModel
     %PROJECTIONHEADMODEL Stub model applying projection head to embeddings.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ProjectionHeadModel(cfg)
-            %PROJECTIONHEADMODEL Construct projection head model.
-            %   OBJ = PROJECTIONHEADMODEL(cfg) uses parameters such as
-            %   cfg.projDim or cfg.gpuEnabled when training projection heads.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = ProjectionHeadModel(varargin)
+            %#ok<INUSD>
         end
 
         function embeddingsMatrix = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/ReportModel.m
+++ b/+reg/+model/ReportModel.m
@@ -5,18 +5,11 @@ classdef ReportModel < reg.mvc.BaseModel
     %   and topic summaries.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = ReportModel(cfg)
-            %REPORTMODEL Construct report generation model.
-            %   OBJ = REPORTMODEL(cfg) accesses values like cfg.reportTitle
-            %   when assembling output.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = ReportModel(varargin)
+            %#ok<INUSD>
         end
 
         function reportInputs = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/SearchIndexModel.m
+++ b/+reg/+model/SearchIndexModel.m
@@ -2,18 +2,11 @@ classdef SearchIndexModel < reg.mvc.BaseModel
     %SEARCHINDEXMODEL Stub model building retrieval index.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = SearchIndexModel(cfg)
-            %SEARCHINDEXMODEL Construct search index model.
-            %   OBJ = SEARCHINDEXMODEL(cfg) uses settings such as
-            %   cfg.gpuEnabled or cfg.projDim when creating indexes.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = SearchIndexModel(varargin)
+            %#ok<INUSD>
         end
 
         function indexInputs = load(~, varargin) %#ok<INUSD>

--- a/+reg/+model/TextChunkModel.m
+++ b/+reg/+model/TextChunkModel.m
@@ -14,25 +14,19 @@ classdef TextChunkModel < reg.mvc.BaseModel
     %   end_idx   (double) : ending token index in source doc
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+        % No stored configuration; callers supply parameters directly.
     end
 
     methods
-        function obj = TextChunkModel(cfg)
-            %TEXTCHUNKMODEL Construct text chunking model.
-            %   OBJ = TEXTCHUNKMODEL(cfg) reads chunking parameters such as
-            %   cfg.chunkSizeTokens and cfg.chunkOverlap.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = TextChunkModel(varargin)
+            %#ok<INUSD>
         end
 
-        function documentsTable = load(~, varargin) %#ok<INUSD>
+        function documentsTable = load(~, cfg) %#ok<INUSD>
             %LOAD Fetch documents for chunking.
-            %   documentsTable = LOAD(obj) retrieves documents to split.
+            %   documentsTable = LOAD(obj, cfg) retrieves documents to split.
             %   Parameters
-            %       varargin - Placeholder for future options (unused)
+            %       cfg - configuration struct controlling chunking
             %   Returns
             %       documentsTable (table): Input documents and metadata.
             %   Side Effects

--- a/+reg/+model/WeakLabelModel.m
+++ b/+reg/+model/WeakLabelModel.m
@@ -2,18 +2,11 @@ classdef WeakLabelModel < reg.mvc.BaseModel
     %WEAKLABELMODEL Stub model generating weak supervision labels.
 
     properties
-        % Shared configuration reference
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
     end
 
     methods
-        function obj = WeakLabelModel(cfg)
-            %WEAKLABELMODEL Construct weak labeling model.
-            %   OBJ = WEAKLABELMODEL(cfg) uses configuration fields like
-            %   cfg.minRuleConf when applying heuristics.
-            if nargin > 0
-                obj.cfg = cfg;
-            end
+        function obj = WeakLabelModel(varargin)
+            %#ok<INUSD>
         end
 
         function chunksTable = load(~, varargin) %#ok<INUSD>

--- a/+reg/+service/ConfigService.m
+++ b/+reg/+service/ConfigService.m
@@ -1,0 +1,24 @@
+classdef ConfigService
+    %CONFIGSERVICE Read and provide configuration settings.
+    %   Wraps ConfigModel so controllers and services can obtain
+    %   configuration without instantiating the model directly.
+
+    properties
+        ConfigModel reg.model.ConfigModel = reg.model.ConfigModel();
+    end
+
+    methods
+        function obj = ConfigService(cfgModel)
+            %CONFIGSERVICE Construct service with underlying model.
+            if nargin > 0
+                obj.ConfigModel = cfgModel;
+            end
+        end
+
+        function cfg = getConfig(obj)
+            %GETCONFIG Load and validate configuration settings.
+            cfgRaw = obj.ConfigModel.load();
+            cfg = obj.ConfigModel.process(cfgRaw);
+        end
+    end
+end

--- a/+reg/+service/EmbeddingService.m
+++ b/+reg/+service/EmbeddingService.m
@@ -4,16 +4,16 @@ classdef EmbeddingService
     %   EmbeddingModel.
 
     properties
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+        ConfigService reg.service.ConfigService
         EmbeddingRepo reg.repository.EmbeddingRepository
         SearchRepo reg.repository.SearchIndexRepository
     end
 
     methods
-        function obj = EmbeddingService(cfg, embeddingRepo, searchRepo)
+        function obj = EmbeddingService(cfgSvc, embeddingRepo, searchRepo)
             %EMBEDDINGSERVICE Construct embedding service with dependencies.
             if nargin > 0
-                obj.cfg = cfg;
+                obj.ConfigService = cfgSvc;
             end
             if nargin > 1
                 obj.EmbeddingRepo = embeddingRepo;
@@ -35,6 +35,9 @@ classdef EmbeddingService
             %   OUTPUT = EMBED(INPUT) should return an EmbeddingOutput
             %   containing an array of `reg.model.Embedding` instances.
             %#ok<NASGU>
+            if ~isempty(obj.ConfigService)
+                cfg = obj.ConfigService.getConfig(); %#ok<NASGU>
+            end
             output = reg.service.EmbeddingOutput([]);
             if ~isempty(obj.EmbeddingRepo)
                 obj.EmbeddingRepo.save(output);

--- a/+reg/+service/EvaluationService.m
+++ b/+reg/+service/EvaluationService.m
@@ -3,14 +3,14 @@ classdef EvaluationService
     %   Centralizes logic previously in EvaluationModel.
 
     properties
-        cfg reg.model.ConfigModel = reg.model.ConfigModel();
+        ConfigService reg.service.ConfigService
     end
 
     methods
-        function obj = EvaluationService(cfg)
+        function obj = EvaluationService(cfgSvc)
             %EVALUATIONSERVICE Construct service with configuration.
             if nargin > 0
-                obj.cfg = cfg;
+                obj.ConfigService = cfgSvc;
             end
         end
 
@@ -21,9 +21,12 @@ classdef EvaluationService
             input = reg.service.EvaluationInput(pred, ref);
         end
 
-        function result = compute(~, input) %#ok<INUSD>
+        function result = compute(obj, input) %#ok<INUSD>
             %COMPUTE Calculate evaluation metrics from INPUT.
             %#ok<NASGU>
+            if ~isempty(obj.ConfigService)
+                cfg = obj.ConfigService.getConfig(); %#ok<NASGU>
+            end
             error("reg:service:NotImplemented", ...
                 "EvaluationService.compute is not implemented.");
             % result = reg.service.EvaluationResult([]);

--- a/tests/TestPipelineController.m
+++ b/tests/TestPipelineController.m
@@ -1,28 +1,29 @@
 classdef TestPipelineController < matlab.unittest.TestCase
     %TESTPIPELINECONTROLLER Ensure PipelineController propagates NotImplemented.
-    
+
     properties
         Controller
     end
-    
+
     methods(TestMethodSetup)
         function setup(tc)
             cfgModel = reg.model.ConfigModel();
+            cfgSvc = reg.service.ConfigService(cfgModel);
             ingestSvc = IngestStub();
-            embSvc = reg.service.EmbeddingService();
-            evalSvc = reg.service.EvaluationService();
+            embSvc = reg.service.EmbeddingService(cfgSvc);
+            evalSvc = reg.service.EvaluationService(cfgSvc);
             logModel = reg.model.LoggingModel();
             view = reg.view.ReportView();
-            tc.Controller = reg.controller.PipelineController(cfgModel, ingestSvc, embSvc, evalSvc, logModel, view);
+            tc.Controller = reg.controller.PipelineController(cfgSvc, ingestSvc, embSvc, evalSvc, logModel, view);
         end
     end
-    
+
     methods(TestMethodTeardown)
         function teardown(tc)
             tc.Controller = [];
         end
     end
-    
+
     methods(Test)
         function runPropagatesNotImplemented(tc)
             tc.verifyError(@() tc.Controller.run(), 'reg:service:NotImplemented');


### PR DESCRIPTION
## Summary
- Introduce `ConfigService` to load and provide configuration
- Inject `ConfigService` into pipeline, embedding, and evaluation services
- Remove direct configuration state from models and pass config at runtime

## Testing
- `octave --version` *(fails: No such file or directory)*
- `/usr/local/MATLAB/bin/matlab -batch "runtests('tests')"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689f827d09088330aa0c6b5ee647b5d6