### PR TITLE
refactor evaluation model constructor and load

### DIFF
--- a/+reg/+model/EvaluationModel.m
+++ b/+reg/+model/EvaluationModel.m
@@ -9,9 +9,17 @@ classdef EvaluationModel < reg.mvc.BaseModel
 
     methods
         function obj = EvaluationModel(cfgModel)
-            if nargin > 0
-                obj.ConfigModel = cfgModel;
+            arguments
+                cfgModel reg.model.ConfigModel = reg.model.ConfigModel()
             end
+            arguments (Output)
+                obj reg.model.EvaluationModel
+            end
+            % Pseudocode for constructor:
+            %   obj.ConfigModel = cfgModel;
+            %   perform additional setup tasks as required
+            error("reg:model:NotImplemented", ...
+                "EvaluationModel constructor is not implemented.");
         end
 
         function input = load(~, predictions, references)
@@ -21,13 +29,13 @@ classdef EvaluationModel < reg.mvc.BaseModel
             %   ``References`` capturing the supplied arrays.
             arguments
                 ~
-                predictions = []
-                references  = []
+                predictions double = []
+                references  double = []
             end
             arguments (Output)
                 input struct
-                input.Predictions
-                input.References
+                input.Predictions double
+                input.References double
             end
             % Pseudocode describing packaging of predictions and references
             %   input.Predictions = predictions;


### PR DESCRIPTION
## Summary
- scaffold EvaluationModel constructor with typed arguments and placeholder
- add argument types for predictions and references in load routine

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e2abcf5083308967c5c713364403