### PR TITLE
Stub PipelineModel.ingestCorpus with NotImplemented error

### DIFF
--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -137,12 +137,19 @@ classdef PipelineModel < reg.mvc.BaseModel
                 searchIndexStruct.docId string
                 searchIndexStruct.embedding double
             end
-            documentsTbl = obj.CorpusModel.ingestPdfs(cfg);
-            obj.CorpusModel.persistDocuments(documentsTbl);
-            indexInputsStruct = struct( ...
-                'documentsTbl', documentsTbl, ...
-                'embeddingsMat', zeros(height(documentsTbl), 0));
-            searchIndexStruct = obj.CorpusModel.buildIndex(indexInputsStruct);
+            % Step 1: ingest PDF documents into a table
+            % documentsTbl = CorpusModel.ingestPdfs(cfg);
+
+            % Step 2: persist the ingested documents
+            % CorpusModel.persistDocuments(documentsTbl);
+
+            % Step 3: build a search index structure from documents
+            % indexInputsStruct = struct('documentsTbl', documentsTbl, ...
+            %     'embeddingsMat', zeros(height(documentsTbl), 0));
+            % searchIndexStruct = CorpusModel.buildIndex(indexInputsStruct);
+
+            error("reg:model:NotImplemented", ...
+                "PipelineModel.ingestCorpus is not implemented.");
         end
 
         function results = exampleSearch(obj, queryString, alpha, topK)


### PR DESCRIPTION
## Summary
- Replace ingestCorpus implementation with pseudocode comments and a NotImplemented error stub

## Testing
- `apt-get update` *(fails: repository not signed)*
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b56b8d7883308e35784c996a0fd9