### PR TITLE
Add argument blocks and placeholders for training pipeline

### DIFF
--- a/+reg/+model/TrainingModel.m
+++ b/+reg/+model/TrainingModel.m
@@ -1,145 +1,251 @@
 classdef TrainingModel < reg.mvc.BaseModel
     %TRAININGMODEL Encapsulates end-to-end training operations.
-    %   Provides methods covering ingestion, chunking, weak labeling,
+    %   Provides methods covering ingestion, chunking, weak labelling,
     %   dataset preparation, encoder fine-tuning and projection head
     %   training. Consolidates functionality previously split across
     %   several specialised models.
+
+    properties
+        % documentsTbl (table): nDoc x vars with columns
+        %   docId (double) - unique identifier
+        %   text  (string) - raw document text
+        documentsTbl table = table();
+
+        % chunksTbl (table): nChunk x vars with columns
+        %   chunkId (double), docId (double), text (string)
+        chunksTbl table = table();
+
+        % weakLabelsMat (double): nChunk x nRule rule confidences
+        weakLabelsMat double = zeros(0,0);
+
+        % bootLabelsMat (double): nChunk x nRule bootstrapped scores
+        bootLabelsMat double = zeros(0,0);
+
+        % featuresTbl (table): nChunk x vars, includes
+        %   chunkId (double), tfidfVec (1xV double)
+        featuresTbl table = table();
+
+        % vocab (string): 1 x V vocabulary terms
+        vocab string = strings(0,1);
+
+        % embeddingsMat (double): nChunk x d dense vectors
+        embeddingsMat double = zeros(0,0);
+
+        % tripletsTbl (table): nTriplet x 3 with columns
+        %   anchorIdx, posIdx, negIdx (double)
+        tripletsTbl table = table();
+
+        % encoderNet (dlnetwork or struct): fine-tuned encoder model
+        encoderNet = [];
+
+        % projectedMat (double): nSample x projDim projected embeddings
+        projectedMat double = zeros(0,0);
+
+        % classifierModels (cell): 1 x nLabel trained classifier models
+        classifierModels cell = {};
+
+        % scoresMat (double): nSample x nLabel prediction scores
+        scoresMat double = zeros(0,0);
+
+        % thresholdsVec (double): 1 x nLabel decision thresholds
+        thresholdsVec double = zeros(1,0);
+
+        % predLabelsMat (logical): nSample x nLabel final labels
+        predLabelsMat logical = false(0,0);
+    end
 
     methods
         function obj = TrainingModel(varargin) %#ok<INUSD>
             %TRAININGMODEL Construct a unified training model.
         end
 
-        function out = ingest(~, cfg) %#ok<INUSD>
-            %INGEST Coordinate document ingestion and feature extraction.
-            %   OUT = INGEST(obj, CFG) returns a struct containing
-            %   documents, chunks and features extracted from the input
-            %   configuration. Mirrors behaviour of the former
-            %   ``IngestionModel`` which orchestrated PDF ingestion,
-            %   text chunking and feature extraction.
-            %   Parameters
-            %       cfg - configuration controlling ingestion workflow
-            %   Returns
-            %       out (struct): with fields ``Documents``, ``Chunks`` and
-            %           ``Features`` representing the processed corpus.
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.ingest is not implemented.");
-        end
-
-        function chunks = chunk(~, documents) %#ok<INUSD>
-            %CHUNK Split documents into text segments.
-            %   CHUNKS = CHUNK(obj, DOCUMENTS) tokenises and partitions
-            %   documents into smaller pieces. Equivalent to the former
-            %   ``TextChunkModel``.
-            %   Parameters
-            %       documents (table): Source documents to split
-            %   Returns
-            %       chunks (table): Generated text chunks
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.chunk is not implemented.");
-        end
-
-        function [weakLabels, bootLabels] = weakLabel(~, chunks) %#ok<INUSD>
-            %WEAKLABEL Generate weak supervision labels for chunks.
-            %   [WEAKLABELS, BOOTLABELS] = WEAKLABEL(obj, CHUNKS) applies
-            %   rule based labelling to produce weak and bootstrapped label
-            %   matrices. Consolidates functionality of the previous
-            %   ``WeakLabelModel``.
-            %   Parameters
-            %       chunks (table): Text chunks awaiting labels
-            %   Returns
-            %       weakLabels (double matrix): Rule based scores
-            %       bootLabels (double matrix): Bootstrapped scores
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.weakLabel is not implemented.");
-        end
-
-        function [features, vocab] = extractFeatures(~, chunks) %#ok<INUSD>
-            %EXTRACTFEATURES Generate sparse feature representations.
-            %   [FEATURES, VOCAB] = EXTRACTFEATURES(obj, CHUNKS) produces
-            %   TF-IDF or other sparse features for each chunk, replacing
-            %   the responsibilities of ``FeatureModel``.
-            %   Parameters
-            %       chunks (table): Text segments to featurize
-            %   Returns
-            %       features (table): Derived feature table
-            %       vocab    (string array): Vocabulary terms
-            %   Note
-            %       CHUNKS is optional and may be loaded internally.
-            if nargin < 2
-                chunks = []; %#ok<NASGU>
+        function documentsTbl = ingest(obj, cfg)
+            %INGEST Read raw documents from disk.
+            %   DOCUMENTSTBL = INGEST(obj, CFG) loads documents described
+            %   by configuration struct CFG.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                cfg (1,1) struct
             end
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.extractFeatures is not implemented.");
+            %   Data contract:
+            %       cfg.inputDir (string): directory containing PDFs
+            %   Pseudocode:
+            %       1. verify required cfg fields exist
+            %       2. read files into table [docId, text]
+            %       3. assign table to obj.documentsTbl
+            obj.documentsTbl = table(); % placeholder
+            documentsTbl = obj.documentsTbl;
         end
 
-        function embeddings = computeEmbeddings(~, features) %#ok<INUSD>
+        function chunksTbl = chunk(obj, documentsTbl)
+            %CHUNK Split documents into text segments.
+            %   CHUNKSTBL = CHUNK(obj, DOCUMENTSTBL) partitions documents
+            %   into smaller text pieces.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                documentsTbl table
+            end
+            %   Data contract:
+            %       documentsTbl.docId (double), documentsTbl.text (string)
+            %       chunksTbl.chunkId, docId, text
+            %   Pseudocode:
+            %       1. validate required columns exist
+            %       2. tokenise and split text
+            %       3. store result in obj.chunksTbl
+            obj.chunksTbl = table(); % placeholder
+            chunksTbl = obj.chunksTbl;
+        end
+
+        function [weakLabelsMat, bootLabelsMat] = weakLabel(obj, chunksTbl)
+            %WEAKLABEL Generate weak supervision labels for chunks.
+            %   [WEAKLABELSMAT, BOOTLABELSMAT] = WEAKLABEL(obj, CHUNKSTBL)
+            %   produces rule-based label scores.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                chunksTbl table
+            end
+            %   Data contract:
+            %       chunksTbl.chunkId (double), chunksTbl.text (string)
+            %       weakLabelsMat (nChunk x nRule double)
+            %       bootLabelsMat (nChunk x nRule double)
+            %   Pseudocode:
+            %       1. ensure chunksTbl is non-empty
+            %       2. apply rule set and bootstrap
+            %       3. store matrices in properties
+            obj.weakLabelsMat = zeros(height(chunksTbl), 0);
+            obj.bootLabelsMat = zeros(height(chunksTbl), 0);
+            weakLabelsMat = obj.weakLabelsMat;
+            bootLabelsMat = obj.bootLabelsMat;
+        end
+
+        function [featuresTbl, vocab] = extractFeatures(obj, chunksTbl)
+            %EXTRACTFEATURES Generate sparse feature representations.
+            %   [FEATURESTBL, VOCAB] = EXTRACTFEATURES(obj, CHUNKSTBL)
+            %   derives sparse vectors for each text chunk.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                chunksTbl table
+            end
+            %   Data contract:
+            %       featuresTbl variables:
+            %           chunkId (double)
+            %           tfidfVec (1xV double)
+            %       vocab (1xV string)
+            %   Pseudocode:
+            %       1. validate chunk table
+            %       2. compute tf-idf and vocabulary
+            %       3. store results in properties
+            obj.featuresTbl = table();
+            obj.vocab = strings(0,1);
+            featuresTbl = obj.featuresTbl;
+            vocab = obj.vocab;
+        end
+
+        function embeddingsMat = computeEmbeddings(obj, featuresTbl)
             %COMPUTEEMBEDDINGS Produce dense embeddings from feature data.
-            %   EMBEDDINGS = COMPUTEEMBEDDINGS(obj, FEATURES) returns
-            %   embedding vectors derived from FEATURES. Consolidates
-            %   functionality of the former ``EmbeddingModel`` including any
-            %   configuration handling and persistence.
-            %   Parameters
-            %       features (table or struct): Input feature data
-            %   Returns
-            %       embeddings (struct): Struct containing embedding matrix
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.computeEmbeddings is not implemented.");
+            %   EMBEDDINGSMAT = COMPUTEEMBEDDINGS(obj, FEATURESTBL) returns
+            %   an embedding matrix.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                featuresTbl table
+            end
+            %   Data contract:
+            %       featuresTbl.tfidfVec (1xV double)
+            %       embeddingsMat (nChunk x d double)
+            %   Pseudocode:
+            %       1. validate feature vectors
+            %       2. run encoder network
+            %       3. store embeddings in obj.embeddingsMat
+            obj.embeddingsMat = zeros(height(featuresTbl), 0);
+            embeddingsMat = obj.embeddingsMat;
         end
 
-        function triplets = prepareDataset(~, rawData) %#ok<INUSD>
+        function tripletsTbl = prepareDataset(obj, rawDataStruct)
             %PREPAREDATASET Build contrastive triplets for training.
-            %   TRIPLETS = PREPAREDATASET(obj, RAWDATA) constructs anchor-
-            %   positive-negative triplets used for encoder or projection
-            %   head training. Replaces the former ``FineTuneDataModel`` and
-            %   its ``buildPairs`` helper.
-            %   Parameters
-            %       rawData (struct): Inputs such as labels or embeddings
-            %   Returns
-            %       triplets (table): Contrastive triplets
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.prepareDataset is not implemented.");
+            %   TRIPLETSTBL = PREPAREDATASET(obj, RAWDATASTRUCT) constructs
+            %   anchor-positive-negative triplets.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                rawDataStruct (1,1) struct
+            end
+            %   Data contract:
+            %       For fine-tuning: fields Chunks, WeakLabels, BootLabels
+            %       For projection head: field Embeddings
+            %       tripletsTbl.anchorIdx, posIdx, negIdx (double)
+            %   Pseudocode:
+            %       1. validate required fields per workflow
+            %       2. sample or build triplets
+            %       3. assign to obj.tripletsTbl
+            obj.tripletsTbl = table();
+            tripletsTbl = obj.tripletsTbl;
         end
 
-        function net = fineTuneEncoder(~, triplets) %#ok<INUSD>
+        function net = fineTuneEncoder(obj, tripletsTbl)
             %FINETUNEENCODER Fine-tune the encoder network.
-            %   NET = FINETUNEENCODER(obj, TRIPLETS) returns a trained
-            %   encoder model. Supersedes ``EncoderFineTuneModel``.
-            %   Parameters
-            %       triplets (table): Training triplets
-            %   Returns
-            %       net (dlnetwork or struct): Fine-tuned encoder
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.fineTuneEncoder is not implemented.");
+            %   NET = FINETUNEENCODER(obj, TRIPLETSTBL) adapts base encoder
+            %   using provided triplets.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                tripletsTbl table
+            end
+            %   Data contract:
+            %       tripletsTbl.anchorIdx, posIdx, negIdx (double)
+            %       net (dlnetwork or struct)
+            %   Pseudocode:
+            %       1. configure training options
+            %       2. iterate over triplets and update weights
+            %       3. store network in obj.encoderNet
+            obj.encoderNet = struct(); % placeholder
+            net = obj.encoderNet;
         end
 
-        function projected = trainProjectionHead(~, embeddings) %#ok<INUSD>
+        function projectedMat = trainProjectionHead(obj, tripletsTbl)
             %TRAINPROJECTIONHEAD Train a projection head over embeddings.
-            %   PROJECTED = TRAINPROJECTIONHEAD(obj, EMBEDDINGS) learns
-            %   projection head parameters and applies them to the provided
-            %   embeddings. Replaces ``ProjectionHeadModel``.
-            %   Parameters
-            %       embeddings (double matrix): Base embedding vectors
-            %   Returns
-            %       projected (double matrix): Projected embeddings
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.trainProjectionHead is not implemented.");
+            %   PROJECTEDMAT = TRAINPROJECTIONHEAD(obj, TRIPLETSTBL) learns
+            %   head parameters and returns projected embeddings.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                tripletsTbl table
+            end
+            %   Data contract:
+            %       tripletsTbl.anchorIdx, posIdx, negIdx (double)
+            %       projectedMat (nSample x projDim double)
+            %   Pseudocode:
+            %       1. validate triplets
+            %       2. optimise projection head
+            %       3. store projections in obj.projectedMat
+            obj.projectedMat = zeros(height(tripletsTbl), 0);
+            projectedMat = obj.projectedMat;
         end
 
-        function [models, scores, thresholds, predLabels] = trainClassifier(~, trainingInputs) %#ok<INUSD>
+        function [modelsCell, scoresMat, thresholdsVec, predLabelsMat] = trainClassifier(obj, trainingInputs)
             %TRAINCLASSIFIER Train downstream classifiers and predict labels.
-            %   [MODELS, SCORES, THRESHOLDS, PREDLABELS] = TRAINCLASSIFIER(obj,
-            %   TRAININGINPUTS) fits classifier models and generates
-            %   predictions, subsuming the former ``ClassifierModel``.
-            %   Parameters
-            %       trainingInputs (struct): Features and labels for training
-            %   Returns
-            %       models (cell array): Trained classifier models
-            %       scores (double matrix): Prediction scores per label
-            %       thresholds (double vector): Decision thresholds
-            %       predLabels (logical matrix): Final label decisions
-            error("reg:model:NotImplemented", ...
-                "TrainingModel.trainClassifier is not implemented.");
+            %   [MODELSCELL, SCORESMAT, THRESHOLDSVEC, PREDLABELSMAT] = ...
+            %   TRAINCLASSIFIER(obj, TRAININGINPUTS) fits classifier models.
+            arguments
+                obj (1,1) reg.model.TrainingModel
+                trainingInputs (1,1) struct
+            end
+            %   Data contract:
+            %       trainingInputs.Embeddings (nSample x d double)
+            %       modelsCell {1 x nLabel}
+            %       scoresMat (nSample x nLabel double)
+            %       thresholdsVec (1 x nLabel double)
+            %       predLabelsMat (nSample x nLabel logical)
+            %   Pseudocode:
+            %       1. ensure embeddings present
+            %       2. cross-validate and fit classifiers
+            %       3. compute thresholds and labels
+            %       4. store outputs in properties
+            obj.classifierModels = {};
+            obj.scoresMat = zeros(0,0);
+            obj.thresholdsVec = zeros(1,0);
+            obj.predLabelsMat = false(0,0);
+            modelsCell = obj.classifierModels;
+            scoresMat = obj.scoresMat;
+            thresholdsVec = obj.thresholdsVec;
+            predLabelsMat = obj.predLabelsMat;
         end
     end
 end
+


### PR DESCRIPTION
## Summary
- add argument blocks and data-contract comments across TrainingModel methods
- store intermediate results in new TrainingModel properties
- align PipelineModel training, fine-tuning and projection head flows with new method signatures

## Testing
- `matlab -batch "runtests('tests','IncludeSubfolders',true)"` *(fails: command not found: matlab)*

------
https://chatgpt.com/codex/tasks/task_b_68a06e6023f083309617dcf983582915