### PR TITLE
Document evaluation metrics schema for evaluation pipeline

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -141,10 +141,16 @@ classdef EvaluationController < reg.mvc.BaseController
         function results = evaluateGoldPack(obj, embeddings, labelMatrix, opts) %#ok<INUSD>
             %EVALUATEGOLDPACK Run evaluation and assemble metrics.
             %   RESULTS = EVALUATEGOLDPACK(EMBEDDINGS, LABELMATRIX) evaluates
-            %   supplied in-memory data, computes metrics (overall, per-label
-            %   and clustering) and logs them.  The returned struct combines
-            %   evaluation outputs and a ``Metrics`` field for downstream
-            %   processing.
+            %   supplied in-memory data, computes metrics and logs them.  The
+            %   returned ``results`` struct merges evaluation outputs with a
+            %   ``Metrics`` field whose schema mirrors ``EvaluationModel.process``:
+            %       results.Metrics.accuracy   (:,1 double)
+            %       results.Metrics.loss       (:,1 double)
+            %       results.Metrics.perLabel   (table)
+            %       results.Metrics.clustering (struct with ``purity``,
+            %                                   ``silhouette`` and ``idx``)
+            %   Additional bookkeeping fields (e.g. ``epochs``) may also be
+            %   present for plotting.
             %
             %   Legacy mapping:
             %       Step 1  ↔ `eval_retrieval`
@@ -162,6 +168,11 @@ classdef EvaluationController < reg.mvc.BaseController
             evalRaw = obj.Model.load(embeddings, labelMatrix);
             evalResult = obj.Model.process(evalRaw);
             metrics = evalResult.Metrics;
+            % Pseudocode/validation stub:
+            %   assert(isfield(metrics, 'accuracy'));
+            %   assert(isfield(metrics, 'loss'));
+            %   assert(isfield(metrics, 'perLabel'));
+            %   assert(isfield(metrics, 'clustering'));
 
             % Per-label evaluation via consolidated model
             try

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -36,8 +36,16 @@ classdef EvaluationModel < reg.mvc.BaseModel
 
         function result = process(obj, input) %#ok<INUSD>
             %PROCESS Calculate evaluation metrics from INPUT.
-            %   RESULT = PROCESS(obj, INPUT) returns a struct containing a
-            %   ``Metrics`` field with evaluation scores.
+            %   RESULT = PROCESS(obj, INPUT) returns a struct with a
+            %   ``Metrics`` field summarising evaluation outcomes.  The
+            %   ``Metrics`` struct is expected to contain:
+            %     - ``accuracy``   (:,1 double) accuracy per epoch
+            %     - ``loss``       (:,1 double) loss values per epoch
+            %     - ``perLabel``   (table) per-label Recall@K scores
+            %     - ``clustering`` (struct) clustering diagnostics such as
+            %                       ``purity``, ``silhouette`` and ``idx``
+            %   Additional fields (e.g. ``epochs``) may be supplied for
+            %   plotting or bookkeeping purposes.
             arguments
                 obj
                 input (1,1) struct
@@ -47,6 +55,13 @@ classdef EvaluationModel < reg.mvc.BaseModel
                 cfg = obj.ConfigModel.process(cfgRaw); %#ok<NASGU>
             end
             result = struct('Metrics', []);
+            % Pseudocode/validation stub:
+            %   m = result.Metrics;
+            %   assert(isfield(m, 'accuracy') && iscolumn(m.accuracy));
+            %   assert(isfield(m, 'loss') && iscolumn(m.loss));
+            %   assert(isfield(m, 'perLabel'));
+            %   assert(isfield(m, 'clustering'));
+            %   assert(numel(m.accuracy) == numel(m.loss));
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.process is not implemented.");
         end


### PR DESCRIPTION
## Summary
- expand EvaluationModel.process docstring to outline expected metrics fields and add validation pseudocode
- clarify EvaluationController.evaluateGoldPack comments with the same metrics schema and validation notes

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a07d4145888330b876272ea5a5f6bc