### PR TITLE
feat: add argument validation stubs

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -6,10 +6,20 @@ classdef EvaluationController < reg.mvc.BaseController
     %   diagnostic plots.
 
     properties
-        % Model computing evaluation metrics (stored in BaseController.Model)
-        ReportModel
-        PlotView
+        % ReportModel (reg.model.ReportModel): transforms metrics into
+        %   report-ready structures.  Fields produced should align with
+        %   ReportModel.load/process contracts (chunks, scores, labels).
+        ReportModel reg.model.ReportModel
+
+        % PlotView (reg.view.PlotView): handles visual artefact display.
+        PlotView reg.view.PlotView
+
+        % VisualizationModel: generates diagnostic figures such as trends
+        %   and co-retrieval heatmaps.
         VisualizationModel reg.model.VisualizationModel = reg.model.VisualizationModel();
+
+        % MetricsView: logs scalar metrics; expected to support ``log`` and
+        %   ``display`` methods accepting structs.
         MetricsView reg.view.MetricsView = reg.view.MetricsView();
     end
 
@@ -114,12 +124,16 @@ classdef EvaluationController < reg.mvc.BaseController
             %   METRICS = RETRIEVALMETRICS(embeddings, posSets, k) should
             %   produce Recall@K, mAP and nDCG scores for a set of embeddings
             %   and positive index sets.
+            arguments
+                ~
+                embeddings double
+                posSets cell
+                k (1,1) double
+            end
             %   Legacy Reference
             %       Equivalent to `reg.eval_retrieval` and `reg.metrics_ndcg`.
-            %   Pseudocode:
-            %       1. For each query embedding compute similarity scores
-            %       2. Derive recall, mAP and nDCG at K
-            %       3. Return metrics struct
+            %   Pseudocode/Validation stub:
+            %       assert(size(embeddings,1) == numel(posSets))
             error("reg:controller:NotImplemented", ...
                 "EvaluationController.retrievalMetrics is not implemented.");
         end
@@ -137,9 +151,11 @@ classdef EvaluationController < reg.mvc.BaseController
             %       Step 1a ↔ `eval_per_label`
             %       Step 1b ↔ `eval_clustering`
             %       Step 2  ↔ `log_metrics`
-
-            if nargin < 3
-                labelMatrix = [];
+            arguments
+                obj
+                embeddings double
+                labelMatrix double = []
+                opts struct = struct()
             end
 
             % Step 1: load evaluation inputs and compute core metrics

--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -2,14 +2,18 @@ classdef PipelineController < reg.mvc.BaseController
     %PIPELINECONTROLLER Orchestrates end-to-end pipeline flow.
 
     properties
-        PipelineModel
+        % PipelineModel (reg.model.PipelineModel): coordinates lower level
+        %   models.  Expected to expose methods ``run``, ``runFineTune``,
+        %   ``runProjectionHead`` and ``runTraining`` returning structs.
+        PipelineModel reg.model.PipelineModel
     end
 
     methods
         function obj = PipelineController(pipelineModel, view)
             %PIPELINECONTROLLER Construct controller wiring pipeline model.
-            if nargin < 2 || isempty(view)
-                view = reg.view.MetricsView();
+            arguments
+                pipelineModel reg.model.PipelineModel
+                view reg.view.MetricsView = reg.view.MetricsView()
             end
             obj@reg.mvc.BaseController(pipelineModel, view);
             obj.PipelineModel = pipelineModel;
@@ -21,6 +25,10 @@ classdef PipelineController < reg.mvc.BaseController
             %   process to the PipelineModel using the supplied processed
             %   configuration CFG and displays any outputs using the
             %   controller view.
+            arguments
+                obj
+                cfg (1,1) struct
+            end
 
             result = obj.PipelineModel.runFineTune(cfg);
             if ~isempty(obj.View)
@@ -33,6 +41,10 @@ classdef PipelineController < reg.mvc.BaseController
             %   PROJECTED = RUNPROJECTIONHEAD(obj, EMBEDDINGS) delegates
             %   projection head training to the PipelineModel and displays
             %   the resulting embeddings using the controller view.
+            arguments
+                obj
+                embeddings double
+            end
 
             projected = obj.PipelineModel.runProjectionHead(embeddings);
             if ~isempty(obj.View)
@@ -42,6 +54,9 @@ classdef PipelineController < reg.mvc.BaseController
 
         function run(obj)
             %RUN Execute the full pipeline end-to-end.
+            arguments
+                obj
+            end
 
             result = obj.PipelineModel.run();
 
@@ -58,6 +73,10 @@ classdef PipelineController < reg.mvc.BaseController
             %   RUNTRAINING(OBJ, CFG) delegates the workflow to the
             %   PipelineModel using the supplied processed configuration
             %   CFG and displays the results using the controller view.
+            arguments
+                obj
+                cfg (1,1) struct
+            end
             result = obj.PipelineModel.runTraining(cfg);
             if ~isempty(obj.View)
                 obj.View.display(result);

--- a/+reg/+model/CorpusModel.m
+++ b/+reg/+model/CorpusModel.m
@@ -38,6 +38,10 @@ classdef CorpusModel < reg.mvc.BaseModel
             %       1. Issue HTTP requests for CRR articles
             %       2. Write HTML/plaintext files and index.csv
             %       3. Return table describing downloaded artefacts
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.fetchEba is not implemented.");
         end
@@ -50,6 +54,10 @@ classdef CorpusModel < reg.mvc.BaseModel
             %       1. Fetch articles as in fetchEba
             %       2. Parse article numbers into `article_num`
             %       3. Return metadata table including `article_num`
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.fetchEbaParsed is not implemented.");
         end
@@ -62,6 +70,10 @@ classdef CorpusModel < reg.mvc.BaseModel
             %       1. Build download URL from consolidation code
             %       2. Download PDF into data/raw
             %       3. Return absolute file path
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.fetchEurlex is not implemented.");
         end
@@ -77,6 +89,11 @@ classdef CorpusModel < reg.mvc.BaseModel
             %       1. Resolve remote resources for params.date
             %       2. Download and unpack corpus
             %       3. Build index files and return paths
+            arguments
+                ~
+                params (1,1) struct
+                params.date (1,1) string
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.sync is not implemented.");
         end
@@ -225,6 +242,12 @@ classdef CorpusModel < reg.mvc.BaseModel
             %       1. Embed and tokenise queryString
             %       2. Compute lexical and embedding similarity
             %       3. Blend scores and return topK results
+            arguments
+                ~
+                queryString (1,1) string
+                alpha (1,1) double
+                topK (1,1) double
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.queryIndex is not implemented.");
         end
@@ -235,6 +258,12 @@ classdef CorpusModel < reg.mvc.BaseModel
             %   documents by article identifiers and compute differences.
             %   Legacy Reference
             %       Equivalent to `reg.crr_diff_articles`.
+            arguments
+                ~
+                dirA (1,1) string
+                dirB (1,1) string
+                outDir (1,1) string
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.runArticles is not implemented.");
         end
@@ -245,6 +274,12 @@ classdef CorpusModel < reg.mvc.BaseModel
             %   file versions and report line-level changes.
             %   Legacy Reference
             %       Equivalent to `reg.crr_diff_versions`.
+            arguments
+                ~
+                dirA (1,1) string
+                dirB (1,1) string
+                outDir (1,1) string
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.runVersions is not implemented.");
         end
@@ -256,6 +291,12 @@ classdef CorpusModel < reg.mvc.BaseModel
             %   Legacy Reference
             %       Equivalent to `reg_crr_diff_report` and
             %       `reg_crr_diff_report_html`.
+            arguments
+                ~
+                dirA (1,1) string
+                dirB (1,1) string
+                outDir (1,1) string
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.runReport is not implemented.");
         end
@@ -265,9 +306,12 @@ classdef CorpusModel < reg.mvc.BaseModel
             %   RESULT = RUNMETHODS(obj, queries, chunksT, config) should
             %   evaluate alternative embedding methods on QUERY strings
             %   against CHUNKST table. CONFIG defaults to an empty struct.
-            if nargin < 4
-                config = struct();
-            end %#ok<NASGU>
+            arguments
+                ~
+                queries (:,1) string
+                chunksT table
+                config struct = struct()
+            end
             error("reg:model:NotImplemented", ...
                 "CorpusModel.runMethods is not implemented.");
         end

--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -3,6 +3,8 @@ classdef DatabaseModel < reg.mvc.BaseModel
 
     properties
         % Database connection handle created in `load` (default: [])
+        %   Should be a database connection object compatible with Database
+        %   Toolbox or a struct providing minimal fields `close` and `exec`.
         conn = [];
     end
 
@@ -31,6 +33,10 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %   Recommended Mitigation
             %       * Implement retry/backoff and surface meaningful errors.
             %       * Ensure existing connections are cleaned before opening new ones.
+            arguments
+                obj
+                varargin (1,:) cell
+            end
             % Pseudocode:
             %   1. If obj.conn is open, close it
             %   2. Create new connection using configuration parameters
@@ -66,6 +72,10 @@ classdef DatabaseModel < reg.mvc.BaseModel
             %       * Use parameterized queries to avoid injection and ensure
             %         proper escaping.
             %       * Provide idempotent retry logic for transient failures.
+            arguments
+                obj
+                predictionTable table
+            end
             % Pseudocode:
             %   1. Begin transaction on obj.conn
             %   2. Upsert rows from predictionTable into reg_chunks

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -2,6 +2,8 @@ classdef EvaluationModel < reg.mvc.BaseModel
     %EVALUATIONMODEL Compute evaluation metrics for model outputs.
 
     properties
+        % ConfigModel: provides configuration validation hooks used during
+        %   processing.  Optional; if empty defaults are assumed.
         ConfigModel reg.model.ConfigModel
     end
 
@@ -17,6 +19,10 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   INPUT = LOAD(~, PRED, REF) returns a struct with fields
             %   ``Predictions`` and ``References`` capturing the supplied
             %   arrays.
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             pred = [];
             ref = [];
             if numel(varargin) >= 1
@@ -32,6 +38,10 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %PROCESS Calculate evaluation metrics from INPUT.
             %   RESULT = PROCESS(obj, INPUT) returns a struct containing a
             %   ``Metrics`` field with evaluation scores.
+            arguments
+                obj
+                input (1,1) struct
+            end
             if ~isempty(obj.ConfigModel)
                 cfgRaw = obj.ConfigModel.load();
                 cfg = obj.ConfigModel.process(cfgRaw); %#ok<NASGU>
@@ -52,6 +62,13 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   ``LabelIdx``, ``RecallAtK`` and ``Support``.
             %
             %   This method replaces the former PerLabelEvalModel.process.
+            arguments
+                ~
+                embeddings double
+                labelsLogical logical
+                k (1,1) double
+            end
+            % Pseudocode: validate size(labelsLogical,1) == size(embeddings,1)
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.perLabelMetrics is not implemented.");
         end
@@ -67,6 +84,12 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   assignments.
             %
             %   This method consolidates the former ClusteringEvalModel.
+            arguments
+                ~
+                embeddings double
+                labelsLogical logical
+                k (1,1) double
+            end
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.clusteringMetrics is not implemented.");
         end
@@ -81,6 +104,12 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   captures the column permutation applied to labels.
             %
             %   This method supersedes the CoRetrievalMatrixModel.
+            arguments
+                ~
+                embeddings double
+                labelMatrix double
+                k (1,1) double
+            end
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.coRetrievalMatrix is not implemented.");
         end

--- a/+reg/+model/GoldPackModel.m
+++ b/+reg/+model/GoldPackModel.m
@@ -2,6 +2,11 @@ classdef GoldPackModel < reg.mvc.BaseModel
     %GOLDPACKMODEL Stub model providing labelled gold data.
 
     properties
+        % GoldTable (table): labelled reference data with variables
+        %   chunkId (double) - unique chunk identifier
+        %   label (string)   - associated label name
+        %   This placeholder is populated in `process`.
+        GoldTable table = table();
     end
 
     methods
@@ -22,6 +27,10 @@ classdef GoldPackModel < reg.mvc.BaseModel
             %       Equivalent to `load_gold`.
             %   Extension Point
             %       Override to retrieve from external repositories.
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             % Pseudocode:
             %   1. Read gold dataset files from disk
             %   2. Parse into goldDataStruct
@@ -29,7 +38,7 @@ classdef GoldPackModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented", ...
                 "GoldPackModel.load is not implemented.");
         end
-        function goldTable = process(~, goldDataStruct) %#ok<INUSD>
+        function goldTable = process(obj, goldDataStruct) %#ok<INUSD>
             %PROCESS Return processed gold data.
             %   goldTable = PROCESS(obj, goldDataStruct) outputs structured
             %   gold artefacts.
@@ -43,10 +52,14 @@ classdef GoldPackModel < reg.mvc.BaseModel
             %       Equivalent to `load_gold` post-processing.
             %   Extension Point
             %       Customize schema or filtering of gold data.
+            arguments
+                obj
+                goldDataStruct (1,1) struct
+            end
             % Pseudocode:
             %   1. Normalize fields in goldDataStruct
             %   2. Convert to table format
-            %   3. Return goldTable
+            %   3. Store in obj.GoldTable and return
             error("reg:model:NotImplemented", ...
                 "GoldPackModel.process is not implemented.");
         end

--- a/+reg/+model/ReportModel.m
+++ b/+reg/+model/ReportModel.m
@@ -5,6 +5,13 @@ classdef ReportModel < reg.mvc.BaseModel
     %   and topic summaries.
 
     properties
+        % ReportInputs (struct): expected fields
+        %   chunks   (table) : chunk metadata with variables chunkId, text
+        %   scores   (double): N-by-L classifier score matrix
+        %   mdlLDA   (struct): topic model handle
+        %   vocab    (string): 1-by-V vocabulary terms
+        %   labels   (string): 1-by-L label names
+        ReportInputs struct = struct();
     end
 
     methods
@@ -32,6 +39,10 @@ classdef ReportModel < reg.mvc.BaseModel
             %       Equivalent to `generate_reg_report` data loading.
             %   Extension Point
             %       Override to incorporate custom metrics sources.
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             % Pseudocode:
             %   1. Load chunk metadata and classifier scores
             %   2. Load or fit LDA model along with vocabulary
@@ -40,7 +51,7 @@ classdef ReportModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented", ...
                 "ReportModel.load is not implemented.");
         end
-        function reportData = process(~, reportInputs) %#ok<INUSD>
+        function reportData = process(obj, reportInputs) %#ok<INUSD>
             %PROCESS Assemble report data structure.
             %   reportData = PROCESS(obj, reportInputs) returns a struct ready
             %   for rendering.
@@ -59,6 +70,10 @@ classdef ReportModel < reg.mvc.BaseModel
             %       Equivalent to `generate_reg_report`.
             %   Extension Point
             %       Hook to inject custom formatting or sections.
+            arguments
+                obj
+                reportInputs (1,1) struct
+            end
             % Pseudocode:
             %   % Coverage table derived from scores
             %   1. pred = scores > threshold
@@ -72,7 +87,8 @@ classdef ReportModel < reg.mvc.BaseModel
             %   7. for each topic k
             %          topIdx = topk(mdlLDA.TopicWordProbabilities(k,:),10)
             %          ldaTopics{k} = vocab(topIdx)
-            %   8. Return reportData struct with above fields
+            %   8. Store reportInputs in obj.ReportInputs and
+            %          return reportData struct
             error("reg:model:NotImplemented", ...
                 "ReportModel.process is not implemented.");
         end

--- a/+reg/+model/VisualizationModel.m
+++ b/+reg/+model/VisualizationModel.m
@@ -2,6 +2,11 @@ classdef VisualizationModel < reg.mvc.BaseModel
     %VISUALIZATIONMODEL Stub model for generating evaluation plots.
     %   Provides helpers to render trend lines and co-retrieval heatmaps.
 
+    properties
+        % LastPlotPath (string): destination of most recently saved plot
+        LastPlotPath string = ""
+    end
+
     methods
         function obj = VisualizationModel(varargin) %#ok<INUSD>
             %VISUALIZATIONMODEL Construct visualization model.
@@ -33,7 +38,7 @@ classdef VisualizationModel < reg.mvc.BaseModel
             ylabel("Metric value");
         end
 
-        function pngPath = plotCoRetrievalHeatmap(~, coMatrix, pngPath, labels) %#ok<INUSD>
+        function pngPath = plotCoRetrievalHeatmap(obj, coMatrix, pngPath, labels) %#ok<INUSD>
             %PLOTCORETRIEVALHEATMAP Render heatmap from co-retrieval matrix.
             %   Inputs
             %       coMatrix - L x L numeric matrix of co-retrieval rates
@@ -47,19 +52,37 @@ classdef VisualizationModel < reg.mvc.BaseModel
             %   Side Effects
             %       Should visualise the supplied matrix as a heatmap and
             %       persist it to ``pngPath``.
-
+            arguments
+                obj
+                coMatrix double
+                pngPath (1,1) string
+                labels cell = {}
+            end
+            % Pseudocode/Validation:
+            %   assert(size(coMatrix,1)==size(coMatrix,2))
+            %   heatmap(coMatrix)
+            %   saveas(fig, pngPath)
+            %   obj.LastPlotPath = pngPath
             error("reg:model:NotImplemented", ...
                 "VisualizationModel.plotCoRetrievalHeatmap is not implemented.");
         end
 
         function data = load(~, varargin) %#ok<INUSD>
             %LOAD Stub for interface completeness.
+            arguments
+                ~
+                varargin (1,:) cell
+            end
             error("reg:model:NotImplemented", ...
                 "VisualizationModel.load is not implemented.");
         end
 
         function result = process(~, data) %#ok<INUSD>
             %PROCESS Stub for interface completeness.
+            arguments
+                ~
+                data struct
+            end
             error("reg:model:NotImplemented", ...
                 "VisualizationModel.process is not implemented.");
         end


### PR DESCRIPTION
## Summary
- add `arguments` blocks to controllers and models for field-level validation
- document expected table schemas and matrix dimensions in placeholders
- include pseudocode stubs for future schema checks

## Testing
- ⚠️ `octave -qf tests/VisualizationModelTest.m` *(command not found)*
- ⚠️ `matlab -batch "runtests('tests/VisualizationModelTest')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a06fe8e5f883309cfc5f3d7a721ca7