### PR TITLE
Refactor evaluation orchestration

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -60,9 +60,19 @@ classdef PipelineController < reg.mvc.BaseController
 
             result = obj.PipelineModel.run();
 
-            if ~isempty(obj.View) && isfield(result, "Metrics")
-                obj.View.log(result.Metrics);
-                obj.View.display(result.Metrics);
+            metrics = [];
+            if isfield(result, "EvaluationInputs")
+                evalController = reg.controller.EvaluationController(
+                    obj.PipelineModel.EvaluationModel, reg.model.ReportModel());
+                evalInputs = result.EvaluationInputs;
+                metrics = evalController.run(
+                    evalInputs.Embeddings, evalInputs.Labels);
+                result.Metrics = metrics;
+            end
+
+            if ~isempty(obj.View) && ~isempty(metrics)
+                obj.View.log(metrics);
+                obj.View.display(metrics);
             elseif ~isempty(obj.View)
                 obj.View.display(result);
             end


### PR DESCRIPTION
## Summary
- Decouple evaluation from PipelineModel by exposing evaluationInputs
- Add evaluationInputs helper that surfaces embeddings and labels
- Have PipelineController build EvaluationController to run evaluation

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0986d4f6083308af400fc2530216e