### PR TITLE
Delegate metrics validation to model stub

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -84,7 +84,7 @@ classdef EvaluationController < reg.mvc.BaseController
 
             % Step 3: create diagnostic plots
             metricsStruct = results.Metrics;
-            validateMetrics(metricsStruct);
+            obj.Model.validateMetrics(metricsStruct);
             trendsFig = obj.VisualizationModel.plotTrends(metricsStruct);
 
             coMatrix = [];
@@ -115,14 +115,6 @@ classdef EvaluationController < reg.mvc.BaseController
                 metrics = results.Metrics;
             else
                 metrics = [];
-            end
-            function validateMetrics(m)
-                arguments
-                    m struct
-                    m.epochs (:,1) double
-                    m.accuracy (:,1) double
-                    m.loss (:,1) double
-                end
             end
         end
         function metrics = retrievalMetrics(~, embeddings, posSets, k) %#ok<INUSD>

--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -112,6 +112,32 @@ classdef EvaluationModel < reg.mvc.BaseModel
             result = struct('Metrics', metrics);
         end
 
+        function validateMetrics(~, m) %#ok<INUSD>
+            %VALIDATEMETRICS Validate metrics structure produced by evaluation.
+            %   VALIDATEMETRICS(~, M) checks the supplied metrics struct for
+            %   expected fields and basic schema.  This placeholder outlines
+            %   the intended validation logic without implementing it.
+            %
+            %   Expected fields in ``m``:
+            %       - ``epochs``   (:,1 double) epoch indices
+            %       - ``accuracy`` (:,1 double) accuracy per epoch
+            %       - ``loss``     (:,1 double) loss values per epoch
+            arguments
+                ~
+                m struct
+                m.epochs (:,1) double
+                m.accuracy (:,1) double
+                m.loss (:,1) double
+            end
+            % Pseudocode/validation stub:
+            %   assert(numel(m.accuracy) == numel(m.loss));
+            %   if isfield(m, 'epochs')
+            %       assert(numel(m.epochs) == numel(m.accuracy));
+            %   end
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel.validateMetrics is not implemented.");
+        end
+
         function perLabel = perLabelMetrics(~, embeddings, labelsLogical, k) %#ok<INUSD>
             %PERLABELMETRICS Compute per-label Recall@K.
             %   perLabel = PERLABELMETRICS(embeddings, labelsLogical, k)


### PR DESCRIPTION
## Summary
- Simplify EvaluationController by delegating metrics validation to EvaluationModel
- Introduce validateMetrics stub in EvaluationModel with argument schema and placeholder error

## Testing
- `octave --eval "runtests"` *(fails: command not found)*
- `matlab -batch "runtests"` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a0a647ca4c83308d176e14c75caef5