### PR TITLE
Refactor pipeline into dedicated model

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -2,68 +2,27 @@ classdef PipelineController < reg.mvc.BaseController
     %PIPELINECONTROLLER Orchestrates end-to-end pipeline flow.
 
     properties
-        ConfigModel
-        TrainingModel
-        EvaluationModel
-        EmbeddingView
-        CorpusModel
+        PipelineModel
     end
 
     methods
-        function obj = PipelineController(cfgModel, trainModel, evalModel, view, embView, corpusModel)
-            %PIPELINECONTROLLER Construct controller wiring core models.
-            %   OBJ = PIPELINECONTROLLER(CFG, TRAIN, EVAL, VIEW, EMBVIEW)
-            %   stores references to the provided models, a metrics view
-            %   and an optional embedding view.
-            if nargin < 4 || isempty(view)
+        function obj = PipelineController(pipelineModel, view)
+            %PIPELINECONTROLLER Construct controller wiring pipeline model.
+            if nargin < 2 || isempty(view)
                 view = reg.view.MetricsView();
             end
-            if nargin < 5 || isempty(embView)
-                embView = reg.view.EmbeddingView();
-            end
-            if nargin < 6 || isempty(corpusModel)
-                corpusModel = reg.model.CorpusModel();
-            end
-            obj@reg.mvc.BaseController(cfgModel, view);
-            obj.ConfigModel = cfgModel;
-            obj.TrainingModel = trainModel;
-            obj.EvaluationModel = evalModel;
-            obj.EmbeddingView = embView;
-            obj.CorpusModel = corpusModel;
+            obj@reg.mvc.BaseController(pipelineModel, view);
+            obj.PipelineModel = pipelineModel;
         end
 
         function run(obj)
-            %RUN Execute simplified pipeline coordinating models.
-            %   Sequencing: Config -> Ingestion -> Embedding -> Evaluation.
-
-            % Step 1: retrieve configuration
-            cfgRaw = obj.ConfigModel.load();
-            cfg = obj.ConfigModel.process(cfgRaw);
-
-            % Step 2: ingest PDFs and build search index via corpus model
-            docs = obj.CorpusModel.ingestPdfs(cfg);
-            obj.CorpusModel.persistDocuments(docs);
-            obj.CorpusModel.buildIndex(docs);
-            obj.CorpusModel.queryIndex("pipeline query", 0.5, 5);
-
-            % Step 3: ingest documents and chunk text via training model
-            ingestOut = obj.TrainingModel.ingest(cfg);
-
-            % Step 4: extract features and compute embeddings
-            [features, ~] = obj.TrainingModel.extractFeatures(ingestOut.Chunks);
-            embOut = obj.TrainingModel.computeEmbeddings(features);
-            if ~isempty(obj.EmbeddingView)
-                obj.EmbeddingView.display(embOut);
-            end
-
-            % Step 5: evaluate results
-            evalRaw = obj.EvaluationModel.load(embOut, []);
-            evalResult = obj.EvaluationModel.process(evalRaw);
-
-            % Log metrics and display via view
-            if ~isempty(obj.View)
-                obj.View.log(evalResult.Metrics);
-                obj.View.display(evalResult.Metrics);
+            %RUN Execute simplified pipeline by delegating to model.
+            result = obj.PipelineModel.run();
+            if ~isempty(obj.View) && isfield(result, "Metrics")
+                obj.View.log(result.Metrics);
+                obj.View.display(result.Metrics);
+            elseif ~isempty(obj.View)
+                obj.View.display(result);
             end
         end
     end

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -1,0 +1,99 @@
+classdef PipelineModel < reg.mvc.BaseModel
+    %PIPELINEMODEL Encapsulate full pipeline coordination.
+    %   Handles configuration loading, corpus ingestion, feature and
+    %   embedding extraction, classifier training, encoder fine-tuning
+    %   and evaluation. Internal steps delegate to specialised models
+    %   such as ConfigModel, CorpusModel, TrainingModel and
+    %   EvaluationModel.
+
+    properties
+        ConfigModel
+        TrainingModel
+        CorpusModel
+        EvaluationModel
+    end
+
+    methods
+        function obj = PipelineModel(cfgModel, corpusModel, trainModel, evalModel)
+            %PIPELINEMODEL Construct pipeline model wiring core models.
+            if nargin < 1 || isempty(cfgModel)
+                cfgModel = reg.model.ConfigModel();
+            end
+            if nargin < 2 || isempty(corpusModel)
+                corpusModel = reg.model.CorpusModel();
+            end
+            if nargin < 3 || isempty(trainModel)
+                trainModel = reg.model.TrainingModel();
+            end
+            if nargin < 4 || isempty(evalModel)
+                evalModel = reg.model.EvaluationModel();
+            end
+            obj.ConfigModel = cfgModel;
+            obj.CorpusModel = corpusModel;
+            obj.TrainingModel = trainModel;
+            obj.EvaluationModel = evalModel;
+        end
+
+        function result = run(obj)
+            %RUN Execute the end-to-end pipeline.
+            %   RESULT = RUN(obj) coordinates configuration loading,
+            %   corpus ingestion, feature/embedding extraction, classifier
+            %   training, fine-tuning and evaluation.
+
+            % Step 1: configuration
+            cfgRaw = obj.ConfigModel.load();
+            cfg = obj.ConfigModel.process(cfgRaw);
+
+            % Step 2: corpus ingestion
+            docs = obj.ingestCorpus(cfg);
+
+            % Step 3: training workflow (features, embeddings, classifier)
+            trainOut = obj.runTraining(cfg);
+
+            % Step 4: fine-tuning workflow
+            ftOut = obj.runFineTune(cfg); %#ok<NASGU>
+
+            % Step 5: evaluation
+            evalRaw = obj.EvaluationModel.load(trainOut.Embeddings, []);
+            evalResult = obj.EvaluationModel.process(evalRaw);
+
+            result = struct('Documents', docs, ...
+                'Training', trainOut, ...
+                'Metrics', evalResult.Metrics);
+        end
+
+        function docs = ingestCorpus(obj, cfg)
+            %INGESTCORPUS Ingest PDFs and build search index.
+            docs = obj.CorpusModel.ingestPdfs(cfg);
+            obj.CorpusModel.persistDocuments(docs);
+            obj.CorpusModel.buildIndex(docs);
+            obj.CorpusModel.queryIndex("pipeline query", 0.5, 5);
+        end
+
+        function out = runTraining(obj, cfg)
+            %RUNTRAINING Execute training sub-pipeline.
+            ingestOut = obj.TrainingModel.ingest(cfg);
+            [features, ~] = obj.TrainingModel.extractFeatures(ingestOut.Chunks);
+            embeddings = obj.TrainingModel.computeEmbeddings(features);
+            trainingInputs = struct('Embeddings', embeddings);
+            [models, scores, thresholds, predLabels] = ...
+                obj.TrainingModel.trainClassifier(trainingInputs);
+            out = struct('Ingest', ingestOut, 'Features', features, ...
+                'Embeddings', embeddings, 'Models', {models}, ...
+                'Scores', scores, 'Thresholds', thresholds, ...
+                'PredLabels', predLabels);
+        end
+
+        function out = runFineTune(obj, cfg)
+            %RUNFINETUNE Execute encoder fine-tuning workflow.
+            docs = obj.TrainingModel.ingest(cfg);
+            chunks = obj.TrainingModel.chunk(docs);
+            [weakLabels, bootLabels] = obj.TrainingModel.weakLabel(chunks);
+            raw = struct('Chunks', chunks, 'WeakLabels', weakLabels, ...
+                'BootLabels', bootLabels);
+            triplets = obj.TrainingModel.prepareDataset(raw);
+            net = obj.TrainingModel.fineTuneEncoder(triplets);
+            out = struct('Triplets', triplets, 'Network', net);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add `PipelineModel` encapsulating config loading, corpus ingest, training, fine-tuning and evaluation
- simplify `PipelineController` to delegate to `PipelineModel`

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --eval "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689fb9f54a808330b1c2dcb12191a381