### PR TITLE
refactor: stub PipelineModel exampleSearch

### DIFF
--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -167,7 +167,10 @@ classdef PipelineModel < reg.mvc.BaseModel
             arguments (Output)
                 results table
             end
-            results = obj.CorpusModel.queryIndex(queryString, alpha, topK);
+            % Pseudocode: delegate query to search index
+            % results = obj.CorpusModel.queryIndex(queryString, alpha, topK);
+            error("reg:model:NotImplemented", ...
+                "PipelineModel.exampleSearch is not implemented.");
         end
 
         function out = runTraining(obj, cfg, documentsTbl)


### PR DESCRIPTION
## Summary
- remove direct query invocation from `PipelineModel.exampleSearch`
- replace call with pseudocode and explicit not implemented error

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --quiet --eval "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0b71c63608330b6867a8df19b7f4c