### PR TITLE
Add GoldPackModel regression test placeholder

### DIFF
--- a/tests/GoldPackModelTest.m
+++ b/tests/GoldPackModelTest.m
@@ -1,0 +1,18 @@
+classdef GoldPackModelTest < matlab.unittest.TestCase
+    %GOLDPACKMODELTEST Exercises the GoldPackModel regression fixture.
+    %   This test outlines how packaged gold labels can be compared with
+    %   live evaluation results to detect metric regressions.
+    methods (Test)
+        function loadsFixtureAndShowsPseudoAssertions(testCase)
+            gm = tests.reg.fixture.GoldPackModel();
+            testCase.verifyClass(gm, "tests.reg.fixture.GoldPackModel");
+            % Pseudocode for future regression check:
+            %   goldData = gm.load();
+            %   tbl = gm.process(goldData);
+            %   testCase.verifyGreaterThan(height(tbl), 0);
+            %   metrics = evaluateModel(tbl);
+            %   goldMetrics = load('tests/+reg/gold/metrics.mat');
+            %   testCase.verifyEqual(metrics, goldMetrics);
+        end
+    end
+end

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Tests
+
+## Gold regression fixtures
+
+`GoldPackModelTest` exercises a deterministic labelled dataset to ensure that
+model evaluation metrics do not regress. The test loads the fixture model and,
+when fully implemented, will compare metrics produced during evaluation with
+gold labels.
+
+Gold fixtures live under [`tests/+reg/+fixture`](+reg/+fixture) and store
+reference data used for regression checks. When the expected evaluation output
+changes intentionally, regenerate the gold data (for example by running the
+full evaluation pipeline) and update the fixtures in that folder before
+committing.


### PR DESCRIPTION
## Summary
- add `GoldPackModelTest` illustrating how to compare evaluation metrics to stored gold labels
- document location and maintenance of gold fixtures

## Testing
- `octave -qf --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a08a9d97f08330884a7ad88f7c9732