### PR TITLE
Add argument validation to base MVC classes

### DIFF
--- a/+reg/+mvc/BaseModel.m
+++ b/+reg/+mvc/BaseModel.m
@@ -7,25 +7,41 @@ classdef BaseModel < handle
     %   artefacts.
 
     methods
-        function data = load(obj, varargin) %#ok<INUSD>
+        function data = load(obj, varargin)
             %LOAD Retrieve raw application data.
             %   DATA = LOAD(obj) should collect information from files,
             %   databases or external services. Implementations may accept
             %   optional parameters via VARARGIN to specialise data
             %   acquisition. The returned DATA is then forwarded to
             %   `process` for transformation.
-            error('reg:mvc:NotImplemented', ...
-                'Models must override load to gather raw data.');
+            arguments
+                obj
+            end
+            arguments (Repeating)
+                varargin
+            end
+            arguments (Output)
+                data
+            end
+            error("reg:mvc:NotImplemented", ...
+                "Models must override load to gather raw data.");
         end
 
-        function result = process(obj, data) %#ok<INUSD>
+        function result = process(obj, data)
             %PROCESS Convert raw data into domain specific results.
             %   RESULT = PROCESS(obj, DATA) receives the output of `load`
             %   and transforms it into the form expected by controllers and
             %   views. For example, in `reg_pipeline` a model may load text
             %   chunks and process them into embeddings.
-            error('reg:mvc:NotImplemented', ...
-                'Models must override process to transform data.');
+            arguments
+                obj
+                data
+            end
+            arguments (Output)
+                result
+            end
+            error("reg:mvc:NotImplemented", ...
+                "Models must override process to transform data.");
         end
     end
 end

--- a/+reg/+mvc/BaseView.m
+++ b/+reg/+mvc/BaseView.m
@@ -6,12 +6,16 @@ classdef BaseView < handle
     %   visualisations for inspection.
 
     methods
-        function display(obj, data) %#ok<INUSD>
+        function display(obj, data)
             %DISPLAY Render processed results to an audience.
             %   DISPLAY(obj, DATA) should present DATA to a user or external
             %   system. Implementations may generate plots, print to the
             %   command window or persist artefacts. Subclasses decide what
             %   DATA represents.
+            arguments
+                obj
+                data struct
+            end
             error('reg:mvc:NotImplemented', ...
                 'Views must override display to present results.');
         end


### PR DESCRIPTION
## Summary
- enforce input and output contracts on BaseModel.load and BaseModel.process using `arguments` blocks
- restrict BaseView.display's `data` input via an `arguments` block for clearer expectations

## Testing
- `matlab -batch "runtests"` *(fails: command not found)*
- `octave --eval "runtests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0ecb2a39883309d3172e9bfc01fee