### PR TITLE
Type obj in Pipeline classes

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -12,11 +12,12 @@ classdef PipelineController < reg.mvc.BaseController
         function obj = PipelineController(pipelineModel, view)
             %PIPELINECONTROLLER Construct controller wiring pipeline model.
             arguments
+                obj (1,1) reg.controller.PipelineController
                 pipelineModel reg.model.PipelineModel
                 view reg.view.MetricsView = reg.view.MetricsView()
             end
             arguments (Output)
-                obj reg.controller.PipelineController
+                obj (1,1) reg.controller.PipelineController
             end
             %{
             % Pseudocode:
@@ -35,7 +36,7 @@ classdef PipelineController < reg.mvc.BaseController
             %   configuration CFG and displays any outputs using the
             %   controller view.
             arguments
-                obj
+                obj (1,1) reg.controller.PipelineController
                 cfg (1,1) struct
             end
             arguments (Output)
@@ -59,7 +60,7 @@ classdef PipelineController < reg.mvc.BaseController
             %   projection head training to the PipelineModel and displays
             %   the resulting embeddings using the controller view.
             arguments
-                obj
+                obj (1,1) reg.controller.PipelineController
                 embeddings double
             end
             arguments (Output)
@@ -80,7 +81,7 @@ classdef PipelineController < reg.mvc.BaseController
         function run(obj)
             %RUN Execute the full pipeline end-to-end.
             arguments
-                obj
+                obj (1,1) reg.controller.PipelineController
             end
             %{
             % Pseudocode:
@@ -108,7 +109,7 @@ classdef PipelineController < reg.mvc.BaseController
             %   configuration CFG and pre-ingested DOCUMENTSTBL, then
             %   displays the results using the controller view.
             arguments
-                obj
+                obj (1,1) reg.controller.PipelineController
                 cfg (1,1) struct
                 documentsTbl table
             end

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -49,7 +49,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   and ``EvaluationInputs`` (struct with embeddings and labels).
 
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
             end
             arguments (Output)
                 result struct
@@ -88,7 +88,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             error("reg:model:NotImplemented","PipelineModel.run is not implemented.");
         end
 
-        function out = evaluationInputs(~, trainOut)
+        function out = evaluationInputs(obj, trainOut)
             %EVALUATIONINPUTS Collate embeddings and labels for evaluation.
             %   OUT = EVALUATIONINPUTS(trainOut) extracts the appropriate
             %   embeddings and optional label matrix from TRAINOUT in
@@ -96,7 +96,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   with fields ``Embeddings`` (double matrix) and ``Labels``
             %   (double matrix, possibly empty).
             arguments
-                ~
+                obj (1,1) reg.model.PipelineModel
                 trainOut struct
             end
             arguments (Output)
@@ -129,7 +129,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %       searchIndexStruct (struct): fields ``docId`` (string) and
             %           ``embedding`` (double matrix).
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
                 cfg (1,1) struct
             end
             arguments (Output)
@@ -160,7 +160,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   provided for debugging convenience. RESULTS is a table with
             %   columns ``docId``, ``score`` and ``rank``.
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
                 queryString (1,1) string = "pipeline query"
                 alpha (1,1) double = 0.5
                 topK (1,1) double = 5
@@ -189,7 +189,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   ``Thresholds`` (double vector) and ``PredLabels`` (double
             %   matrix).
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
                 cfg (1,1) struct
                 documentsTbl table
             end
@@ -237,7 +237,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   ``TripletsTbl`` (table) and ``Network`` (struct placeholder
             %   for encoder).
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
                 cfg (1,1) struct
             end
             arguments (Output)
@@ -277,7 +277,7 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   matrix of projected embeddings.
 
             arguments
-                obj
+                obj (1,1) reg.model.PipelineModel
                 embeddings double
             end
             arguments (Output)

--- a/+tests/+fixtures/reflect_utils.m
+++ b/+tests/+fixtures/reflect_utils.m
@@ -33,7 +33,8 @@ for i=1:numel(funcStarts)-1
     token = regexp(segment,'function\s+(?:[^\n=]*=\s*)?(\w+)\s*\(','tokens','once');
     if isempty(token); continue; end
     name = token{1};
-    if ~contains(segment,'arguments')
+    hasInputArgs = ~isempty(regexp(segment,'(?m)^\s*arguments\s*(?!\(Output\))','once'));
+    if ~hasInputArgs
         missing{end+1} = name; %#ok<AGROW>
     end
 end


### PR DESCRIPTION
## Summary
- specify `(1,1)` and class types for the `obj` argument in PipelineController methods
- mirror the same typed `obj` in PipelineModel methods
- update reflection helper to only flag methods missing input `arguments` blocks

## Testing
- `matlab -batch "addpath('+tests'); runAllTests;"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a0fee2b3bc833097c2bef176b4012d