### PR TITLE
Refactor trend plotting to accept metrics struct

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -50,8 +50,10 @@ classdef EvaluationController < reg.mvc.BaseController
             %   of the legacy ``EvalController.run`` and
             %   ``EvaluationPipeline.run``.
 
-            if nargin < 3
-                labelMatrix = [];
+            arguments
+                obj
+                embeddings double
+                labelMatrix double = []
             end
 
             % Step 1: evaluate gold pack and compute metrics
@@ -65,8 +67,9 @@ classdef EvaluationController < reg.mvc.BaseController
             end
 
             % Step 3: create diagnostic plots
-            trendsPNG = obj.VisualizationModel.plotTrends(
-                results.Metrics, fullfile(tempdir(), 'trends.png'));
+            metricsStruct = results.Metrics;
+            validateMetrics(metricsStruct);
+            trendsFig = obj.VisualizationModel.plotTrends(metricsStruct);
 
             coMatrix = [];
             labels = [];
@@ -87,7 +90,7 @@ classdef EvaluationController < reg.mvc.BaseController
             % Step 4: hand off plots to plot view
             if ~isempty(obj.PlotView)
                 obj.PlotView.display(struct(
-                    'TrendsPNG', trendsPNG, ...
+                    'TrendsFigure', trendsFig, ...
                     'HeatmapPNG', heatPNG));
             end
 
@@ -96,6 +99,14 @@ classdef EvaluationController < reg.mvc.BaseController
                 metrics = results.Metrics;
             else
                 metrics = [];
+            end
+            function validateMetrics(m)
+                arguments
+                    m struct
+                    m.epochs (:,1) double
+                    m.accuracy (:,1) double
+                    m.loss (:,1) double
+                end
             end
         end
         function metrics = retrievalMetrics(~, embeddings, posSets, k) %#ok<INUSD>

--- a/+reg/+model/VisualizationModel.m
+++ b/+reg/+model/VisualizationModel.m
@@ -9,20 +9,28 @@ classdef VisualizationModel < reg.mvc.BaseModel
             %   symmetry with other models in the MVC framework.
         end
 
-        function pngPath = plotTrends(~, csvPath, pngPath) %#ok<INUSD>
-            %PLOTTRENDS Generate trend plots from metrics history.
+        function fig = plotTrends(~, metrics)
+            %PLOTTRENDS Generate trend plot from supplied metrics struct.
             %   Inputs
-            %       csvPath - file path to a metrics CSV containing
-            %                 historical values.
-            %       pngPath - destination file path for the rendered PNG.
+            %       metrics - struct containing training history with fields:
+            %                 ``epochs``, ``accuracy`` and ``loss``.
             %   Output
-            %       pngPath - the path where the plot should be written.
-            %   Side Effects
-            %       Should read metric values from csvPath and write a trend
-            %       plot image to pngPath.
+            %       fig     - handle to the created figure.  No files are
+            %                 written by this stub implementation.
 
-            error("reg:model:NotImplemented", ...
-                "VisualizationModel.plotTrends is not implemented.");
+            arguments
+                ~
+                metrics struct
+                metrics.epochs (:,1) double
+                metrics.accuracy (:,1) double
+                metrics.loss (:,1) double
+            end
+
+            fig = figure("Visible", "off");
+            plot(metrics.epochs, [metrics.accuracy(:), metrics.loss(:)]);
+            legend("Accuracy", "Loss");
+            xlabel("Epoch");
+            ylabel("Metric value");
         end
 
         function pngPath = plotCoRetrievalHeatmap(~, coMatrix, pngPath, labels) %#ok<INUSD>

--- a/tests/VisualizationModelTest.m
+++ b/tests/VisualizationModelTest.m
@@ -1,0 +1,18 @@
+classdef VisualizationModelTest < matlab.unittest.TestCase
+    methods (Test)
+        function rejectsMalformedStruct(testCase)
+            vm = reg.model.VisualizationModel();
+            bad = struct();
+            testCase.verifyError(@() vm.plotTrends(bad), ?MException);
+        end
+        function plotsValidMetrics(testCase)
+            vm = reg.model.VisualizationModel();
+            metrics = struct('epochs', (1:3)', ...
+                             'accuracy', [0.5 0.6 0.7]', ...
+                             'loss', [1.0 0.8 0.6]');
+            fig = vm.plotTrends(metrics);
+            testCase.verifyClass(fig, "matlab.ui.Figure");
+            close(fig);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- Refactor `VisualizationModel.plotTrends` to accept an in-memory metrics struct and generate a figure without file I/O.
- Validate required metrics fields and update `EvaluationController.run` to pass the struct and forward the figure handle.
- Add placeholder tests for `plotTrends` validating rejection of malformed structs and success with valid data.

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a06834b4e8833083811a172c2e85af