### PR TITLE
Require processed configuration for training workflows

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -18,8 +18,9 @@ classdef PipelineController < reg.mvc.BaseController
         function result = runFineTune(obj, cfg)
             %RUNFINETUNE Execute encoder fine-tuning workflow.
             %   RESULT = RUNFINETUNE(obj, CFG) delegates the fine-tuning
-            %   process to the PipelineModel and displays any outputs using
-            %   the controller view.
+            %   process to the PipelineModel using the supplied processed
+            %   configuration CFG and displays any outputs using the
+            %   controller view.
 
             result = obj.PipelineModel.runFineTune(cfg);
             if ~isempty(obj.View)
@@ -52,9 +53,12 @@ classdef PipelineController < reg.mvc.BaseController
             end
         end
 
-        function runTraining(obj)
+        function runTraining(obj, cfg)
             %RUNTRAINING Execute only the training workflow.
-            result = obj.PipelineModel.runTraining();
+            %   RUNTRAINING(OBJ, CFG) delegates the workflow to the
+            %   PipelineModel using the supplied processed configuration
+            %   CFG and displays the results using the controller view.
+            result = obj.PipelineModel.runTraining(cfg);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -89,10 +89,10 @@ classdef PipelineModel < reg.mvc.BaseModel
 
         function out = runTraining(obj, cfg)
             %RUNTRAINING Execute training sub-pipeline.
-            if nargin < 2 || isempty(cfg)
-                cfgRaw = obj.ConfigModel.load();
-                cfg = obj.ConfigModel.process(cfgRaw);
-            end
+            %   OUT = RUNTRAINING(OBJ, CFG) executes the training workflow
+            %   using the supplied configuration CFG. CFG must be a fully
+            %   processed configuration struct as returned by
+            %   ConfigModel.process.
             ingestOut = obj.TrainingModel.ingest(cfg);
             [features, ~] = obj.TrainingModel.extractFeatures(ingestOut.Chunks);
             embeddings = obj.TrainingModel.computeEmbeddings(features);
@@ -107,10 +107,10 @@ classdef PipelineModel < reg.mvc.BaseModel
 
         function out = runFineTune(obj, cfg)
             %RUNFINETUNE Execute encoder fine-tuning workflow.
-            if nargin < 2 || isempty(cfg)
-                cfgRaw = obj.ConfigModel.load();
-                cfg = obj.ConfigModel.process(cfgRaw);
-            end
+            %   OUT = RUNFINETUNE(OBJ, CFG) performs encoder fine-tuning
+            %   using the supplied configuration CFG. CFG must be a fully
+            %   processed configuration struct as returned by
+            %   ConfigModel.process.
             docs = obj.TrainingModel.ingest(cfg);
             chunks = obj.TrainingModel.chunk(docs);
             [weakLabels, bootLabels] = obj.TrainingModel.weakLabel(chunks);


### PR DESCRIPTION
## Summary
- require callers to supply processed configuration when running training and fine-tuning routines
- document the expectation for processed configs and update controller calls accordingly

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0573c4a608330869a235f012f20a3