### PR TITLE
Stub out projection head training

### DIFF
--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -283,8 +283,15 @@ classdef PipelineModel < reg.mvc.BaseModel
                 projected double
             end
 
-            tripletsTbl = obj.TrainingModel.prepareDataset(struct('Embeddings', embeddings));
-            projected = obj.TrainingModel.trainProjectionHead(tripletsTbl);
+            % Step 1: assemble triplet dataset from input embeddings
+            % datasetStruct = struct('Embeddings', embeddings);
+            % tripletsTbl = obj.TrainingModel.prepareDataset(datasetStruct);
+
+            % Step 2: train projection head using triplets
+            % projected = obj.TrainingModel.trainProjectionHead(tripletsTbl);
+
+            error("reg:model:NotImplemented", ...
+                "PipelineModel.runProjectionHead is not implemented.");
         end
     end
 end


### PR DESCRIPTION
## Summary
- Remove dataset preparation and projection head training calls from `PipelineModel.runProjectionHead`
- Replace implementation with pseudocode comments and a `NotImplemented` error

## Testing
- `matlab -batch "runtests('tests')"` *(command not found)*
- `octave --eval "runtests('tests')"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0bbfae05483309057364232c3ed15