### PR TITLE
Add configuration argument to TrainingModel constructor

### DIFF
--- a/+reg/+model/TrainingModel.m
+++ b/+reg/+model/TrainingModel.m
@@ -57,8 +57,14 @@ classdef TrainingModel < reg.mvc.BaseModel
     end
 
     methods
-        function obj = TrainingModel(varargin) %#ok<INUSD>
+        function obj = TrainingModel(cfg)
             %TRAININGMODEL Construct a unified training model.
+            arguments
+                cfg (1,1) struct = struct()
+            end
+            %   Pseudocode:
+            %       initialise model properties from cfg fields
+            error("reg:model:NotImplemented", "TrainingModel constructor is not implemented.");
         end
 
         function documentsTbl = ingest(obj, cfg)


### PR DESCRIPTION
## Summary
- allow `TrainingModel` to accept an optional configuration struct
- outline property initialisation steps and raise not-implemented error

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0e3f847d883308796b612ada861af