### PR TITLE
Add type checks and placeholder wiring in MVC constructors

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -26,11 +26,23 @@ classdef Application < handle
             %APPLICATION Construct the application container.
             %   OBJ = APPLICATION(MODEL, VIEW, CONTROLLER) simply stores the
             %   provided components for later execution.
-            if nargin > 0
-                obj.Model = model;
-                obj.View = view;
-                obj.Controller = controller;
+
+            arguments (Output)
+                obj (1,1) reg.mvc.Application
             end
+            arguments
+                model (1,1) reg.mvc.BaseModel
+                view (1,1) reg.mvc.BaseView
+                controller (1,1) reg.mvc.BaseController
+            end
+
+            % Expected wiring pseudocode:
+            %   obj.Model <- model;
+            %   obj.View <- view;
+            %   obj.Controller <- controller;
+
+            error('reg:mvc:NotImplemented', ...
+                'Application constructor must wire model, view and controller.');
         end
 
         function start(obj)

--- a/+reg/+mvc/BaseController.m
+++ b/+reg/+mvc/BaseController.m
@@ -22,10 +22,21 @@ classdef BaseController < handle
             %   VIEW  = reg.view.SomeView();
             %   CTLR  = reg.controller.SomeController(MODEL, VIEW);
             %   CTLR.run();  % see `reg_pipeline` for a full example
-            if nargin > 0
-                obj.Model = model;
-                obj.View = view;
+
+            arguments (Output)
+                obj (1,1) reg.mvc.BaseController
             end
+            arguments
+                model (1,1) reg.mvc.BaseModel
+                view (1,1) reg.mvc.BaseView
+            end
+
+            % Expected wiring pseudocode:
+            %   obj.Model <- model;
+            %   obj.View <- view;
+
+            error('reg:mvc:NotImplemented', ...
+                'BaseController constructor must wire model and view.');
         end
 
         function run(obj) %#ok<MANU>


### PR DESCRIPTION
## Summary
- add `arguments` blocks to Application and BaseController constructors
- replace property assignments with pseudocode and placeholder errors

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0eb0e8f548330b3933a6c18babda1