### PR TITLE
Use evaluation controller within pipeline

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -41,12 +41,13 @@ classdef EvaluationController < reg.mvc.BaseController
             end
         end
 
-        function run(obj, goldDir, metricsCSV)
+        function metrics = run(obj, goldDir, metricsCSV)
             %RUN Execute end-to-end evaluation workflow.
-            %   RUN(obj, goldDir, metricsCSV) evaluates the contents of
-            %   goldDir, logs metrics, renders reports and produces trend and
-            %   co-retrieval plots.  This method subsumes the responsibilities
-            %   of the legacy EvalController.run and EvaluationPipeline.run.
+            %   METRICS = RUN(obj, goldDir, metricsCSV) evaluates the contents
+            %   of ``goldDir``, generates reports and diagnostic plots and
+            %   returns the computed metrics.  This method subsumes the
+            %   responsibilities of the legacy ``EvalController.run`` and
+            %   ``EvaluationPipeline.run``.
 
             % Step 1: evaluate gold pack and compute metrics
             results = obj.evaluateGoldPack(goldDir);
@@ -83,6 +84,13 @@ classdef EvaluationController < reg.mvc.BaseController
                 obj.PlotView.display(struct(
                     'TrendsPNG', trendsPNG, ...
                     'HeatmapPNG', heatPNG));
+            end
+
+            % Return metrics for upstream consumers
+            if isstruct(results) && isfield(results, 'Metrics')
+                metrics = results.Metrics;
+            else
+                metrics = [];
             end
         end
         function metrics = retrievalMetrics(~, embeddings, posSets, k) %#ok<INUSD>

--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -41,28 +41,9 @@ classdef PipelineController < reg.mvc.BaseController
         end
 
         function run(obj)
-            %RUN Execute end-to-end pipeline and optionally fine-tune or
-            %   train a projection head based on configuration.
+            %RUN Execute the full pipeline through the PipelineModel.
 
-            cfgRaw = obj.PipelineModel.ConfigModel.load();
-            cfg = obj.PipelineModel.ConfigModel.process(cfgRaw);
-
-            docs = obj.PipelineModel.ingestCorpus(cfg);
-            trainOut = obj.PipelineModel.runTraining(cfg);
-
-            if isfield(cfg, "projEpochs") && cfg.projEpochs > 0
-                obj.runProjectionHead(trainOut.Embeddings);
-            end
-
-            if isfield(cfg, "fineTuneEpochs") && cfg.fineTuneEpochs > 0
-                obj.runFineTune(cfg);
-            end
-
-            evalRaw = obj.PipelineModel.EvaluationModel.load(trainOut.Embeddings, []);
-            evalResult = obj.PipelineModel.EvaluationModel.process(evalRaw);
-
-            result = struct('Documents', docs, 'Training', trainOut, ...
-                'Metrics', evalResult.Metrics);
+            result = obj.PipelineModel.run();
 
             if ~isempty(obj.View) && isfield(result, "Metrics")
                 obj.View.log(result.Metrics);

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -53,13 +53,14 @@ classdef PipelineModel < reg.mvc.BaseModel
             % Step 4: fine-tuning workflow
             ftOut = obj.runFineTune(cfg); %#ok<NASGU>
 
-            % Step 5: evaluation
-            evalRaw = obj.EvaluationModel.load(trainOut.Embeddings, []);
-            evalResult = obj.EvaluationModel.process(evalRaw);
+            % Step 5: evaluation via controller
+            evalController = reg.controller.EvaluationController(
+                obj.EvaluationModel, reg.model.ReportModel());
+            metrics = evalController.run(trainOut.Embeddings, []);
 
             result = struct('Documents', docs, ...
                 'Training', trainOut, ...
-                'Metrics', evalResult.Metrics);
+                'Metrics', metrics);
         end
 
         function docs = ingestCorpus(obj, cfg)


### PR DESCRIPTION
## Summary
- Run EvaluationController inside PipelineModel to produce metrics and reports
- Have EvaluationController.run return metrics for upstream use
- Simplify PipelineController.run to invoke PipelineModel.run and display metrics

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_689fcd25992083308fb0c7d1420935a7