### PR TITLE
docs: document struct outputs

### DIFF
--- a/+reg/+controller/PipelineController.m
+++ b/+reg/+controller/PipelineController.m
@@ -34,7 +34,9 @@ classdef PipelineController < reg.mvc.BaseController
             %   RESULT = RUNFINETUNE(obj, CFG) delegates the fine-tuning
             %   process to the PipelineModel using the supplied processed
             %   configuration CFG and displays any outputs using the
-            %   controller view.
+            %   controller view. RESULT is a struct with fields:
+            %       TripletsTbl table [n x ?]  - dataset of contrastive triplets
+            %       Network     struct [1 x 1] - placeholder encoder network
             arguments
                 obj (1,1) reg.controller.PipelineController
                 cfg (1,1) struct
@@ -104,10 +106,19 @@ classdef PipelineController < reg.mvc.BaseController
 
         function result = runTraining(obj, cfg, documentsTbl)
             %RUNTRAINING Execute only the training workflow.
-            %   RUNTRAINING(OBJ, CFG, DOCUMENTSTBL) delegates the workflow
-            %   to the PipelineModel using the supplied processed
+            %   RESULT = RUNTRAINING(OBJ, CFG, DOCUMENTSTBL) delegates the
+            %   workflow to the PipelineModel using the supplied processed
             %   configuration CFG and pre-ingested DOCUMENTSTBL, then
-            %   displays the results using the controller view.
+            %   displays the results using the controller view. RESULT is a
+            %   struct with fields:
+            %       DocumentsTbl table [n x ?]   - original documents
+            %       ChunksTbl    table [c x ?]   - document chunks
+            %       FeaturesTbl  table [c x ?]   - extracted features
+            %       Embeddings   double [c x d] - embedding matrix
+            %       Models       cell   [1 x m] - trained model objects
+            %       Scores       double [c x m] - classifier scores
+            %       Thresholds   double [1 x m] - decision thresholds
+            %       PredLabels   double [c x m] - predicted labels
             arguments
                 obj (1,1) reg.controller.PipelineController
                 cfg (1,1) struct

--- a/+reg/+model/PipelineModel.m
+++ b/+reg/+model/PipelineModel.m
@@ -44,9 +44,10 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   RESULT = RUN(obj) coordinates configuration loading,
             %   corpus ingestion, feature/embedding extraction, classifier
             %   training, fine-tuning and evaluation input collation.
-            %   RESULT is a struct with fields ``SearchIndex`` (struct with
-            %   docId and embedding), ``Training`` (see RUNTRAINING output)
-            %   and ``EvaluationInputs`` (struct with embeddings and labels).
+            %   RESULT is a struct with fields:
+            %       SearchIndex      struct [1 x 1] - fields ``docId`` string [n x 1], ``embedding`` double [n x d]
+            %       Training         struct [1 x 1] - see RUNTRAINING output
+            %       EvaluationInputs struct [1 x 1] - fields ``Embeddings`` double [m x d], ``Labels`` double [m x k]
 
             arguments
                 obj (1,1) reg.model.PipelineModel
@@ -183,11 +184,15 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   DOCUMENTSTBL should typically be the same table produced
             %   during indexing via ``ingestCorpus`` so ingestion only
             %   occurs once for both indexing and training. OUT is a struct
-            %   with fields ``DocumentsTbl`` (table), ``ChunksTbl`` (table),
-            %   ``FeaturesTbl`` (table), ``Embeddings`` (double matrix),
-            %   ``Models`` (cell), ``Scores`` (double matrix),
-            %   ``Thresholds`` (double vector) and ``PredLabels`` (double
-            %   matrix).
+            %   with fields:
+            %       DocumentsTbl table [n x ?]   - ingested documents
+            %       ChunksTbl    table [c x ?]   - document chunks
+            %       FeaturesTbl  table [c x ?]   - extracted features
+            %       Embeddings   double [c x d] - embedding matrix
+            %       Models       cell   [1 x m] - trained model objects
+            %       Scores       double [c x m] - classifier scores
+            %       Thresholds   double [1 x m] - decision thresholds
+            %       PredLabels   double [c x m] - predicted labels
             arguments
                 obj (1,1) reg.model.PipelineModel
                 cfg (1,1) struct
@@ -233,9 +238,9 @@ classdef PipelineModel < reg.mvc.BaseModel
             %   OUT = RUNFINETUNE(OBJ, CFG) performs encoder fine-tuning
             %   using the supplied configuration CFG. CFG must be a fully
             %   processed configuration struct as returned by
-            %   ConfigModel.process. OUT is a struct with fields
-            %   ``TripletsTbl`` (table) and ``Network`` (struct placeholder
-            %   for encoder).
+            %   ConfigModel.process. OUT is a struct with fields:
+            %       TripletsTbl table [n x ?]   - triplet dataset
+            %       Network     struct [1 x 1] - placeholder encoder model
             arguments
                 obj (1,1) reg.model.PipelineModel
                 cfg (1,1) struct

--- a/+tests/+controller/testPipelineController.m
+++ b/+tests/+controller/testPipelineController.m
@@ -38,6 +38,20 @@ classdef testPipelineController < matlab.unittest.TestCase
         end
     end
 
+    methods (Test, TestTags={'Doc'})
+        function structFieldDocs(testCase)
+            docFine = help('reg.controller.PipelineController/runFineTune');
+            testCase.verifyNotEmpty(strfind(docFine, 'TripletsTbl'), 'TripletsTbl missing');
+            testCase.verifyNotEmpty(strfind(docFine, 'Network'), 'Network missing');
+
+            docTrain = help('reg.controller.PipelineController/runTraining');
+            fields = ["DocumentsTbl","ChunksTbl","FeaturesTbl","Embeddings","Models","Scores","Thresholds","PredLabels"];
+            for f = fields
+                testCase.verifyNotEmpty(strfind(docTrain, f), "Field " + f + " missing");
+            end
+        end
+    end
+
     methods (Test, TestTags={'Regression'})
         function baselineStub(testCase)
             data = tests.fixtures.baseline_load('example.json'); %#ok<NASGU>

--- a/+tests/+model/testPipelineModel.m
+++ b/+tests/+model/testPipelineModel.m
@@ -38,6 +38,28 @@ classdef testPipelineModel < matlab.unittest.TestCase
         end
     end
 
+    methods (Test, TestTags={'Doc'})
+        function structFieldDocs(testCase)
+            docRun = help('reg.model.PipelineModel/run');
+            runFields = ["SearchIndex","Training","EvaluationInputs"];
+            for f = runFields
+                testCase.verifyNotEmpty(strfind(docRun, f), "Field " + f + " missing");
+            end
+
+            docTrain = help('reg.model.PipelineModel/runTraining');
+            trainFields = ["DocumentsTbl","ChunksTbl","FeaturesTbl","Embeddings","Models","Scores","Thresholds","PredLabels"];
+            for f = trainFields
+                testCase.verifyNotEmpty(strfind(docTrain, f), "Field " + f + " missing");
+            end
+
+            docFine = help('reg.model.PipelineModel/runFineTune');
+            fineFields = ["TripletsTbl","Network"];
+            for f = fineFields
+                testCase.verifyNotEmpty(strfind(docFine, f), "Field " + f + " missing");
+            end
+        end
+    end
+
     methods (Test, TestTags={'Regression'})
         function baselineStub(testCase)
             data = tests.fixtures.baseline_load('example.json'); %#ok<NASGU>


### PR DESCRIPTION
## Summary
- document PipelineController fine-tune and training outputs with expected struct fields
- clarify struct field contracts for PipelineModel run, training, and fine-tune methods
- add documentation tests verifying struct field mentions

## Testing
- `matlab -batch "runAllTests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a10078a3dc833088ccf0974ccf258a