### PR TITLE
Document evaluation metric schema

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -150,13 +150,14 @@ classdef EvaluationController < reg.mvc.BaseController
             %   label information via ``RuntimeLabelModel`` and computes metrics.
             %   The returned ``results`` struct merges evaluation outputs with a
             %   ``Metrics`` field whose schema mirrors ``EvaluationModel.process``:
-            %       results.Metrics.accuracy   (:,1 double)
-            %       results.Metrics.loss       (:,1 double)
-            %       results.Metrics.perLabel   (table)
-            %       results.Metrics.clustering (struct with ``purity``,
-            %                                   ``silhouette`` and ``idx``)
-            %   Additional bookkeeping fields (e.g. ``epochs``) may also be
-            %   present for plotting.
+            %       - results.Metrics.accuracy   (:,1 double)
+            %       - results.Metrics.loss       (:,1 double)
+            %       - results.Metrics.perLabel   (table with ``LabelIdx``,
+            %                                     ``RecallAtK`` and ``Support``)
+            %       - results.Metrics.clustering (struct with ``purity``,
+            %                                     ``silhouette`` and ``idx``)
+            %       - results.Metrics.epochs     (:,1 double) optional
+            %   Additional bookkeeping fields may also be present for plotting.
             %
             %   Evaluation Flow (pseudocode):
             %       rlm   = reg.model.RuntimeLabelModel();
@@ -177,10 +178,14 @@ classdef EvaluationController < reg.mvc.BaseController
             evalResult = obj.Model.process(evalRaw);
             metrics = evalResult.Metrics;
             % Pseudocode/validation stub:
-            %   assert(isfield(metrics, 'accuracy'));
-            %   assert(isfield(metrics, 'loss'));
-            %   assert(isfield(metrics, 'perLabel'));
-            %   assert(isfield(metrics, 'clustering'));
+            %   assert(isfield(metrics, 'accuracy') && iscolumn(metrics.accuracy));
+            %   assert(isfield(metrics, 'loss') && iscolumn(metrics.loss));
+            %   assert(isfield(metrics, 'perLabel') && istable(metrics.perLabel));
+            %   assert(isfield(metrics, 'clustering') && isstruct(metrics.clustering));
+            %   if isfield(metrics, 'epochs')
+            %       assert(iscolumn(metrics.epochs));
+            %       assert(numel(metrics.epochs) == numel(metrics.accuracy));
+            %   end
 
             % Per-label evaluation via consolidated model
             try

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -37,15 +37,18 @@ classdef EvaluationModel < reg.mvc.BaseModel
         function result = process(obj, input) %#ok<INUSD>
             %PROCESS Calculate evaluation metrics from INPUT.
             %   RESULT = PROCESS(obj, INPUT) returns a struct with a
-            %   ``Metrics`` field summarising evaluation outcomes.  The
-            %   ``Metrics`` struct is expected to contain:
+            %   ``Metrics`` field summarising evaluation outcomes. The
+            %   ``Metrics`` struct should provide at minimum:
             %     - ``accuracy``   (:,1 double) accuracy per epoch
             %     - ``loss``       (:,1 double) loss values per epoch
-            %     - ``perLabel``   (table) per-label Recall@K scores
-            %     - ``clustering`` (struct) clustering diagnostics such as
+            %     - ``perLabel``   (table) per-label Recall@K with
+            %                       columns ``LabelIdx``, ``RecallAtK``
+            %                       and ``Support``
+            %     - ``clustering`` (struct) diagnostics with fields
             %                       ``purity``, ``silhouette`` and ``idx``
-            %   Additional fields (e.g. ``epochs``) may be supplied for
-            %   plotting or bookkeeping purposes.
+            %     - ``epochs``     (:,1 double) optional epoch indices
+            %   Additional fields may be supplied for plotting or
+            %   bookkeeping purposes.
             arguments
                 obj
                 input (1,1) struct
@@ -59,9 +62,13 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   m = result.Metrics;
             %   assert(isfield(m, 'accuracy') && iscolumn(m.accuracy));
             %   assert(isfield(m, 'loss') && iscolumn(m.loss));
-            %   assert(isfield(m, 'perLabel'));
-            %   assert(isfield(m, 'clustering'));
+            %   assert(isfield(m, 'perLabel') && istable(m.perLabel));
+            %   assert(isfield(m, 'clustering') && isstruct(m.clustering));
             %   assert(numel(m.accuracy) == numel(m.loss));
+            %   if isfield(m, 'epochs')
+            %       assert(iscolumn(m.epochs));
+            %       assert(numel(m.epochs) == numel(m.accuracy));
+            %   end
             error("reg:model:NotImplemented", ...
                 "EvaluationModel.process is not implemented.");
         end


### PR DESCRIPTION
## Summary
- detail expected metrics fields in `EvaluationModel.process`
- mirror metrics schema in `EvaluationController.evaluateLabelledData`

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "ver"` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a09035715c833099dcfa14783ac92a