### PR TITLE
Specify MVC component types in Application

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -16,16 +16,18 @@ classdef Application < handle
     % - Computer Vision Toolbox
 
     properties
-        Model
-        View
-        Controller
+        Model (1,1) reg.mvc.BaseModel
+        View (1,1) reg.mvc.BaseView
+        Controller (1,1) reg.mvc.BaseController
     end
 
     methods
         function obj = Application(model, view, controller)
             %APPLICATION Construct the application container.
-            %   OBJ = APPLICATION(MODEL, VIEW, CONTROLLER) simply stores the
-            %   provided components for later execution.
+            %   OBJ = APPLICATION(MODEL, VIEW, CONTROLLER) stores the provided
+            %   components for later execution. MODEL, VIEW and CONTROLLER are
+            %   enforced to be reg.mvc.BaseModel, reg.mvc.BaseView and
+            %   reg.mvc.BaseController respectively.
 
             arguments (Output)
                 obj (1,1) reg.mvc.Application


### PR DESCRIPTION
## Summary
- enforce MVC component types for `Model`, `View`, and `Controller` properties
- document constructor requirements for strict MVC component types

## Testing
- `matlab -batch "tests.runAllTests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0fbf008908330807f8e6444185422