### PR TITLE
feat: evaluate in-memory embeddings

### DIFF
--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -66,9 +66,13 @@ classdef PipelineModel < reg.mvc.BaseModel
             if isfield(trainOut, 'ProjectedEmbeddings')
                 evalEmbeddings = trainOut.ProjectedEmbeddings;
             end
+            labels = [];
+            if isfield(trainOut, 'PredLabels')
+                labels = trainOut.PredLabels;
+            end
             evalController = reg.controller.EvaluationController(
                 obj.EvaluationModel, reg.model.ReportModel());
-            metrics = evalController.run(evalEmbeddings, []);
+            metrics = evalController.run(evalEmbeddings, labels);
 
             result = struct('Documents', docs, ...
                 'Training', trainOut, ...


### PR DESCRIPTION
## Summary
- update EvaluationController to evaluate provided embeddings and optional label matrices directly
- adapt plotting and report generation to use in-memory metrics
- pipeline model forwards embeddings and available labels to evaluation controller

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a04982bcfc833093b554a42a546d53