### PR TITLE
refactor pipeline to use EvaluationController

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -43,31 +43,7 @@ classdef PipelineController < reg.mvc.BaseController
         function run(obj)
             %RUN Execute the full pipeline end-to-end.
 
-            cfgRaw = obj.PipelineModel.ConfigModel.load();
-            cfg = obj.PipelineModel.ConfigModel.process(cfgRaw);
-
-            docs = obj.PipelineModel.ingestCorpus(cfg);
-            trainOut = obj.PipelineModel.runTraining(cfg);
-
-            if isfield(cfg, 'fineTuneEpochs') && cfg.fineTuneEpochs > 0
-                trainOut.FineTune = obj.runFineTune(cfg);
-            end
-
-            if isfield(cfg, 'projEpochs') && cfg.projEpochs > 0
-                trainOut.ProjectedEmbeddings = obj.runProjectionHead(trainOut.Embeddings);
-            end
-
-            evalEmbeddings = trainOut.Embeddings;
-            if isfield(trainOut, 'ProjectedEmbeddings')
-                evalEmbeddings = trainOut.ProjectedEmbeddings;
-            end
-
-            evalController = reg.controller.EvaluationController( ...
-                obj.PipelineModel.EvaluationModel, reg.model.ReportModel());
-            metrics = evalController.run(evalEmbeddings, []);
-
-            result = struct('Documents', docs, 'Training', trainOut, ...
-                'Metrics', metrics);
+            result = obj.PipelineModel.run();
 
             if ~isempty(obj.View) && isfield(result, "Metrics")
                 obj.View.log(result.Metrics);


### PR DESCRIPTION
## Summary
- delegate evaluation to `EvaluationController` inside `PipelineModel`
- simplify `PipelineController.run` to invoke the pipeline model and display metrics

## Testing
- `matlab -batch "disp('Running tests');"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a04446f1048330ba79f1eb2fa6d066