### PR TITLE
Stub view methods with argument validation

### DIFF
--- a/+reg/+view/DiffView.m
+++ b/+reg/+view/DiffView.m
@@ -12,16 +12,22 @@ classdef DiffView < reg.mvc.BaseView
     end
 
     methods
-        function display(obj, data)
-            %DISPLAY Store diff data for inspection.
-            %   DISPLAY(obj, DATA) retains diff structures for verification.
-            %   In a production setting this method might pretty-print
-            %   summaries or write patch files to disk.
+        function display(~, data) %#ok<INUSD>
+            %DISPLAY Present diff data.
+            %   DISPLAY(~, DATA) would render differences between corpora
+            %   or methods, for example by printing tables or writing patch
+            %   files to disk.
 
-            obj.DiffResult = data;
-            if ~isempty(obj.OnDisplayCallback)
-                obj.OnDisplayCallback(data);
+            arguments
+                ~
+                data struct
             end
+
+            % Pseudocode:
+            %   iterate over diff entries in ``data``
+            %   render each difference to the desired medium
+            error("reg:view:NotImplemented", ...
+                "DiffView.display is not implemented.");
         end
     end
 end

--- a/+reg/+view/EmbeddingView.m
+++ b/+reg/+view/EmbeddingView.m
@@ -12,25 +12,22 @@ classdef EmbeddingView < reg.mvc.BaseView
     end
 
     methods
-        function display(obj, data)
-            %DISPLAY Store embedding data for inspection.
-            %   DISPLAY(obj, DATA) retains embedding vectors and reports
-            %   their dimensions. In production this might serialise
-            %   embeddings or send them to a visualiser.
+        function display(~, data) %#ok<INUSD>
+            %DISPLAY Present embedding data.
+            %   DISPLAY(~, DATA) would report vector dimensions or forward
+            %   embeddings to downstream visualisation tools.
 
-            obj.DisplayedEmbeddings = data;
-            vecs = [];
-            if isstruct(data) && isfield(data, 'Vectors')
-                vecs = data.Vectors;
-            elseif isnumeric(data)
-                vecs = data;
+            arguments
+                ~
+                data {mustBeA(data,{"double","struct"})}
             end
-            if ~isempty(vecs)
-                fprintf('Embeddings: %d-by-%d matrix\n', size(vecs,1), size(vecs,2));
-            end
-            if ~isempty(obj.OnDisplayCallback)
-                obj.OnDisplayCallback(data);
-            end
+
+            % Pseudocode:
+            %   if struct, extract embedding vectors
+            %   else treat DATA as a numeric matrix of vectors
+            %   render or summarise vector information
+            error("reg:view:NotImplemented", ...
+                "EmbeddingView.display is not implemented.");
         end
     end
 end

--- a/+reg/+view/MetricsView.m
+++ b/+reg/+view/MetricsView.m
@@ -16,27 +16,38 @@ classdef MetricsView < reg.mvc.BaseView
     end
 
     methods
-        function display(obj, data)
-            %DISPLAY Store metrics for verification.
-            %   DISPLAY(obj, DATA) captures metric structures for later
-            %   inspection. In a production view:
-            %       * overall scores could be printed or persisted to CSV
-            %       * perLabel tables might be turned into bar charts
-            %       * history arrays would feed trend plots
-            %   If OnDisplayCallback is set, it is invoked with DATA.
+        function display(~, data) %#ok<INUSD>
+            %DISPLAY Present metrics for verification.
+            %   DISPLAY(~, DATA) would format metrics into tables, charts or
+            %   logs for further analysis.
 
-            obj.DisplayedMetrics = data;
-            if ~isempty(obj.OnDisplayCallback)
-                obj.OnDisplayCallback(data);
+            arguments
+                ~
+                data struct
             end
+
+            % Pseudocode:
+            %   extract overall, perLabel and history sections from DATA
+            %   render each section using appropriate visualisation
+            error("reg:view:NotImplemented", ...
+                "MetricsView.display is not implemented.");
         end
 
-        function log(~, metrics)
-            %LOG Simple logging helper for metrics structs.
-            %   LOG(~, METRICS) prints METRICS to the console. In a full
-            %   implementation this could persist to disk or external services.
+        function log(~, metrics) %#ok<INUSD>
+            %LOG Present metrics through a logging mechanism.
+            %   LOG(~, METRICS) would persist metrics to a log file or
+            %   external monitoring service.
 
-            disp(metrics);
+            arguments
+                ~
+                metrics struct
+            end
+
+            % Pseudocode:
+            %   convert METRICS struct to textual representation
+            %   append text to log output
+            error("reg:view:NotImplemented", ...
+                "MetricsView.log is not implemented.");
         end
     end
 end

--- a/+reg/+view/PlotView.m
+++ b/+reg/+view/PlotView.m
@@ -10,25 +10,21 @@ classdef PlotView < reg.mvc.BaseView
     end
 
     methods
-        function display(obj, data)
-            %DISPLAY Store plot references and optionally print paths.
-            %   DISPLAY(obj, DATA) captures plot artefacts for verification.
-            %   A real implementation might embed images into reports or
-            %   open figures interactively.
+        function display(~, data) %#ok<INUSD>
+            %DISPLAY Present plot artefacts.
+            %   DISPLAY(~, DATA) would embed plots into reports or open
+            %   figures for inspection.
 
-            obj.DisplayedPlots = data;
-            if isstruct(data)
-                fns = fieldnames(data);
-                for i = 1:numel(fns)
-                    val = data.(fns{i});
-                    if ischar(val) || isstring(val)
-                        fprintf('Plot saved to %s\n', string(val));
-                    end
-                end
+            arguments
+                ~
+                data struct
             end
-            if ~isempty(obj.OnDisplayCallback)
-                obj.OnDisplayCallback(data);
-            end
+
+            % Pseudocode:
+            %   loop over fields in DATA referencing plot artefacts
+            %   render or save each plot as required
+            error("reg:view:NotImplemented", ...
+                "PlotView.display is not implemented.");
         end
 
         function plotTrends(~, data) %#ok<INUSD>

--- a/+reg/+view/ReportView.m
+++ b/+reg/+view/ReportView.m
@@ -22,30 +22,22 @@ classdef ReportView < reg.mvc.BaseView
     end
 
     methods
-        function display(obj, data)
-            %DISPLAY Store report data for verification and expose key sections.
-            %   DISPLAY(obj, DATA) retains summary tables, IRB subsets and
-            %   trend charts for inspection. In a real view:
-            %       * summaryTables would be rendered to HTML/Markdown
-            %       * irbSubset could be written to a CSV for manual review
-            %       * trendCharts might be saved as PNG and embedded
-            %   Additional metric arrays would be handled similarly.
-            %   If PostRenderCallback is defined it is invoked with DATA.
+        function display(~, data) %#ok<INUSD>
+            %DISPLAY Present report data for rendering.
+            %   DISPLAY(~, DATA) would format summary tables, IRB subsets and
+            %   trend charts into a comprehensive evaluation report.
 
-            obj.DisplayedData = data;
-            if isstruct(data) && isfield(data, 'summaryTables')
-                obj.SummaryTables = data.summaryTables;
-            end
-            if isstruct(data) && isfield(data, 'irbSubset')
-                obj.IRBSubset = data.irbSubset;
-            end
-            if isstruct(data) && isfield(data, 'trendCharts')
-                obj.TrendCharts = data.trendCharts;
+            arguments
+                ~
+                data struct
             end
 
-            if ~isempty(obj.PostRenderCallback)
-                obj.PostRenderCallback(data);
-            end
+            % Pseudocode:
+            %   render DATA.summaryTables into HTML or Markdown
+            %   export DATA.irbSubset for review
+            %   embed DATA.trendCharts into the report
+            error("reg:view:NotImplemented", ...
+                "ReportView.display is not implemented.");
         end
     end
 end


### PR DESCRIPTION
## Summary
- Add argument validation to DiffView, EmbeddingView, MetricsView, PlotView, and ReportView display routines
- Replace method bodies with pseudocode stubs that raise reg:view:NotImplemented errors
- Stub MetricsView.log with argument block and NotImplemented error

## Testing
- `matlab -batch "exit"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a0d3fa399c83309ee9709f41894a7d