### PR TITLE
Reuse ingested documents table for training

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -68,16 +68,18 @@ classdef PipelineController < reg.mvc.BaseController
             end
         end
 
-        function runTraining(obj, cfg)
+        function runTraining(obj, cfg, documentsTbl)
             %RUNTRAINING Execute only the training workflow.
-            %   RUNTRAINING(OBJ, CFG) delegates the workflow to the
-            %   PipelineModel using the supplied processed configuration
-            %   CFG and displays the results using the controller view.
+            %   RUNTRAINING(OBJ, CFG, DOCUMENTSTBL) delegates the workflow
+            %   to the PipelineModel using the supplied processed
+            %   configuration CFG and pre-ingested DOCUMENTSTBL, then
+            %   displays the results using the controller view.
             arguments
                 obj
                 cfg (1,1) struct
+                documentsTbl table
             end
-            result = obj.PipelineModel.runTraining(cfg);
+            result = obj.PipelineModel.runTraining(cfg, documentsTbl);
             if ~isempty(obj.View)
                 obj.View.display(result);
             end


### PR DESCRIPTION
## Summary
- Accept pre-ingested documents table in PipelineModel.runTraining
- Reuse documents table from ingestCorpus for both index building and classifier training
- Update PipelineController to pass through the pre-ingested documents table

## Testing
- `matlab -batch "cd('tests');runtests"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a07a1c38d48330b5f3c0d08a7a51de