### PR TITLE
Add constructor and load argument stubs for DatabaseModel

### DIFF
--- a/+reg/+model/DatabaseModel.m
+++ b/+reg/+model/DatabaseModel.m
@@ -10,7 +10,11 @@ classdef DatabaseModel < reg.mvc.BaseModel
 
     methods
         function obj = DatabaseModel(varargin)
-            %#ok<INUSD>
+            arguments
+                varargin (1,:) cell
+            end
+            error("reg:model:NotImplemented", ...
+                "DatabaseModel constructor is not implemented.");
         end
 
         function dbHandles = load(obj, varargin) %#ok<INUSD>
@@ -36,6 +40,9 @@ classdef DatabaseModel < reg.mvc.BaseModel
             arguments
                 obj
                 varargin (1,:) cell
+            end
+            arguments (Output)
+                dbHandles struct
             end
             % Pseudocode:
             %   1. If obj.conn is open, close it


### PR DESCRIPTION
## Summary
- add arguments block and placeholder error to DatabaseModel constructor
- specify dbHandles struct output in load with arguments (Output)
- document connection setup with pseudocode and not-implemented error

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e11f109083308d5603f7336bfc1e