### PR TITLE
feat: add discrete pipeline workflow methods

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -25,5 +25,21 @@ classdef PipelineController < reg.mvc.BaseController
                 obj.View.display(result);
             end
         end
+
+        function runTraining(obj)
+            %RUNTRAINING Execute only the training workflow.
+            result = obj.PipelineModel.runTraining();
+            if ~isempty(obj.View)
+                obj.View.display(result);
+            end
+        end
+
+        function runFineTune(obj)
+            %RUNFINETUNE Execute only the fine-tuning workflow.
+            result = obj.PipelineModel.runFineTune();
+            if ~isempty(obj.View)
+                obj.View.display(result);
+            end
+        end
     end
 end

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -72,6 +72,10 @@ classdef PipelineModel < reg.mvc.BaseModel
 
         function out = runTraining(obj, cfg)
             %RUNTRAINING Execute training sub-pipeline.
+            if nargin < 2 || isempty(cfg)
+                cfgRaw = obj.ConfigModel.load();
+                cfg = obj.ConfigModel.process(cfgRaw);
+            end
             ingestOut = obj.TrainingModel.ingest(cfg);
             [features, ~] = obj.TrainingModel.extractFeatures(ingestOut.Chunks);
             embeddings = obj.TrainingModel.computeEmbeddings(features);
@@ -86,6 +90,10 @@ classdef PipelineModel < reg.mvc.BaseModel
 
         function out = runFineTune(obj, cfg)
             %RUNFINETUNE Execute encoder fine-tuning workflow.
+            if nargin < 2 || isempty(cfg)
+                cfgRaw = obj.ConfigModel.load();
+                cfg = obj.ConfigModel.process(cfgRaw);
+            end
             docs = obj.TrainingModel.ingest(cfg);
             chunks = obj.TrainingModel.chunk(docs);
             [weakLabels, bootLabels] = obj.TrainingModel.weakLabel(chunks);


### PR DESCRIPTION
## Summary
- allow `PipelineModel` to load its own configuration when running training and fine-tuning workflows
- expose `runTraining` and `runFineTune` methods on `PipelineController` that delegate to the model and forward results to the view

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689fbfadb6208330bedeb45b8d4e034a