### PR TITLE
fix: reorder Application constructor arguments

### DIFF
--- a/+reg/+mvc/Application.m
+++ b/+reg/+mvc/Application.m
@@ -29,13 +29,13 @@ classdef Application < handle
             %   enforced to be reg.mvc.BaseModel, reg.mvc.BaseView and
             %   reg.mvc.BaseController respectively.
 
-            arguments (Output)
-                obj (1,1) reg.mvc.Application
-            end
             arguments
                 model (1,1) reg.mvc.BaseModel
                 view (1,1) reg.mvc.BaseView
                 controller (1,1) reg.mvc.BaseController
+            end
+            arguments (Output)
+                obj (1,1) reg.mvc.Application
             end
 
             % Expected wiring pseudocode:


### PR DESCRIPTION
## Summary
- reorder Application constructor argument blocks to put inputs before outputs

## Testing
- `matlab -batch "+tests/runAllTests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a102e83f5483309c2697d380442349