### PR TITLE
Stub CorpusModel.process with output arguments

### DIFF
--- a/+reg/+model/CorpusModel.m
+++ b/+reg/+model/CorpusModel.m
@@ -33,7 +33,20 @@ classdef CorpusModel < reg.mvc.BaseModel
             %PROCESS Synchronise local corpus from upstream sources.
             %   out = PROCESS(obj, params) delegates to `sync` and returns
             %   its output.
-            out = obj.sync(params);
+            arguments
+                obj
+                params (1,1) struct
+                params.date (1,1) string
+            end
+            arguments (Output)
+                out (1,1) struct
+                out.eba_dir (1,1) string
+                out.eba_index (1,1) string
+            end
+            % Pseudocode:
+            %   1. Delegate to sync(params) and return result
+            error("reg:model:NotImplemented", ...
+                "CorpusModel.process is not implemented.");
         end
 
         function T = fetchEba(~, varargin) %#ok<INUSD>


### PR DESCRIPTION
## Summary
- define input and output argument blocks for `CorpusModel.process` to specify expected parameters and returned struct fields
- replace implementation with pseudocode and not-implemented error

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --no-gui --quiet --eval "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0c0e497088330a2caa760d9acf930