### PR TITLE
refactor: use models instead of services

### DIFF
--- a/+controller/DiffArticlesController.m
+++ b/+controller/DiffArticlesController.m
@@ -1,35 +1,31 @@
 classdef DiffArticlesController < reg.mvc.BaseController
     %DIFFARTICLESCONTROLLER Article-aware diff of two CRR corpora.
-    %   Relies on a `reg.service.DiffService` to compute differences and a
+    %   Utilises a reg.model.DiffVersionsModel to compute differences and a
     %   view to present results.
 
-    properties
-        DiffService
-    end
-
     methods
-        function obj = DiffArticlesController(service, view)
-            %DIFFARTICLESCONTROLLER Construct controller with service and view.
-            %   OBJ = DIFFARTICLESCONTROLLER(service, view) wires a
-            %   DiffService to a view. SERVICE defaults to
-            %   `reg.service.DiffService()` and VIEW defaults to
-            %   `reg.view.DiffView()` which focuses purely on rendering
+        function obj = DiffArticlesController(model, view)
+            %DIFFARTICLESCONTROLLER Construct controller with model and view.
+            %   OBJ = DIFFARTICLESCONTROLLER(model, view) wires a
+            %   DiffVersionsModel to a view. MODEL defaults to
+            %   reg.model.DiffVersionsModel() and VIEW defaults to
+            %   reg.view.DiffView() which focuses purely on rendering
             %   diff artefacts.
-            if nargin < 1 || isempty(service)
-                service = reg.service.DiffService();
+            if nargin < 1 || isempty(model)
+                model = reg.model.DiffVersionsModel();
             end
             if nargin < 2 || isempty(view)
                 view = reg.view.DiffView();
             end
-            obj@reg.mvc.BaseController([], view);
-            obj.DiffService = service;
+            obj@reg.mvc.BaseController(model, view);
         end
 
         function result = run(obj, dirA, dirB, outDir)
             %RUN Compare CRR corpora by article number.
             %   RESULT = RUN(obj, dirA, dirB, outDir) delegates to the
-            %   DiffService and forwards results to the view.
-            result = obj.DiffService.compare(dirA, dirB, outDir);
+            %   model and forwards results to the view.
+            params = obj.Model.load(dirA, dirB, outDir);
+            result = obj.Model.process(params);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end

--- a/+controller/DiffReportController.m
+++ b/+controller/DiffReportController.m
@@ -19,18 +19,16 @@ classdef DiffReportController < reg.mvc.BaseController
             obj@reg.mvc.BaseController(model, view);
         end
 
-        function report = run(obj, dirA, dirB, outDir) %#ok<INUSD>
+        function report = run(obj, dirA, dirB, outDir)
             %RUN Produce diff reports for two directories.
             %   REPORT = RUN(obj, dirA, dirB, outDir) orchestrates
             %   generation of PDF and HTML artifacts summarizing
             %   differences between corpora.
-            %   Steps:
-            %       1. Determine output directory
-            %       2. Generate PDF diff
-            %       3. Generate HTML diff
-            %       4. Assemble artifact paths and display via view
-            error("reg:controller:NotImplemented", ...
-                "DiffReportController.run is not implemented.");
+            params = obj.Model.load(dirA, dirB, outDir);
+            report = obj.Model.process(params);
+            if ~isempty(obj.View)
+                obj.View.display(report);
+            end
         end
     end
 end

--- a/+controller/PipelineController.m
+++ b/+controller/PipelineController.m
@@ -6,20 +6,19 @@ classdef PipelineController < reg.mvc.BaseController
         IngestionModel
         EmbeddingModel
         EvaluationModel
-        LoggingModel
         EmbeddingView
     end
 
     methods
-        function obj = PipelineController(cfgModel, ingestModel, embedModel, evalModel, logModel, view, embView)
+        function obj = PipelineController(cfgModel, ingestModel, embedModel, evalModel, view, embView)
             %PIPELINECONTROLLER Construct controller wiring core models.
-            %   OBJ = PIPELINECONTROLLER(CFG, INGEST, EMBED, EVAL, LOG, VIEW, EMBVIEW)
+            %   OBJ = PIPELINECONTROLLER(CFG, INGEST, EMBED, EVAL, VIEW, EMBVIEW)
             %   stores references to the provided models, a metrics view
             %   and an optional embedding view.
-            if nargin < 6 || isempty(view)
+            if nargin < 5 || isempty(view)
                 view = reg.view.MetricsView();
             end
-            if nargin < 7 || isempty(embView)
+            if nargin < 6 || isempty(embView)
                 embView = reg.view.EmbeddingView();
             end
             obj@reg.mvc.BaseController(cfgModel, view);
@@ -27,7 +26,6 @@ classdef PipelineController < reg.mvc.BaseController
             obj.IngestionModel = ingestModel;
             obj.EmbeddingModel = embedModel;
             obj.EvaluationModel = evalModel;
-            obj.LoggingModel = logModel;
             obj.EmbeddingView = embView;
         end
 
@@ -55,8 +53,7 @@ classdef PipelineController < reg.mvc.BaseController
             evalResult = obj.EvaluationModel.process(evalRaw);
 
             % Log metrics and display via view
-            logData = obj.LoggingModel.load(evalResult.Metrics);
-            obj.LoggingModel.process(logData);
+            reg.helpers.logMetrics(evalResult.Metrics);
             if ~isempty(obj.View)
                 obj.View.display(evalResult.Metrics);
             end

--- a/+controller/SyncController.m
+++ b/+controller/SyncController.m
@@ -18,15 +18,14 @@ classdef SyncController < reg.mvc.BaseController
             obj@reg.mvc.BaseController(model, view);
         end
 
-        function out = run(obj, date) %#ok<INUSD>
+        function out = run(obj, date)
             %RUN Execute synchronization for a given date.
             %   OUT = RUN(obj, date) orchestrates corpus synchronization.
-            %   Steps:
-            %       1. Determine target date
-            %       2. Synchronize corpus for the date
-            %       3. Display summary via view
-            error("reg:controller:NotImplemented", ...
-                "SyncController.run is not implemented.");
+            params = obj.Model.load(date);
+            out = obj.Model.process(params);
+            if ~isempty(obj.View)
+                obj.View.display(out);
+            end
         end
     end
 end

--- a/+helpers/logMetrics.m
+++ b/+helpers/logMetrics.m
@@ -1,0 +1,7 @@
+function logMetrics(metrics)
+%LOGMETRICS Simple logging helper for metrics structs.
+%   LOGMETRICS(METRICS) prints METRICS to the console. In a full
+%   implementation this could persist to disk or external services.
+
+    disp(metrics);
+end

--- a/+model/EmbeddingInput.m
+++ b/+model/EmbeddingInput.m
@@ -1,0 +1,16 @@
+classdef EmbeddingInput
+    %EMBEDDINGINPUT Value object representing features destined for the
+    %embedding backend.
+
+    properties
+        Features
+    end
+
+    methods
+        function obj = EmbeddingInput(features)
+            if nargin > 0
+                obj.Features = features;
+            end
+        end
+    end
+end

--- a/+model/EmbeddingModel.m
+++ b/+model/EmbeddingModel.m
@@ -14,7 +14,7 @@ classdef EmbeddingModel < reg.mvc.BaseModel
 
         function input = load(~, features)
             %LOAD Wrap raw FEATURES in an EmbeddingInput value object.
-            input = reg.service.EmbeddingInput(features);
+            input = reg.model.EmbeddingInput(features);
         end
 
         function output = process(obj, input) %#ok<INUSD>
@@ -23,7 +23,7 @@ classdef EmbeddingModel < reg.mvc.BaseModel
                 cfgRaw = obj.ConfigModel.load();
                 cfg = obj.ConfigModel.process(cfgRaw); %#ok<NASGU>
             end
-            output = reg.service.EmbeddingOutput([]);
+            output = reg.model.EmbeddingOutput([]);
             reg.model.Embedding.save(output.Vectors);
             error("reg:model:NotImplemented", ...
                 "EmbeddingModel.process is not implemented.");

--- a/+model/EmbeddingOutput.m
+++ b/+model/EmbeddingOutput.m
@@ -1,0 +1,15 @@
+classdef EmbeddingOutput
+    %EMBEDDINGOUTPUT Value object carrying dense vector representations.
+
+    properties
+        Vectors
+    end
+
+    methods
+        function obj = EmbeddingOutput(vecs)
+            if nargin > 0
+                obj.Vectors = vecs;
+            end
+        end
+    end
+end

--- a/+model/EvaluationInput.m
+++ b/+model/EvaluationInput.m
@@ -1,0 +1,17 @@
+classdef EvaluationInput
+    %EVALUATIONINPUT Container for artifacts needed to compute metrics.
+
+    properties
+        Predictions
+        References
+    end
+
+    methods
+        function obj = EvaluationInput(pred, ref)
+            if nargin > 0
+                obj.Predictions = pred;
+                obj.References = ref;
+            end
+        end
+    end
+end

--- a/+model/EvaluationModel.m
+++ b/+model/EvaluationModel.m
@@ -22,7 +22,7 @@ classdef EvaluationModel < reg.mvc.BaseModel
             if numel(varargin) >= 2
                 ref = varargin{2};
             end
-            input = reg.service.EvaluationInput(pred, ref);
+            input = reg.model.EvaluationInput(pred, ref);
         end
 
         function result = process(obj, input) %#ok<INUSD>
@@ -31,7 +31,7 @@ classdef EvaluationModel < reg.mvc.BaseModel
                 cfgRaw = obj.ConfigModel.load();
                 cfg = obj.ConfigModel.process(cfgRaw); %#ok<NASGU>
             end
-            result = reg.service.EvaluationResult([]);
+            result = reg.model.EvaluationResult([]);
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.process is not implemented.");
         end

--- a/+model/EvaluationResult.m
+++ b/+model/EvaluationResult.m
@@ -1,0 +1,15 @@
+classdef EvaluationResult
+    %EVALUATIONRESULT Value object for metric summaries.
+
+    properties
+        Metrics
+    end
+
+    methods
+        function obj = EvaluationResult(metrics)
+            if nargin > 0
+                obj.Metrics = metrics;
+            end
+        end
+    end
+end

--- a/+model/IngestionModel.m
+++ b/+model/IngestionModel.m
@@ -31,7 +31,7 @@ classdef IngestionModel < reg.mvc.BaseModel
         function out = process(obj, raw)
             %PROCESS Finalise features and optionally persist documents.
             [features, ~] = obj.FeatureModel.process(raw.FeatRaw);
-            out = reg.service.IngestionOutput(raw.Docs, raw.Chunks, features);
+            out = reg.model.IngestionOutput(raw.Docs, raw.Chunks, features);
             reg.model.Document.save(raw.Docs);
         end
     end

--- a/+model/IngestionOutput.m
+++ b/+model/IngestionOutput.m
@@ -1,0 +1,24 @@
+classdef IngestionOutput
+    %INGESTIONOUTPUT Value object for ingestion results.
+    %   Encapsulates documents and text chunks produced during preprocessing
+    %   so downstream components remain loosely coupled to the concrete
+    %   models that generated them.
+
+    properties
+        Documents
+        Chunks
+        Features
+    end
+
+    methods
+        function obj = IngestionOutput(docs, chunks, feats)
+            if nargin > 0
+                obj.Documents = docs;
+                obj.Chunks = chunks;
+                if nargin > 2
+                    obj.Features = feats;
+                end
+            end
+        end
+    end
+end

--- a/+view/EmbeddingView.m
+++ b/+view/EmbeddingView.m
@@ -1,6 +1,6 @@
 classdef EmbeddingView < reg.mvc.BaseView
     %EMBEDDINGVIEW Stub view for rendering embedding outputs.
-    %   Expects DATA as a numeric matrix or reg.service.EmbeddingOutput.
+    %   Expects DATA as a numeric matrix or reg.model.EmbeddingOutput.
     %   Rendering is limited to printing vector dimensions or persisting
     %   via callbacks; all computation remains within services.
 
@@ -20,7 +20,7 @@ classdef EmbeddingView < reg.mvc.BaseView
 
             obj.DisplayedEmbeddings = data;
             vecs = [];
-            if isa(data, 'reg.service.EmbeddingOutput')
+            if isa(data, 'reg.model.EmbeddingOutput')
                 vecs = data.Vectors;
             elseif isnumeric(data)
                 vecs = data;


### PR DESCRIPTION
## Summary
- replace DiffArticlesController service with DiffVersionsModel and route model outputs to views
- add diff report and sync run implementations using model load/process pattern
- drop LoggingModel in favor of helper-based logging and add model value objects for embeddings, evaluation, and ingestion

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689f923ef84483308db9ca5906fae152