### PR TITLE
Refactor corpus controller to call model diff methods directly

### DIFF
--- a/+reg/+controller/CorpusController.m
+++ b/+reg/+controller/CorpusController.m
@@ -89,8 +89,8 @@ classdef CorpusController < reg.mvc.BaseController
         function result = runArticles(obj, dirA, dirB, outDir)
             %RUNARTICLES Compare corpora by article number.
             %   RESULT = RUNARTICLES(obj, dirA, dirB, outDir) forwards to
-            %   the model's diffArticles implementation and displays results.
-            result = obj.Model.diffArticles(dirA, dirB, outDir);
+            %   the model's runArticles implementation and displays results.
+            result = obj.Model.runArticles(dirA, dirB, outDir);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end
@@ -99,8 +99,8 @@ classdef CorpusController < reg.mvc.BaseController
         function result = runVersions(obj, dirA, dirB, outDir)
             %RUNVERSIONS Diff directories on a file-by-file basis.
             %   RESULT = RUNVERSIONS(obj, dirA, dirB, outDir) delegates to
-            %   the model's diffVersions method and displays results.
-            result = obj.Model.diffVersions(dirA, dirB, outDir);
+            %   the model's runVersions method and displays results.
+            result = obj.Model.runVersions(dirA, dirB, outDir);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end
@@ -110,7 +110,7 @@ classdef CorpusController < reg.mvc.BaseController
             %RUNREPORT Produce diff reports for two directories.
             %   REPORT = RUNREPORT(obj, dirA, dirB, outDir) orchestrates
             %   generation of diff artefacts using the model.
-            report = obj.Model.generateReport(dirA, dirB, outDir);
+            report = obj.Model.runReport(dirA, dirB, outDir);
             if ~isempty(obj.View)
                 obj.View.display(report);
             end
@@ -124,7 +124,7 @@ classdef CorpusController < reg.mvc.BaseController
             if nargin < 4
                 config = struct();
             end
-            result = obj.Model.diffMethods(queries, chunksT, config);
+            result = obj.Model.runMethods(queries, chunksT, config);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end

--- a/+reg/+model/CorpusModel.m
+++ b/+reg/+model/CorpusModel.m
@@ -81,47 +81,47 @@ classdef CorpusModel < reg.mvc.BaseModel
                 "CorpusModel.sync is not implemented.");
         end
 
-        function result = diffArticles(~, dirA, dirB, outDir)
-            %DIFFARTICLES Compare corpora by article number.
-            %   RESULT = DIFFARTICLES(obj, dirA, dirB, outDir) should align
+        function result = runArticles(~, dirA, dirB, outDir)
+            %RUNARTICLES Compare corpora by article number.
+            %   RESULT = RUNARTICLES(obj, dirA, dirB, outDir) should align
             %   documents by article identifiers and compute differences.
             %   Legacy Reference
             %       Equivalent to `reg.crr_diff_articles`.
             error("reg:model:NotImplemented", ...
-                "CorpusModel.diffArticles is not implemented.");
+                "CorpusModel.runArticles is not implemented.");
         end
 
-        function diff = diffVersions(~, dirA, dirB, outDir)
-            %DIFFVERSIONS Compute file-level diffs between directories.
-            %   DIFF = DIFFVERSIONS(obj, dirA, dirB, outDir) should compare
+        function diff = runVersions(~, dirA, dirB, outDir)
+            %RUNVERSIONS Compute file-level diffs between directories.
+            %   DIFF = RUNVERSIONS(obj, dirA, dirB, outDir) should compare
             %   file versions and report line-level changes.
             %   Legacy Reference
             %       Equivalent to `reg.crr_diff_versions`.
             error("reg:model:NotImplemented", ...
-                "CorpusModel.diffVersions is not implemented.");
+                "CorpusModel.runVersions is not implemented.");
         end
 
-        function report = generateReport(~, dirA, dirB, outDir)
-            %GENERATEREPORT Produce diff reports for two directories.
-            %   REPORT = GENERATEREPORT(obj, dirA, dirB, outDir) should
+        function report = runReport(~, dirA, dirB, outDir)
+            %RUNREPORT Produce diff reports for two directories.
+            %   REPORT = RUNREPORT(obj, dirA, dirB, outDir) should
             %   generate PDF and HTML artifacts summarising differences.
             %   Legacy Reference
             %       Equivalent to `reg_crr_diff_report` and
             %       `reg_crr_diff_report_html`.
             error("reg:model:NotImplemented", ...
-                "CorpusModel.generateReport is not implemented.");
+                "CorpusModel.runReport is not implemented.");
         end
 
-        function result = diffMethods(~, queries, chunksT, config)
-            %DIFFMETHODS Compare retrieval across encoder variants.
-            %   RESULT = DIFFMETHODS(obj, queries, chunksT, config) should
+        function result = runMethods(~, queries, chunksT, config)
+            %RUNMETHODS Compare retrieval across encoder variants.
+            %   RESULT = RUNMETHODS(obj, queries, chunksT, config) should
             %   evaluate alternative embedding methods on QUERY strings
             %   against CHUNKST table. CONFIG defaults to an empty struct.
             if nargin < 4
                 config = struct();
             end %#ok<NASGU>
             error("reg:model:NotImplemented", ...
-                "CorpusModel.diffMethods is not implemented.");
+                "CorpusModel.runMethods is not implemented.");
         end
     end
 end


### PR DESCRIPTION
## Summary
- route CorpusController's run* methods directly to matching model methods
- expose runArticles/runVersions/runReport/runMethods stubs in CorpusModel

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fb2a9a4488330b197d0ce8a4b7f9d