### PR TITLE
Add output argument validation to evaluation controller functions

### DIFF
--- a/+reg/+controller/EvaluationController.m
+++ b/+reg/+controller/EvaluationController.m
@@ -71,6 +71,9 @@ classdef EvaluationController < reg.mvc.BaseController
                 embeddings double
                 labelMatrix double = []
             end
+            arguments (Output)
+                metrics struct
+            end
             % Step 1: ingest runtime labels
             %   rlm   = reg.model.RuntimeLabelModel();
             %   cfg   = rlm.load(labelMatrix);
@@ -106,6 +109,9 @@ classdef EvaluationController < reg.mvc.BaseController
                 posSets cell
                 k (1,1) double
             end
+            arguments (Output)
+                metrics struct
+            end
             %   Legacy Reference
             %       Equivalent to `reg.eval_retrieval` and `reg.metrics_ndcg`.
             %   Pseudocode/Validation stub:
@@ -129,6 +135,9 @@ classdef EvaluationController < reg.mvc.BaseController
                 embeddings double
                 labelMatrix double = []
                 opts struct = struct()
+            end
+            arguments (Output)
+                results struct
             end
 
             error("reg:controller:NotImplemented", ...


### PR DESCRIPTION
## Summary
- Add output argument validation for run, retrievalMetrics, and evaluateLabelledData methods in EvaluationController
- Keep functions unimplemented with NotImplemented errors

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0de35e5f48330b89239da0c978079